### PR TITLE
TD-4014-HTML resource page displaying launch button twice

### DIFF
--- a/LearningHub.Nhs.WebUI/Views/Resource/_ResourceItem.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Resource/_ResourceItem.cshtml
@@ -161,23 +161,7 @@
                         </div>
                     }
                 }
-                @* Html Resource *@
-                @if (canShowMoreDetails && resourceItem.ResourceTypeEnum == ResourceTypeEnum.Html)
-                {
-                    <div id="resourcePg" class="nhsuk-card nhsuk-bg-light-blue">
-                        <div class="nhsuk-card__content">
-                            <a v-on:click=checkUserCertificateAvailability(@resourceItem.Id) href="@($"{Context.Request.Scheme}://{Context.Request.Host}/resource/html/{resourceItem.Id}/index.html")"
-                               onclick="@($"window.open(this.href, 'scormDebugWindow', 'status=no,location=no,toolbar=no,menubar=no,dependent=no,width={resourceItem.HtmlDetails.PopupWidth},height={resourceItem.HtmlDetails.PopupHeight}'); return false;")">
-                                <button class="nhsuk-button">
-                                    Launch HTML resource
-                                </button>
-                            </a>
-                            <p>This resource will launch in a new window</p>
-                        </div>
-                    </div>
-                }
-
-
+               
                 @if (canShowMoreDetails && resourceItem.ResourceTypeEnum == ResourceTypeEnum.Video || resourceItem.ResourceTypeEnum == ResourceTypeEnum.Audio || resourceItem.ResourceTypeEnum == ResourceTypeEnum.Scorm ||
                resourceItem.ResourceTypeEnum == ResourceTypeEnum.Case || resourceItem.ResourceTypeEnum == ResourceTypeEnum.Assessment)
                 {


### PR DESCRIPTION
### JIRA link
TD-4014

### Description
HTML resource page displaying launch button twice

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors
- [] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [X] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [X] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
