### PR TITLE
TD-4020 : incorrect message for edit resource my contributions

### DIFF
--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/mycontributions/gridcomponent.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/mycontributions/gridcomponent.vue
@@ -44,7 +44,7 @@
                         </div>
 
                         <div class="modal-body">
-                            You are about to make a change to this resource. If you continue, changes cannot be undone.
+                            You are about to make a change to this resource. Editing this page will create a new draft, nothing will change until this draft is published.
                         </div>
 
                         <div class="modal-footer">


### PR DESCRIPTION
### JIRA link
[_TD-###_](https://hee-tis.atlassian.net/browse/TD-2959?atlOrigin=eyJpIjoiODZhM2Y3NzMwYmY2NDI1M2ExNDBjMjNhMzcyMjAxNjMiLCJwIjoiaiJ9)

### Description
Updated the edit resource message

### Screenshots
Before:
![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/163844873/67586ec3-349a-4750-b2ba-d460cd48feab)

After:
![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/163844873/484d31f8-5833-460c-8be0-83867f402996)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
