### PR TITLE
TD-3846- Logs are Getting Saved in Production Log-Resource Version

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/LearningSessionsController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/LearningSessionsController.cs
@@ -54,9 +54,12 @@ namespace LearningHub.Nhs.WebUI.Controllers
         public async Task<IActionResult> Scorm(int id)
         {
             var rv = await this.resourceService.GetItemByIdAsync(id);
+            if (rv != null)
+            {
+                this.ViewBag.FilePath = $"/ScormContent/{rv.ScormDetails.ContentFilePath}/{rv.ScormDetails.ScormManifest.ManifestUrl}";
+            }
 
             this.ViewBag.ResourceReferenceId = id;
-            this.ViewBag.FilePath = $"/ScormContent/{rv.ScormDetails.ContentFilePath}/{rv.ScormDetails.ScormManifest.ManifestUrl}";
             this.ViewBag.KeepUserSessionAliveInterval = Convert.ToInt32(this.settings.Value.KeepUserSessionAliveIntervalMins) * 60000;
             this.ViewBag.UseTraceWindow = await this.userGroupService.UserHasPermissionAsync("Scorm_Trace_Window");
 

--- a/WebAPI/LearningHub.Nhs.Services/ResourceService.cs
+++ b/WebAPI/LearningHub.Nhs.Services/ResourceService.cs
@@ -1646,64 +1646,71 @@ namespace LearningHub.Nhs.Services
             // - set field ResourceVersionIdInEdit / ResourceVersionIdPublishing for this scenario, required for UI rendering
             var rv = await this.resourceVersionRepository.GetCurrentForResourceReferenceIdAsync(resourceReferenceId);
 
-            int resourceVersionIdInEdit = 0;
-            int resourceVersionIdPublishing = 0;
-
-            if (rv.VersionStatusEnum == VersionStatusEnum.Draft || rv.VersionStatusEnum == VersionStatusEnum.Publishing)
+            if (rv != null)
             {
-                var rvp = await this.resourceVersionRepository.GetCurrentPublicationForResourceReferenceIdAsync(resourceReferenceId);
+                int resourceVersionIdInEdit = 0;
+                int resourceVersionIdPublishing = 0;
 
-                if (rvp != null && rv.VersionStatusEnum == VersionStatusEnum.Draft)
+                if (rv.VersionStatusEnum == VersionStatusEnum.Draft || rv.VersionStatusEnum == VersionStatusEnum.Publishing)
                 {
-                    resourceVersionIdInEdit = rv.Id;
+                    var rvp = await this.resourceVersionRepository.GetCurrentPublicationForResourceReferenceIdAsync(resourceReferenceId);
+
+                    if (rvp != null && rv.VersionStatusEnum == VersionStatusEnum.Draft)
+                    {
+                        resourceVersionIdInEdit = rv.Id;
+                    }
+
+                    if (rvp != null && rv.VersionStatusEnum == VersionStatusEnum.Publishing)
+                    {
+                        resourceVersionIdPublishing = rv.Id;
+                    }
+
+                    rv = rvp;
                 }
 
-                if (rvp != null && rv.VersionStatusEnum == VersionStatusEnum.Publishing)
+                var erv = await this.GetResourceVersionExtendedViewModelAsync(rv.Id, userId);
+
+                var retVal = new ResourceItemViewModel(erv);
+                retVal.Id = resourceReferenceId;
+                var bookmark = this.bookmarkRepository.GetAll().Where(b => b.ResourceReferenceId == resourceReferenceId && b.UserId == userId).FirstOrDefault();
+                retVal.BookmarkId = bookmark?.Id;
+                retVal.IsBookmarked = !bookmark?.Deleted ?? false;
+                retVal.ReadOnly = readOnly;
+                retVal.DisplayForContributor = await this.UserCanEditResourceVersion(rv.CreateUserId, rv.Id, userId);
+                retVal.ResourceVersionIdInEdit = resourceVersionIdInEdit;
+                retVal.ResourceVersionIdPublishing = resourceVersionIdPublishing;
+                retVal.ResourceAccessibilityEnum = rv.ResourceAccessibilityEnum;
+
+                // Obtain catalogue associated with the supplied Resource Reference.
+                var rr = await this.resourceReferenceRepository.GetByOriginalResourceReferenceIdAsync(resourceReferenceId, true);
+                var catalogueNodeVersion = this.catalogueNodeVersionRepository.GetBasicCatalogue(rr.NodePath.CatalogueNode.Id);
+                retVal.Catalogue = this.mapper.Map<CatalogueViewModel>(catalogueNodeVersion);
+                retVal.NodePathId = rr.NodePathId.Value;
+
+                switch (rv.Resource.ResourceTypeEnum)
                 {
-                    resourceVersionIdPublishing = rv.Id;
+                    case ResourceTypeEnum.Case:
+                        retVal.CaseDetails = erv.CaseDetails;
+                        break;
+
+                    case ResourceTypeEnum.Assessment:
+                        retVal.AssessmentDetails = erv.AssessmentDetails;
+                        break;
+
+                    case ResourceTypeEnum.Html:
+                        retVal.HtmlDetails = erv.HtmlDetails;
+                        break;
+
+                    default:
+                        break;
                 }
 
-                rv = rvp;
+                return retVal;
             }
-
-            var erv = await this.GetResourceVersionExtendedViewModelAsync(rv.Id, userId);
-
-            var retVal = new ResourceItemViewModel(erv);
-            retVal.Id = resourceReferenceId;
-            var bookmark = this.bookmarkRepository.GetAll().Where(b => b.ResourceReferenceId == resourceReferenceId && b.UserId == userId).FirstOrDefault();
-            retVal.BookmarkId = bookmark?.Id;
-            retVal.IsBookmarked = !bookmark?.Deleted ?? false;
-            retVal.ReadOnly = readOnly;
-            retVal.DisplayForContributor = await this.UserCanEditResourceVersion(rv.CreateUserId, rv.Id, userId);
-            retVal.ResourceVersionIdInEdit = resourceVersionIdInEdit;
-            retVal.ResourceVersionIdPublishing = resourceVersionIdPublishing;
-            retVal.ResourceAccessibilityEnum = rv.ResourceAccessibilityEnum;
-
-            // Obtain catalogue associated with the supplied Resource Reference.
-            var rr = await this.resourceReferenceRepository.GetByOriginalResourceReferenceIdAsync(resourceReferenceId, true);
-            var catalogueNodeVersion = this.catalogueNodeVersionRepository.GetBasicCatalogue(rr.NodePath.CatalogueNode.Id);
-            retVal.Catalogue = this.mapper.Map<CatalogueViewModel>(catalogueNodeVersion);
-            retVal.NodePathId = rr.NodePathId.Value;
-
-            switch (rv.Resource.ResourceTypeEnum)
+            else
             {
-                case ResourceTypeEnum.Case:
-                    retVal.CaseDetails = erv.CaseDetails;
-                    break;
-
-                case ResourceTypeEnum.Assessment:
-                    retVal.AssessmentDetails = erv.AssessmentDetails;
-                    break;
-
-                case ResourceTypeEnum.Html:
-                    retVal.HtmlDetails = erv.HtmlDetails;
-                    break;
-
-                default:
-                    break;
+                return null;
             }
-
-            return retVal;
         }
 
         /// <summary>
@@ -3225,30 +3232,30 @@ namespace LearningHub.Nhs.Services
         /// <returns>The <see cref="Task{LearningHubValidationResult}"/>.</returns>
         public async Task CheckAndRemoveResourceVersionProviderAsync(int resourceVersionId, int userId)
         {
-                List<int> userProviderList = new List<int>();
+            List<int> userProviderList = new List<int>();
 
-                // list of resource version provider
-                var resourceProviderList = await this.providerService.GetByResourceVersionIdAsync(resourceVersionId);
+            // list of resource version provider
+            var resourceProviderList = await this.providerService.GetByResourceVersionIdAsync(resourceVersionId);
 
-                // list of user providers
-                var userProviders = await this.providerService.GetByUserIdAsync(userId);
+            // list of user providers
+            var userProviders = await this.providerService.GetByUserIdAsync(userId);
 
-                if (userProviders != null && userProviders.Count > 0)
+            if (userProviders != null && userProviders.Count > 0)
+            {
+                userProviderList.AddRange(userProviders.Select(n => n.Id).ToList());
+            }
+
+            // delete provider from resource version if user do not have permission.
+            if (resourceProviderList != null && resourceProviderList.Count > 0)
+            {
+                foreach (ProviderViewModel resourceProvider in resourceProviderList)
                 {
-                    userProviderList.AddRange(userProviders.Select(n => n.Id).ToList());
-                }
-
-                // delete provider from resource version if user do not have permission.
-                if (resourceProviderList != null && resourceProviderList.Count > 0)
-                {
-                    foreach (ProviderViewModel resourceProvider in resourceProviderList)
+                    if (!userProviderList.Contains(resourceProvider.Id))
                     {
-                        if (!userProviderList.Contains(resourceProvider.Id))
-                        {
-                            await this.resourceVersionProviderRepository.DeleteAsync(resourceVersionId, resourceProvider.Id, userId);
-                        }
+                        await this.resourceVersionProviderRepository.DeleteAsync(resourceVersionId, resourceProvider.Id, userId);
                     }
                 }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3846

### Description
Logs are Getting Saved in Production Log-Resource Version - 

Implemented the fix to remove the null reference error from the API Call Resource/GetResourceItemViewModelAsync/{id}

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
