### PR TITLE
Auto Save button issue when updating case resources

### DIFF
--- a/WebAPI/LearningHub.Nhs.Repository/LearningHubDbContext.cs
+++ b/WebAPI/LearningHub.Nhs.Repository/LearningHubDbContext.cs
@@ -41,6 +41,14 @@ namespace LearningHub.Nhs.Repository
         }
 
         /// <summary>
+        /// Gets the Options.
+        /// </summary>
+        public LearningHubDbContextOptions Options
+        {
+            get { return this.options; }
+        }
+
+        /// <summary>
         /// Gets or sets the Address.
         /// </summary>
         public virtual DbSet<Address> Address { get; set; }

--- a/WebAPI/LearningHub.Nhs.Repository/Resources/BlockCollectionRepository.cs
+++ b/WebAPI/LearningHub.Nhs.Repository/Resources/BlockCollectionRepository.cs
@@ -83,7 +83,10 @@ namespace LearningHub.Nhs.Repository.Resources
 
             foreach (var id in collectionIds)
             {
-                await this.DbContext.Database.ExecuteSqlRawAsync("resources.BlockCollectionDelete @p0", new SqlParameter("@p0", SqlDbType.Int) { Value = id });
+                using (var lhContext = new LearningHubDbContext(this.DbContext.Options))
+                {
+                    _ = lhContext.Database.ExecuteSqlRawAsync("resources.BlockCollectionDelete @p0", new SqlParameter("@p0", SqlDbType.Int) { Value = id });
+                }
             }
         }
 


### PR DESCRIPTION
### JIRA link
[TD-3948](https://hee-tis.atlassian.net/browse/TD-3948)

### Description
The endpoint previously experienced timeouts when making repeated stored procedure calls to the database. To address this issue, the endpoint was modified to execute these calls without waiting for a confirmation response from the database. Consequently, a database context had to be manually instantiated and disposed within the loop to handle concurrency effectively.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._
Not available.
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3948]: https://hee-tis.atlassian.net/browse/TD-3948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ