### PR TITLE
TD-3023 limit the removal of output content to scorm and html resource

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/ResourceController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/ResourceController.cs
@@ -413,7 +413,11 @@
 
             if (validationResult.IsValid)
             {
-                _ = Task.Run(async () => { await this.fileService.PurgeResourceFile(associatedFile, null); });
+                if (associatedFile.ScormDetails != null || associatedFile.HtmlDetails != null)
+                {
+                    _ = Task.Run(async () => { await this.fileService.PurgeResourceFile(associatedFile, null); });
+                }
+
                 if (viewModel.CatalogueNodeVersionId == 1)
                 {
                     return this.Redirect("/my-contributions/unpublished");


### PR DESCRIPTION

### JIRA link
TD-3023

### Description
limit the removal of output content to scorm and html resource during resource unpublish activity.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
