### PR TITLE
TD-3881 stream audio or video file content within html resource

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/ResourceController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/ResourceController.cs
@@ -484,15 +484,24 @@
                 contentType = "text/html";
             }
 
-            var file = await this.fileService.DownloadFileAsync(contentFilePath, path);
-            if (file != null)
+            if (contentType.Contains("video") || contentType.Contains("audio"))
             {
-                return this.File(file.Content, contentType);
+                var stream = await this.fileService.StreamFileAsync(contentFilePath, path);
+                if (stream != null)
+                {
+                    return this.File(stream, contentType, enableRangeProcessing: true);
+                }
             }
             else
             {
-                return this.Ok(this.Content("No file found"));
+                var file = await this.fileService.DownloadFileAsync(contentFilePath, path);
+                if (file != null)
+                {
+                    return this.File(file.Content, contentType);
+                }
             }
+
+            return this.Ok(this.Content("No file found"));
         }
     }
 }

--- a/LearningHub.Nhs.WebUI/Interfaces/IFileService.cs
+++ b/LearningHub.Nhs.WebUI/Interfaces/IFileService.cs
@@ -28,6 +28,14 @@
         Task<ShareFileDownloadInfo> DownloadFileAsync(string filePath, string fileName);
 
         /// <summary>
+        /// The StreamFileAsync.
+        /// </summary>
+        /// <param name="filePath">The filePath.</param>
+        /// <param name="fileName">The fileName.</param>
+        /// <returns>The <see cref="Task{Stream}"/>.</returns>
+        Task<Stream> StreamFileAsync(string filePath, string fileName);
+
+        /// <summary>
         /// The ProcessFile.
         /// </summary>
         /// <param name="fileBytes">The fileBytes<see cref="Stream"/>.</param>

--- a/LearningHub.Nhs.WebUI/Services/FileService.cs
+++ b/LearningHub.Nhs.WebUI/Services/FileService.cs
@@ -144,6 +144,29 @@
         }
 
         /// <summary>
+        /// The StreamFileAsync.
+        /// </summary>
+        /// <param name="filePath">The filePath.</param>
+        /// <param name="fileName">The fileName.</param>
+        /// <returns>The <see cref="Task{Stream}"/>.</returns>
+        public async Task<Stream> StreamFileAsync(string filePath, string fileName)
+        {
+            var directory = this.ShareClient.GetDirectoryClient(filePath);
+
+            if (await directory.ExistsAsync())
+            {
+                var file = directory.GetFileClient(fileName);
+
+                if (await file.ExistsAsync())
+                {
+                    return await file.OpenReadAsync();
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// The ProcessFile.
         /// </summary>
         /// <param name="fileBytes">The fileBytes<see cref="Stream"/>.</param>


### PR DESCRIPTION
### JIRA link
[TD-3881](https://hee-tis.atlassian.net/browse/TD-3881)

### Description
LH users are unable to seek a range from the entire playtime of a video content and clicking to navigate to any point in time in the video failed. Video and audio content within a html resource have now been configured to stream rather than download

### Screenshots
not applicable

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3881]: https://hee-tis.atlassian.net/browse/TD-3881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ