### PR TITLE
Fixes-TD-3699

### DIFF
--- a/LearningHub.Nhs.WebUI/Models/RestrictedAccessBannerViewModel.cs
+++ b/LearningHub.Nhs.WebUI/Models/RestrictedAccessBannerViewModel.cs
@@ -1,9 +1,11 @@
 ﻿namespace LearningHub.Nhs.WebUI.Models
 {
+    using System.Collections.Generic;
     using LearningHub.Nhs.Models.Catalogue;
     using LearningHub.Nhs.Models.Entities.Hierarchy;
+    using LearningHub.Nhs.Models.User;
 
-    /// <summary>
+     /// <summary>
     /// Defines the <see cref="RestrictedAccessBannerViewModel" />.
     /// </summary>
     public class RestrictedAccessBannerViewModel
@@ -37,5 +39,10 @@
         /// Gets or sets the CatalogueAccessRequest if there is one.
         /// </summary>
         public CatalogueAccessRequestViewModel CatalogueAccessRequest { get; set; }
+
+        /// <summary>
+        /// Gets or sets the current user's usergroups.
+        /// </summary>
+        public List<RoleUserGroupViewModel> UserGroups { get; set; }
     }
 }

--- a/LearningHub.Nhs.WebUI/Views/Catalogue/Index.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Catalogue/Index.cshtml
@@ -79,7 +79,8 @@
         CatalogueNodeVersionId = Model.Catalogue.Id,
         RestrictedAccess = Model.Catalogue.RestrictedAccess,
         HasCatalogueAccess = Unlocked(),
-        CatalogueAccessRequest = Model.CatalogueAccessRequest
+        CatalogueAccessRequest = Model.CatalogueAccessRequest,
+        UserGroups = Model.UserGroups
       };
 }
 

--- a/LearningHub.Nhs.WebUI/Views/Shared/_RestrictedAccessBanner.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Shared/_RestrictedAccessBanner.cshtml
@@ -6,7 +6,7 @@
 {
     <div class="nhsuk-bg-pale-blue nhsuk-u-padding-top-4 nhsuk-u-padding-bottom-3 nhsuk-u-margin-bottom-3">
         <div class="nhsuk-width-container app-width-container">
-            @if (Model.CatalogueAccessRequest == null)
+            @if (Model.CatalogueAccessRequest == null || Model.UserGroups.Count == 0)
             {
                 <h2>@Model.TitleText</h2>
                 <p class="nhsuk-u-reading-width">@Model.BodyText</p>


### PR DESCRIPTION
### JIRA link
TD-3699

### Description
If you remove a user from a restricted catalogue via the Manage Catalogue page, although they are removed from the usergroup, they still have access to the catalogue.
If however you remove a user via the usergroup directly, it does prevent their access.
### Screenshots
![TD-3699](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/154979799/dc9a0382-d10e-4499-9713-7c6fa1510f5a)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [X] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3699]: https://hee-tis.atlassian.net/browse/TD-3699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ