### PR TITLE
TD-3744-Job role with slash in causes error during registration

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/AccountController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/AccountController.cs
@@ -1249,11 +1249,6 @@
                 accountCreationViewModel.CurrentRoleName = role.Item2.FirstOrDefault(x => x.Id == int.Parse(accountCreationViewModel.CurrentRole)).NameWithStaffGroup;
             }
 
-            if (role.Item1 > 0)
-            {
-                accountCreationViewModel.CurrentRoleName = role.Item2.FirstOrDefault(x => x.Id == int.Parse(accountCreationViewModel.CurrentRole)).NameWithStaffGroup;
-            }
-
             var grade = await this.gradeService.GetGradesForJobRoleAsync(int.TryParse(accountCreationViewModel.CurrentRole, out int roleId) ? roleId : 0);
             var confirmationPayload = new AccountCreationConfirmation
             {

--- a/LearningHub.Nhs.WebUI/Controllers/AccountController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/AccountController.cs
@@ -1,5 +1,6 @@
 ﻿namespace LearningHub.Nhs.WebUI.Controllers
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Net;
@@ -1232,7 +1233,22 @@
             var employer = await this.locationService.GetByIdAsync(int.TryParse(accountCreationViewModel.LocationId, out int primaryEmploymentId) ? primaryEmploymentId : 0);
             var region = await this.regionService.GetAllAsync();
             var specialty = await this.specialtyService.GetSpecialtiesAsync();
-            var role = await this.jobRoleService.GetPagedFilteredAsync(accountCreationViewModel.CurrentRoleName, accountCreationViewModel.CurrentPageIndex, UserRegistrationContentPageSize);
+            var role = new Tuple<int, List<JobRoleBasicViewModel>>(0, null);
+            if (!string.IsNullOrEmpty(accountCreationViewModel.CurrentRoleName) && accountCreationViewModel.CurrentRoleName.Contains('/'))
+            {
+                string jobrole = accountCreationViewModel.CurrentRoleName.Replace("/", " ");
+                role = await this.jobRoleService.GetPagedFilteredAsync(jobrole, accountCreationViewModel.CurrentPageIndex, UserRegistrationContentPageSize);
+            }
+            else
+            {
+                role = await this.jobRoleService.GetPagedFilteredAsync(accountCreationViewModel.CurrentRoleName, accountCreationViewModel.CurrentPageIndex, UserRegistrationContentPageSize);
+            }
+
+            if (role.Item1 > 0)
+            {
+                accountCreationViewModel.CurrentRoleName = role.Item2.FirstOrDefault(x => x.Id == int.Parse(accountCreationViewModel.CurrentRole)).NameWithStaffGroup;
+            }
+
             if (role.Item1 > 0)
             {
                 accountCreationViewModel.CurrentRoleName = role.Item2.FirstOrDefault(x => x.Id == int.Parse(accountCreationViewModel.CurrentRole)).NameWithStaffGroup;


### PR DESCRIPTION
### JIRA link
TD-3744

### Description
Job role with slash in causes error during registration.

### Screenshots
![235](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/154979799/f9f94132-2503-434f-9994-0f28cd19811e)
![234](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/154979799/f77e566e-9815-4ca2-8f40-9970ebe73d8c)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [X] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [X] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
