### PR TITLE
TD-3955: eLearning with Passed type is also included when the user completes the learning and exit without proper closure

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/Api/ScormController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/Api/ScormController.cs
@@ -260,7 +260,7 @@
 
                 // Persist update.
                 await this.activityService.UpdateScormActivityAsync(scoObject);
-                if (scoObject.LessonStatusId == 3 || scoObject.LessonStatusId == 5)
+                if (scoObject.LessonStatusId == ScormLessionStatus.ActivityStatusId(ScormLessionStatus.Completed) || scoObject.LessonStatusId == ScormLessionStatus.ActivityStatusId(ScormLessionStatus.Passed))
                 {
                     await this.activityService.CompleteScormActivity(scoObject);
                 }

--- a/LearningHub.Nhs.WebUI/Controllers/Api/ScormController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/Api/ScormController.cs
@@ -260,7 +260,7 @@
 
                 // Persist update.
                 await this.activityService.UpdateScormActivityAsync(scoObject);
-                if (scoObject.LessonStatusId == 3)
+                if (scoObject.LessonStatusId == 3 || scoObject.LessonStatusId == 5)
                 {
                     await this.activityService.CompleteScormActivity(scoObject);
                 }


### PR DESCRIPTION


### JIRA link
https://hee-tis.atlassian.net/browse/TD-3955

### Description
eLearning with Passed type is also included when the user completes the learning and exit without proper closure

### Screenshots
**_Before code change_**
![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/120369940/3ca9c881-a795-414f-97d9-d6d0e555c72f)

**_After code change:_**
![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/120369940/497c664c-78f2-4611-86a5-07ffd0dd91a3)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
