### PR TITLE
TD-3744-Job role with slash in causes error during registration

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/AccountController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/AccountController.cs
@@ -1266,16 +1266,7 @@
             var region = await this.regionService.GetAllAsync();
             var specialty = await this.specialtyService.GetSpecialtiesAsync();
             var role = new Tuple<int, List<JobRoleBasicViewModel>>(0, null);
-            if (!string.IsNullOrEmpty(accountCreationViewModel.CurrentRoleName) && accountCreationViewModel.CurrentRoleName.Contains('/'))
-            {
-                string jobrole = accountCreationViewModel.CurrentRoleName.Replace("/", " ");
-                role = await this.jobRoleService.GetPagedFilteredAsync(jobrole, accountCreationViewModel.CurrentPageIndex, UserRegistrationContentPageSize);
-            }
-            else
-            {
-                role = await this.jobRoleService.GetPagedFilteredAsync(accountCreationViewModel.CurrentRoleName, accountCreationViewModel.CurrentPageIndex, UserRegistrationContentPageSize);
-            }
-
+            role = await this.jobRoleService.GetPagedFilteredAsync(accountCreationViewModel.CurrentRoleName, accountCreationViewModel.CurrentPageIndex, UserRegistrationContentPageSize);
             if (role.Item1 > 0)
             {
                 accountCreationViewModel.CurrentRoleName = role.Item2.FirstOrDefault(x => x.Id == int.Parse(accountCreationViewModel.CurrentRole)).NameWithStaffGroup;

--- a/LearningHub.Nhs.WebUI/Controllers/AccountController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/AccountController.cs
@@ -1265,8 +1265,7 @@
             var employer = await this.locationService.GetByIdAsync(int.TryParse(accountCreationViewModel.LocationId, out int primaryEmploymentId) ? primaryEmploymentId : 0);
             var region = await this.regionService.GetAllAsync();
             var specialty = await this.specialtyService.GetSpecialtiesAsync();
-            var role = new Tuple<int, List<JobRoleBasicViewModel>>(0, null);
-            role = await this.jobRoleService.GetPagedFilteredAsync(accountCreationViewModel.CurrentRoleName, accountCreationViewModel.CurrentPageIndex, UserRegistrationContentPageSize);
+            var role = await this.jobRoleService.GetPagedFilteredAsync(accountCreationViewModel.CurrentRoleName, accountCreationViewModel.CurrentPageIndex, UserRegistrationContentPageSize);
             if (role.Item1 > 0)
             {
                 accountCreationViewModel.CurrentRoleName = role.Item2.FirstOrDefault(x => x.Id == int.Parse(accountCreationViewModel.CurrentRole)).NameWithStaffGroup;

--- a/LearningHub.Nhs.WebUI/Services/JobRoleService.cs
+++ b/LearningHub.Nhs.WebUI/Services/JobRoleService.cs
@@ -4,9 +4,12 @@
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using elfhHub.Nhs.Models.Common;
+    using LearningHub.Nhs.WebUI.Helpers;
     using LearningHub.Nhs.WebUI.Interfaces;
+    using LearningHub.Nhs.WebUI.Models.Account;
     using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
+    using NuGet.Common;
 
     /// <summary>
     /// Defines the <see cref="JobRoleService" />.
@@ -101,7 +104,7 @@
 
             var client = await this.userApiHttpClient.GetClientAsync();
 
-            var request = $"JobRole/GetPagedFilteredWithStaffGroup/{filter}/{page}/{pageSize}";
+            var request = $"JobRole/GetPagedFilteredWithStaffGroup/{Uri.EscapeDataString(filter.EncodeParameter())}/{page}/{pageSize}";
             var response = await client.GetAsync(request).ConfigureAwait(false);
 
             if (response.IsSuccessStatusCode)


### PR DESCRIPTION
### JIRA link
TD-3744
### Description
Job role with slash in causes error during registration

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/154979799/03faf581-752c-41e0-94fe-2dddd0f3f383)
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [X] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
