### PR TITLE
TD-4047: Duplicate records appearing in Mylearning page. Brought back removed code to fix the issue and implemented same logic in newly created stored procedures.

### DIFF
--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLatestActivityCheck.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLatestActivityCheck.sql
@@ -144,7 +144,31 @@ FROM (
                      WHERE  ([ScormActivity].[Deleted] = 0 AND [ResourceActivity].[Id] = [ScormActivity].[ResourceActivityId])										 
 				) 
 					IS NULL
-			)		
+			)
+		AND   
+				(
+					(
+					   -- resource type is not video/audio and launch resource activity doesn't exists
+					   [Res].[ResourceTypeId] NOT IN (7,2) AND NOT (EXISTS
+								(
+									SELECT 1 FROM   [activity].[ResourceActivity] AS [ResAct1]
+									WHERE  [ResAct1].[Deleted] = 0 AND [ResourceActivity].[Id] = [ResAct1].[LaunchResourceActivityId]
+								))
+					)
+				OR  
+					-- or launch resource activity completed
+					EXISTS
+					(
+							SELECT 1	FROM   [activity].[ResourceActivity] AS [ResAct2]
+							WHERE  [ResAct2].[Deleted] = 0 AND  [ResourceActivity].[Id] = [ResAct2].[LaunchResourceActivityId] AND  [ResAct2].[ActivityStatusId] = 3
+					)
+					
+				)
+		AND
+				(
+					-- resource type is not assessment and activity status is launched
+					[Res].[ResourceTypeId] <> 11 OR [ResourceActivity].[ActivityStatusId] = 1
+				)
 
 ) AS [t2]
 LEFT JOIN [resources].[VideoResourceVersion] AS [VideoResourceVersion] ON [t2].[Id1] = [VideoResourceVersion].[ResourceVersionId]

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivities.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivities.sql
@@ -213,7 +213,30 @@ FROM (
 				) 
 					IS NULL
 			)		
-		
+		AND   
+				(
+					(
+					   -- resource type is not video/audio and launch resource activity doesn't exists
+					   [Res].[ResourceTypeId] NOT IN (7,2) AND NOT (EXISTS
+								(
+									SELECT 1 FROM   [activity].[ResourceActivity] AS [ResAct1]
+									WHERE  [ResAct1].[Deleted] = 0 AND [ResourceActivity].[Id] = [ResAct1].[LaunchResourceActivityId]
+								))
+					)
+				OR  
+					-- or launch resource activity completed
+					EXISTS
+					(
+							SELECT 1	FROM   [activity].[ResourceActivity] AS [ResAct2]
+							WHERE  [ResAct2].[Deleted] = 0 AND  [ResourceActivity].[Id] = [ResAct2].[LaunchResourceActivityId] AND  [ResAct2].[ActivityStatusId] = 3
+					)
+					
+				)
+		AND
+				(
+					-- resource type is not assessment and activity status is launched
+					[Res].[ResourceTypeId] <> 11 OR [ResourceActivity].[ActivityStatusId] = 1
+				)
 		AND
 				(
 						@filterActivityStatus = 0			

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivitiesCount.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivitiesCount.sql
@@ -128,7 +128,31 @@ FROM (
                      WHERE  ([ScormActivity].[Deleted] = 0 AND [ResourceActivity].[Id] = [ScormActivity].[ResourceActivityId])										 
 				) 
 					IS NULL
-			)		
+			)	
+		AND   
+				(
+					(
+					   -- resource type is not video/audio and launch resource activity doesn't exists
+					   [Res].[ResourceTypeId] NOT IN (7,2) AND NOT (EXISTS
+								(
+									SELECT 1 FROM   [activity].[ResourceActivity] AS [ResAct1]
+									WHERE  [ResAct1].[Deleted] = 0 AND [ResourceActivity].[Id] = [ResAct1].[LaunchResourceActivityId]
+								))
+					)
+				OR  
+					-- or launch resource activity completed
+					EXISTS
+					(
+							SELECT 1	FROM   [activity].[ResourceActivity] AS [ResAct2]
+							WHERE  [ResAct2].[Deleted] = 0 AND  [ResourceActivity].[Id] = [ResAct2].[LaunchResourceActivityId] AND  [ResAct2].[ActivityStatusId] = 3
+					)
+					
+				)
+		AND
+				(
+					-- resource type is not assessment and activity status is launched
+					[Res].[ResourceTypeId] <> 11 OR [ResourceActivity].[ActivityStatusId] = 1
+				)
 		AND   
 					(
 						@filterActivityStatus = 0			

--- a/WebAPI/LearningHub.Nhs.Repository/Activity/ResourceActivityRepository.cs
+++ b/WebAPI/LearningHub.Nhs.Repository/Activity/ResourceActivityRepository.cs
@@ -96,6 +96,7 @@ namespace LearningHub.Nhs.Repository.Activity
             //
             // For assessment activities, only include the original activities that were created when starting the assessment. The created end record is only for consistency.
             // It's easier to get the real assessment resource activity from the original resource activity, so only fetch that one.
+            // TD-4047: As part of this defect bringing back the removed code which then used for the new stored procedure created as part of performance improvement.
             return this.DbContext.ResourceActivity
                .Include(r => r.Resource)
                .ThenInclude(r => r.ResourceReference)
@@ -111,9 +112,10 @@ namespace LearningHub.Nhs.Repository.Activity
                .Include(r => r.NodePath)
                .AsNoTracking()
              .Where(r =>
-                            r.UserId == userId && r.ScormActivity.First().CmiCoreLessonStatus != (int)ActivityStatusEnum.Completed &&
-                           ((!r.InverseLaunchResourceActivity.Any()) ||
-                              r.InverseLaunchResourceActivity.Any()))
+                      r.UserId == userId && r.ScormActivity.First().CmiCoreLessonStatus != (int)ActivityStatusEnum.Completed &&
+                     ((r.Resource.ResourceTypeEnum != ResourceTypeEnum.Video && r.Resource.ResourceTypeEnum != ResourceTypeEnum.Audio && !r.InverseLaunchResourceActivity.Any()) ||
+                        r.InverseLaunchResourceActivity.Any(y => y.ActivityStatusId == (int)ActivityStatusEnum.Completed)) &&
+                     (r.Resource.ResourceTypeEnum != ResourceTypeEnum.Assessment || r.ActivityStatusId == (int)ActivityStatusEnum.Launched))
               .OrderByDescending(r => r.ActivityStart);
         }
 


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4047

### Description
My Learning page - elearning with Assessment displays the learning record twice based upon the assessment result

### Screenshots

**_Before code change:_**
![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/120369940/6ad97787-6bcb-4f34-bae6-b33c7a583779)

**_After code change:_**
![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/120369940/bf86e581-84c4-47ab-9b02-943ad555c488)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
