### PR TITLE
TD-1325: My Learning record disappearing after session completed

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/Api/ScormController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/Api/ScormController.cs
@@ -260,6 +260,11 @@
 
                 // Persist update.
                 await this.activityService.UpdateScormActivityAsync(scoObject);
+                if (scoObject.LessonStatusId == 3)
+                {
+                    await this.activityService.CompleteScormActivity(scoObject);
+                }
+
                 return true;
             }
             catch (Exception ex)

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/ScormActivityComplete.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/ScormActivityComplete.sql
@@ -6,6 +6,7 @@
 -- Modification History
 --
 -- 11-06-2021  Killian Davies	Initial Revision
+-- 22-03-2024  Sarathlal		TD-1325
 -------------------------------------------------------------------------------
 CREATE PROCEDURE [activity].[ScormActivityComplete]
 (
@@ -23,7 +24,7 @@ BEGIN
 	DECLARE @DurationSeconds int
 	DECLARE @ScormActivityDurationLimitHours int = 10 * 60 * 60
 	DECLARE @AmendDate datetimeoffset(7) = ISNULL(TODATETIMEOFFSET(DATEADD(mi, @UserTimezoneOffset, GETUTCDATE()), @UserTimezoneOffset), SYSDATETIMEOFFSET())
-
+	DECLARE @CmiCoreSessionTime NVARCHAR(MAX)
 	SELECT 
 		@ScormResourceActivityId = [ResourceActivityId],
 		@ActivityStatusId = CmiCoreLesson_status,
@@ -32,7 +33,8 @@ BEGIN
 							WHEN (activity.ScormTimeToSeconds(CmiCoreSession_time) >= @ScormActivityDurationLimitHours) THEN (@ScormActivityDurationLimitHours - 1)
 							ELSE activity.ScormTimeToSeconds(CmiCoreSession_time) 
 						   END,
-		@Score = CmiCoreScoreRaw
+		@Score = CmiCoreScoreRaw,
+		@CmiCoreSessionTime = CmiCoreSession_time
 	FROM 
 		activity.ScormActivity sa
 	INNER JOIN	
@@ -52,7 +54,7 @@ BEGIN
 	END
 
 	-- Validation ported from e-LfH: completed status requires duration > 0
-	IF (@ActivityStatusId IN (3, 4, 5) AND @DurationSeconds > 0)
+	IF ((@ActivityStatusId IN (3, 4, 5) AND @DurationSeconds > 0) OR (@ActivityStatusId=3 AND @CmiCoreSessionTime =''))
 	BEGIN TRY
 		BEGIN TRAN
 
@@ -122,5 +124,3 @@ BEGIN
 				);
 	END CATCH
 END
-
-GO


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-1325

### Description
https://hee-tis.atlassian.net/browse/TD-1325

### Screenshots
**_Before code changes:_**
![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/120369940/3591cb73-aa79-4fd2-b3cc-e13cb203b175)

Disappeared after complete
![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/120369940/c1cfec9d-c8a7-4e2d-a54f-2e4407c2be58)

Appeared again after window close
![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/120369940/438fa371-6676-407e-aa37-58408eeef37e)

**_After code fix:_**
![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/120369940/24f10a0d-4414-4800-9ad2-f301f65f0ac3)
![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/120369940/fd44d762-4fd0-4ab9-becf-aa4eda3fd500)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
