### PR TITLE
TD-3991 Fix for certificate display for web and generic file resource

### DIFF
--- a/LearningHub.Nhs.WebUI/Views/Resource/_ResourceItem.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Resource/_ResourceItem.cshtml
@@ -92,7 +92,7 @@
                 @* Weblink *@
                 @if (canShowMoreDetails && resourceItem.ResourceTypeEnum == ResourceTypeEnum.WebLink)
                 {
-                    <div class="nhsuk-card nhsuk-bg-light-blue">
+                    <div id="resourcePg" class="nhsuk-card nhsuk-bg-light-blue">
                         <div class="nhsuk-card__content">
                             <p class="nhsuk-body-l nhsuk-u-margin-bottom-3">Visit site:</p>
                             @{
@@ -103,7 +103,7 @@
                                     displayText = resourceItem.WebLinkDetails.Url;
                                 }
                             }
-                            <p class="nhsuk-body-l word-break__break-word"><a href="@GetWeblinkNavigateLink(resourceItem.WebLinkDetails.Url)" target="_blank">@displayText</a></p>
+                            <p class="nhsuk-body-l word-break__break-word"><a v-on:click=checkUserCertificateAvailability(@resourceItem.Id) href="@GetWeblinkNavigateLink(resourceItem.WebLinkDetails.Url)" target="_blank">@displayText</a></p>
                         </div>
                     </div>
                 }
@@ -112,12 +112,12 @@
                 @if (canShowMoreDetails && resourceItem.ResourceTypeEnum == ResourceTypeEnum.GenericFile)
                 {
                     <div class="resource-panel-container">
-                        <div class="nhsuk-card nhsuk-bg-light-blue">
+                        <div id="resourcePg" class="nhsuk-card nhsuk-bg-light-blue">
                             <div class="nhsuk-card__content">
                                 <p class="nhsuk-body-l nhsuk-u-margin-bottom-3">Download:</p>
                                 <p class="nhsuk-body-l word-break__break-word">
                                     <span class="nhsuk-u-margin-right-4 pill @UtilityHelper.GetPillColour(resourceItem.GenericFileDetails.File.FileName)">@GetFileExtension(resourceItem.GenericFileDetails.File.FileName)</span>
-                                    <a class="nhsuk-u-margin-right-4" href="@GetDownloadResourceLink(resourceItem.GenericFileDetails.File.FilePath, resourceItem.GenericFileDetails.File.FileName)">@resourceItem.GenericFileDetails.File.FileName</a> (@resourceItem.GenericFileDetails.File.FileSizeKb KB)
+                                    <a v-on:click=checkUserCertificateAvailability(@resourceItem.Id) class="nhsuk-u-margin-right-4" href="@GetDownloadResourceLink(resourceItem.GenericFileDetails.File.FilePath, resourceItem.GenericFileDetails.File.FileName)">@resourceItem.GenericFileDetails.File.FileName</a> (@resourceItem.GenericFileDetails.File.FileSizeKb KB)
                                 </p>
                             </div>
                         </div>


### PR DESCRIPTION
### JIRA link
[TD-3991](https://hee-tis.atlassian.net/browse/TD-3991)

### Description
some vue.js click event directive were missing

### Screenshots
Not applicable

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3991]: https://hee-tis.atlassian.net/browse/TD-3991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ