### PR TITLE
TD-3551 audio and video certificate visibility

### DIFF
--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/resource/ResourceContent.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/resource/ResourceContent.vue
@@ -422,6 +422,11 @@
                             window.location.pathname = './Home/Error';
                         });
                 }
+
+                if (interactionType == "ended") {
+                    setTimeout(() => { this.checkUserCertificateAvailability() }, 10000);
+                    await this.recordActivityComplete();                 
+                }
             },
             async recordMediaPlayingEvent(): Promise<void> {
                 let currentMediaTime = this.getMediaPlayerDisplayTime();


### PR DESCRIPTION
### JIRA link
TD-3551 

### Description
Enable certificate link to be made available as soon as a video and audio resource are completed.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/114475132/919f077f-f69a-4c43-8130-35a563cd0a70)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
