### PR TITLE
TD-3823: CmiSuspend_data limit extended from 4096 to 64000

### DIFF
--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/models/learningsessions/cmiVocabulary.ts
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/models/learningsessions/cmiVocabulary.ts
@@ -18,7 +18,8 @@
     Entry = 16,
     Interaction = 17,
     Result = 18,
-    TimeLimitAction = 19
+    TimeLimitAction = 19,
+    CMIString64000 = 20
 };
 
 export enum CMIVocabularyMode {

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/models/learningsessions/scormApiModel.ts
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/models/learningsessions/scormApiModel.ts
@@ -480,13 +480,13 @@ export class ScormApiModel {
 			}
 		}
 		else if (paramName === "cmi.suspend_data") {
-			if (this.isValidateDataType(paramValue, CMIDataType.CMIString4096)) {
+			if (this.isValidateDataType(paramValue, CMIDataType.CMIString64000)) {
 				this.sco.suspendData = paramValue;
 				result = true;
 			}
 		}
 		else if (paramName === "cmi.comments") {
-			if (this.isValidateDataType(paramValue, CMIDataType.CMIString4096)) {
+			if (this.isValidateDataType(paramValue, CMIDataType.CMIString64000)) {
 				this.sco.comments = paramValue;
 				result = true;
 			}
@@ -1016,6 +1016,11 @@ export class ScormApiModel {
 				break;
 			case CMIDataType.CMIString4096:
 				if (value.length < 4096) {
+					response = true;
+				}
+				break;
+			case CMIDataType.CMIString64000:
+				if (value.length < 64000) {
 					response = true;
 				}
 				break;


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3823

### Description
Extended CmiSuspend_data limit from 4096 to 64000

### Screenshots
Noticed few files are missing in Prod folder as below.
![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/120369940/74125678-dfd9-4f35-8eb9-80ee75157b53)


**_Before code fix:_**
![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/120369940/28696f0d-6b93-48e1-b34a-6f1580f756bb)

![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/120369940/3c39f504-0476-4994-9b10-1bdcffe542d4)

**_After code fix._**
![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/120369940/f132ef9f-5001-48cf-9ca1-bb39c6e3da14)

![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/120369940/21dc83ef-0774-484a-a8fd-95838897ca62)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
