### PR TITLE
TD-3950 bookmark partial view error bugfix

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/HomeController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/HomeController.cs
@@ -246,17 +246,29 @@ namespace LearningHub.Nhs.WebUI.Controllers
                     Catalogues = new Nhs.Models.Dashboard.DashboardCatalogueResponseViewModel { Type = catalogueDashBoard },
                 };
 
-                switch (dashBoardTray)
+                bool isAjax = this.HttpContext.Request.Headers["X-Requested-With"] == "XMLHttpRequest";
+
+                if (isAjax)
                 {
-                    case "my-learning":
-                        model.MyLearnings = await this.dashboardService.GetMyAccessLearningsAsync(myLearningDashBoard, pageNumber);
-                        return this.PartialView("_MyAccessedLearningTray", model);
-                    case "resources":
-                        model.Resources = await this.dashboardService.GetResourcesAsync(resourceDashBoard, pageNumber);
-                        return this.PartialView("_ResourceTray", model);
-                    case "catalogues":
-                        model.Catalogues = await this.dashboardService.GetCataloguesAsync(catalogueDashBoard, pageNumber);
-                        return this.PartialView("_CatalogueTray", model);
+                    switch (dashBoardTray)
+                    {
+                        case "my-learning":
+                            model.MyLearnings = await this.dashboardService.GetMyAccessLearningsAsync(myLearningDashBoard, pageNumber);
+                            return this.PartialView("_MyAccessedLearningTray", model);
+                        case "resources":
+                            model.Resources = await this.dashboardService.GetResourcesAsync(resourceDashBoard, pageNumber);
+                            return this.PartialView("_ResourceTray", model);
+                        case "catalogues":
+                            model.Catalogues = await this.dashboardService.GetCataloguesAsync(catalogueDashBoard, pageNumber);
+                            return this.PartialView("_CatalogueTray", model);
+                    }
+                }
+                else
+                {
+                    model.MyLearnings = await this.dashboardService.GetMyAccessLearningsAsync(myLearningDashBoard, dashBoardTray == "my-learning" ? pageNumber : 1);
+                    model.Resources = await this.dashboardService.GetResourcesAsync(resourceDashBoard, dashBoardTray == "resources" ? pageNumber : 1);
+                    model.Catalogues = await this.dashboardService.GetCataloguesAsync(catalogueDashBoard, dashBoardTray == "catalogues" ? pageNumber : 1);
+                    return this.View("Dashboard", model);
                 }
             }
 


### PR DESCRIPTION
### JIRA link
[TD-3950 ](https://hee-tis.atlassian.net/browse/TD-3950)

### Description
Adding resources to bookmarks returns an error when user has proceeded beyond page 1 of the dashboard trays
### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
