### PR TITLE
Correct Skipped headiing issue for catalogue folders

### DIFF
--- a/LearningHub.Nhs.WebUI/Styles/nhsuk/pages/bookmark.scss
+++ b/LearningHub.Nhs.WebUI/Styles/nhsuk/pages/bookmark.scss
@@ -29,7 +29,7 @@ a.cancel-link:visited {
     }
 }
 
-.folder-title {
+div.folder-title {
     font-weight: bold;
 }
 

--- a/LearningHub.Nhs.WebUI/Styles/nhsuk/pages/catalogue.scss
+++ b/LearningHub.Nhs.WebUI/Styles/nhsuk/pages/catalogue.scss
@@ -29,6 +29,13 @@ textarea {
     }
 }
 
+@media(min-width: 40.0625em) {
+    .folder-title {
+        font-size: 24px;
+        font-size: 1.5rem;
+    }
+}
+
 .folder-title_empty {
     display: flex;
 

--- a/LearningHub.Nhs.WebUI/Views/Catalogue/_ContentStructure.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Catalogue/_ContentStructure.cshtml
@@ -10,17 +10,17 @@
     {
       @if (item.IsEmptyFolder)
       {
-        <h3 class="folder-title">
+        <h2 class="folder-title">
           <img src="/images/folder-icon.svg" alt="folder icon" />
           <a asp-controller="Catalogue" asp-route-reference="@Model.Catalogue.Url" asp-route-nodeId="@item.NodeId">@item.Name</a>
-        </h3>
+        </h2>
       }
       else
       {
-        <h3 class="folder-title_empty">
+        <h2 class="folder-title_empty">
           <img src="/images/folder-icon.svg" alt="folder icon" />
           @item.Name
-        </h3>
+        </h2>
       }
     }
         else


### PR DESCRIPTION
### JIRA link
_TD-3163_

### Description
_Describe what has changed and how that will affect the app. If relevant, add references to the resources you used. Use this as your opportunity to highlight anything odd and give people context around particular decisions._

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
