### PR TITLE
TD-3741 - LMS server issue related to active content cache is null.

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/Api/ScormController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/Api/ScormController.cs
@@ -230,6 +230,11 @@
             try
             {
                 var activeContent = this.userService.GetActiveContentAsync().Result;
+                if (activeContent.Count == 0)
+                {
+                    return false;
+                }
+
                 if (!activeContent.Any(ac => ac.ScormActivityId == scoObject.InstanceId))
                 {
                     throw new Exception($"User does not have ActiveContent for ScormActivityId={scoObject.InstanceId}");


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3741

### Description
Implemented the logic to fix the issues related to the LMS server after releasing cache content on commit. 

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
