### PR TITLE
TD-3839-Logs are Getting Saved in Production Log-Content Server Issues

### DIFF
--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Resources/GetScormContentServerDetailsForHistoricExternalUrl.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Resources/GetScormContentServerDetailsForHistoricExternalUrl.sql
@@ -19,7 +19,7 @@ BEGIN
 			srv.EsrLinkTypeId EsrLinkType,
 			er.Active IsActive,
 			srv.ContentFilePath AS InternalResourceIdentifier, 
-			svm.ManifestURL AS ManifestUrl				
+			svm.ManifestURL AS DefaultUrl				
 		FROM 
 			[resources].[UrlRewriting] u  
 			join resources.ExternalReference er on u.ExternalReferenceId = er.Id 


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3839

### Description
Fixed the issue ESR Resources are not Loading and throwing 500 Errors.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
