### PR TITLE
TD-3285, vue cache storing the feature flag inconsistently, update the way its populating now

### DIFF
--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/SelectResourceType.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/SelectResourceType.vue
@@ -5,7 +5,7 @@
         </div>
         <div class="mx-5">
             <h3 class="nhsuk-heading-l nhsuk-u-margin-bottom-2">{{title}}</h3>
-            <div>{{description}}</div>            
+            <div>{{description}}</div>
             <div v-if="!contributeResourceAVFlag && title === 'File' && !isSelected" class="align-self-center">
                 <div v-html="audioVideoUnavailableView"></div>
             </div>
@@ -39,7 +39,7 @@
         },
         data() {
             return {
-                contributeResourceAVFlag: false                
+                contributeResourceAVFlag: true
             };
         },
         created() {
@@ -57,18 +57,17 @@
             },
             isSelected(): boolean {
                 return this.resourceDetails.resourceType === this.resourceType;
-            },           
+            },
             audioVideoUnavailableView(): string {
-                var view = this.$store.state.getAVUnavailableView;
                 return this.$store.state.getAVUnavailableView;
             }
         },
         methods: {
             getContributeResAVResourceFlag() {
-                 resourceData.getContributeAVResourceFlag().then(response => {
-                 this.contributeResourceAVFlag = response;
+                resourceData.getContributeAVResourceFlag().then(response => {
+                    this.contributeResourceAVFlag = response;
                 });
-             },
+            },
             getResourceTypeDescription(resourceType: ResourceType): string {
                 switch (resourceType) {
                     case ResourceType.ARTICLE:

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/ContentVideo.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/ContentVideo.vue
@@ -105,6 +105,7 @@
                 uploadingFile: null as File,
                 uploadingTranscriptFile: null as File,
                 uploadingCaptionsFile: null as File,
+                contributeResourceAVFlag: true
             };
         },
         computed: {
@@ -120,15 +121,13 @@
             fileUpdated(): ResourceFileModel {
                 return this.$store.state.fileUpdated;
             },
-            contributeResourceAVFlag(): boolean {
-                return this.$store.state.contributeAVResourceFlag;
-            },
             audioVideoUnavailableView(): string {
                 return this.$store.state.getAVUnavailableView;
             },
         },
         created() {
             this.setInitialValues();
+            this.getContributeResAVResourceFlag();
             EventBus.$on('deleteFile', (fileTypeToBeDeleted: number) => {
                 this.processDeleteFile(fileTypeToBeDeleted);
             });
@@ -141,6 +140,11 @@
         methods: {
             changeFile() {
                 this.$emit('filechanged');
+            },
+            getContributeResAVResourceFlag() {
+                resourceData.getContributeAVResourceFlag().then(response => {
+                    this.contributeResourceAVFlag = response;
+                });
             },
             changeTranscriptFile() {
                 $('#transcriptFileUpload').val(null);

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/GenericFileUploader.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/GenericFileUploader.vue
@@ -21,6 +21,7 @@
 
 <script lang="ts">
     import Vue, { PropOptions } from 'vue';
+    import { resourceData } from '../data/resource';
     import { ResourceType, UploadResourceType } from '../constants';
     import { ContributeSettingsModel } from '../models/contribute/contributeSettingsModel';
 
@@ -33,7 +34,11 @@
         data() {
             return {
                 uploadResourceType: UploadResourceType,
+                contributeResourceAVFlag: true
             }
+        },
+        created() {
+            this.getContributeResAVResourceFlag();
         },
         computed: {
             contributeSettings(): ContributeSettingsModel {
@@ -42,13 +47,17 @@
             fileAccept(): string {
                 return this.$store.state.resourceDetail.resourceType == ResourceType.HTML ? '.zip,.rar,.7zip' : ''
             },
-            contributeResourceAVFlag(): boolean {
-                return this.$store.state.contributeAVResourceFlag;
-            },
             audioVideoUnavailableView(): string {
                 return this.$store.state.getAVUnavailableView;
             },
         },
+        methods: {
+            getContributeResAVResourceFlag() {
+                resourceData.getContributeAVResourceFlag().then(response => {
+                    this.contributeResourceAVFlag = response;
+                });
+            },
+        }
     });
 </script>
 


### PR DESCRIPTION
### JIRA link
_TD-###_

### Description
_Describe what has changed and how that will affect the app. If relevant, add references to the resources you used. Use this as your opportunity to highlight anything odd and give people context around particular decisions._

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
