### PR TITLE
TD-4052 bugfix

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/Api/ContributeController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/Api/ContributeController.cs
@@ -228,7 +228,7 @@
             var validationResult = await this.contributeService.DeleteResourceVersionAsync(resourceVersionId);
             if (validationResult.IsValid)
             {
-                if (associatedFile.Any())
+                if (associatedFile != null && associatedFile.Any())
                 {
                     _ = Task.Run(async () => { await this.fileService.PurgeResourceFile(null, associatedFile); });
                 }
@@ -348,7 +348,7 @@
                 if (associatedResource.ResourceTypeEnum != ResourceTypeEnum.Scorm && associatedResource.ResourceTypeEnum != ResourceTypeEnum.Html)
                 {
                     var obsoleteFiles = await this.resourceService.GetObsoleteResourceFile(publishViewModel.ResourceVersionId);
-                    if (obsoleteFiles.Any())
+                    if (obsoleteFiles != null && obsoleteFiles.Any())
                     {
                         await this.fileService.PurgeResourceFile(null, obsoleteFiles);
                     }

--- a/LearningHub.Nhs.WebUI/Services/FileService.cs
+++ b/LearningHub.Nhs.WebUI/Services/FileService.cs
@@ -405,6 +405,10 @@
                 {
                     var directory = this.ShareClient.GetDirectoryClient(directoryRef);
                     var archiveDirectory = this.InputArchiveShareClient.GetDirectoryClient(directoryRef);
+                    if (!directory.Exists())
+                    {
+                        continue;
+                    }
 
                     await foreach (var fileItem in directory.GetFilesAndDirectoriesAsync())
                     {

--- a/WebAPI/LearningHub.Nhs.Services/ResourceService.cs
+++ b/WebAPI/LearningHub.Nhs.Services/ResourceService.cs
@@ -1390,7 +1390,7 @@ namespace LearningHub.Nhs.Services
                 }
                 else if (extendedResourceVersion.ResourceTypeEnum == ResourceTypeEnum.Audio)
                 {
-                    if (resource.AudioDetails.File.FilePath != extendedResourceVersion.AudioDetails.File.FilePath)
+                    if (resource.AudioDetails?.File?.FilePath != extendedResourceVersion.AudioDetails.File.FilePath)
                     {
                         if (!deletedResource)
                         {
@@ -1402,7 +1402,7 @@ namespace LearningHub.Nhs.Services
                         }
                     }
 
-                    if (resource.AudioDetails.ResourceAzureMediaAsset.FilePath != extendedResourceVersion.AudioDetails.ResourceAzureMediaAsset.FilePath)
+                    if (resource.AudioDetails?.ResourceAzureMediaAsset?.FilePath != extendedResourceVersion.AudioDetails.ResourceAzureMediaAsset.FilePath)
                     {
                         if (!deletedResource)
                         {
@@ -1416,7 +1416,7 @@ namespace LearningHub.Nhs.Services
                 }
                 else if (extendedResourceVersion.ResourceTypeEnum == ResourceTypeEnum.Video)
                 {
-                    if (resource.VideoDetails.File.FilePath != extendedResourceVersion.VideoDetails.File.FilePath)
+                    if (resource.VideoDetails?.File?.FilePath != extendedResourceVersion.VideoDetails.File.FilePath)
                     {
                         if (!deletedResource)
                         {
@@ -1428,7 +1428,7 @@ namespace LearningHub.Nhs.Services
                         }
                     }
 
-                    if (resource.VideoDetails.ResourceAzureMediaAsset.FilePath != extendedResourceVersion.VideoDetails.ResourceAzureMediaAsset.FilePath)
+                    if (resource.VideoDetails?.ResourceAzureMediaAsset?.FilePath != extendedResourceVersion.VideoDetails.ResourceAzureMediaAsset.FilePath)
                     {
                         if (!deletedResource)
                         {
@@ -1443,7 +1443,7 @@ namespace LearningHub.Nhs.Services
                 else if (extendedResourceVersion.ResourceTypeEnum == ResourceTypeEnum.Article)
                 {
                     var inputResourceFiles = resource.ArticleDetails.Files.ToList();
-                    var previousPublishedfiles = extendedResourceVersion.ArticleDetails.Files.ToList();
+                    var previousPublishedfiles = extendedResourceVersion.ArticleDetails?.Files?.ToList();
                     if (!deletedResource)
                     {
                         if (previousPublishedfiles.Any())


### PR DESCRIPTION
### JIRA link
[TD-4052](https://hee-tis.atlassian.net/browse/TD-4052)

### Description
this fix does a null check before checking the content of a list

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4052]: https://hee-tis.atlassian.net/browse/TD-4052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ