### PR TITLE
TD-3833-Recently Added Tray Not Loading On Prod-Resources Tab

### DIFF
--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Resources/GetDashboardResources.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Resources/GetDashboardResources.sql
@@ -150,7 +150,7 @@ BEGIN
 		LEFT JOIN (  SELECT DISTINCT CatalogueNodeId 
 						FROM [hub].[RoleUserGroupView] rug JOIN hub.UserUserGroup uug ON rug.UserGroupId = uug.UserGroupId
 						WHERE rug.ScopeTypeId = 1 and rug.RoleId in (1,2,3) and uug.Deleted = 0 and uug.UserId = @userId) auth ON n.Id = auth.CatalogueNodeId
-		LEFT JOIN resources.ResourceVersionRatingSummary rs ON rs.ResourceVersionId = rv.Id
+		INNER JOIN resources.ResourceVersionRatingSummary rs ON rs.ResourceVersionId = rv.Id
 		WHERE rv.VersionStatusId = 2	
 		ORDER BY rvrs.AverageRating DESC, rvrs.RatingCount DESC, rv.Title
 
@@ -207,7 +207,7 @@ BEGIN
 		LEFT JOIN (  SELECT DISTINCT CatalogueNodeId 
 						FROM [hub].[RoleUserGroupView] rug JOIN hub.UserUserGroup uug ON rug.UserGroupId = uug.UserGroupId
 						WHERE rug.ScopeTypeId = 1 and rug.RoleId in (1,2,3) and uug.Deleted = 0 and uug.UserId = @userId) auth ON n.Id = auth.CatalogueNodeId
-		LEFT JOIN resources.ResourceVersionRatingSummary rs ON rs.ResourceVersionId = rv.Id
+		INNER JOIN resources.ResourceVersionRatingSummary rs ON rs.ResourceVersionId = rv.Id
 		WHERE rv.VersionStatusId = 2
 		ORDER BY p.CreateDate DESC
 		


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3833

### Description
Fixed the performance issue with the resource tray loading.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
