### PR TITLE
TD-4057: Re-introduced the label with "Only the first 3,000 characters of the description will be used by search" message for description field.

### DIFF
--- a/AdminUI/LearningHub.Nhs.AdminUI/Views/Catalogue/Edit.cshtml
+++ b/AdminUI/LearningHub.Nhs.AdminUI/Views/Catalogue/Edit.cshtml
@@ -138,6 +138,7 @@
             <div class="col-12">
                 <label for="Description">Description</label>
                 <textarea asp-for="Description" class="form-control"></textarea>
+                <small id="with-hint-info" class="pt-2">Only the first 3,000 characters of the description will be used by search</small>
                 <span asp-validation-for="Description"></span>
             </div>
         </div>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4057

### Description
Re-introduced the label with "Only the first 3,000 characters of the description will be used by search" message for description field.

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/120369940/65a66909-42fb-479c-bfae-fb0fd08d28e6)

Findwise data
![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/120369940/e621fa86-5b7c-4b5a-9f5e-2a1ea13dee82)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
