### PR TITLE
TD-3023 Delete files associated with resources without older versions

### DIFF
--- a/WebAPI/LearningHub.Nhs.Services/ResourceService.cs
+++ b/WebAPI/LearningHub.Nhs.Services/ResourceService.cs
@@ -1539,6 +1539,113 @@ namespace LearningHub.Nhs.Services
                     }
                 }
             }
+            else if (rv == null && deletedResource)
+            {
+                if (resource.ResourceTypeEnum == ResourceTypeEnum.Scorm)
+                {
+                      retVal.Add(resource.ScormDetails.ContentFilePath);
+                }
+                else if (resource.ResourceTypeEnum == ResourceTypeEnum.Html)
+                {
+                      retVal.Add(resource.HtmlDetails.ContentFilePath);
+                }
+                else if (resource.ResourceTypeEnum == ResourceTypeEnum.GenericFile)
+                {
+                    retVal.Add(resource.GenericFileDetails.File.FilePath);
+                }
+                else if (resource.ResourceTypeEnum == ResourceTypeEnum.Image)
+                {
+                    retVal.Add(resource.ImageDetails.File.FilePath);
+                }
+                else if (resource.ResourceTypeEnum == ResourceTypeEnum.Audio)
+                {
+                    retVal.Add(resource.AudioDetails.File.FilePath);
+                    if (resource.AudioDetails?.ResourceAzureMediaAsset?.FilePath != null)
+                    {
+                            retVal.Add(resource.AudioDetails.ResourceAzureMediaAsset.FilePath);
+                    }
+                }
+                else if (resource.ResourceTypeEnum == ResourceTypeEnum.Video)
+                {
+                    retVal.Add(resource.VideoDetails.File.FilePath);
+                    if (resource.VideoDetails?.ResourceAzureMediaAsset?.FilePath != null)
+                    {
+                         retVal.Add(resource.VideoDetails.ResourceAzureMediaAsset.FilePath);
+                    }
+                }
+                else if (resource.ResourceTypeEnum == ResourceTypeEnum.Article)
+                {
+                        var inputResourceFiles = resource.ArticleDetails.Files.ToList();
+                        if (inputResourceFiles.Any())
+                        {
+                            foreach (var file in inputResourceFiles)
+                            {
+                                    retVal.Add(file.FilePath);
+                            }
+                        }
+                    }
+                else if (resource.ResourceTypeEnum == ResourceTypeEnum.Case)
+                {
+                    var allBlocks = resource.CaseDetails.BlockCollection.Blocks.ToList();
+                    if (allBlocks.Any())
+                    {
+                        var existingAttachements = allBlocks.Where(x => x.BlockType == BlockType.Media && x.MediaBlock != null && x.MediaBlock.MediaType == MediaType.Attachment && x.MediaBlock.Attachment != null).ToList();
+                        if (existingAttachements.Any())
+                        {
+                            foreach (var oldblock in existingAttachements)
+                            {
+                                retVal.Add(oldblock.MediaBlock.Attachment?.File?.FilePath);
+                            }
+                        }
+
+                        var existingVideos = allBlocks.Where(x => x.BlockType == BlockType.Media && x.MediaBlock != null && x.MediaBlock.MediaType == MediaType.Video && x.MediaBlock.Video != null).ToList();
+                        if (existingVideos.Any())
+                        {
+                            foreach (var oldblock in existingVideos)
+                            {
+                                retVal.Add(oldblock.MediaBlock.Video?.VideoFile?.File?.FilePath);
+                                if (oldblock.MediaBlock?.Video?.VideoFile.TranscriptFile?.File.FilePath != null)
+                                {
+                                    retVal.Add(oldblock.MediaBlock.Video?.VideoFile?.TranscriptFile?.File?.FilePath);
+                                }
+                            }
+                        }
+
+                        var existingImages = allBlocks.Where(x => x.BlockType == BlockType.Media && x.MediaBlock != null && x.MediaBlock.MediaType == MediaType.Image && x.MediaBlock.Image != null).ToList();
+                        if (existingImages.Any())
+                        {
+                            foreach (var oldblock in existingImages)
+                            {
+                                retVal.Add(oldblock.MediaBlock?.Image?.File?.FilePath);
+                            }
+                        }
+
+                        var existingImageCarousel = allBlocks.Where(x => x.BlockType == BlockType.ImageCarousel && x.ImageCarouselBlock != null && x.ImageCarouselBlock.ImageBlockCollection != null && x.ImageCarouselBlock.ImageBlockCollection.Blocks != null).ToList();
+                        if (existingImageCarousel.Any())
+                        {
+                            foreach (var imageBlock in existingImageCarousel)
+                            {
+                                foreach (var oldblock in imageBlock?.ImageCarouselBlock?.ImageBlockCollection.Blocks)
+                                {
+                                    retVal.Add(oldblock.MediaBlock?.Image?.File?.FilePath);
+                                }
+                            }
+                        }
+
+                        var existingWholeSlideImages = allBlocks.Where(x => x.WholeSlideImageBlock != null && x.WholeSlideImageBlock.WholeSlideImageBlockItems.Any()).ToList();
+                        if (existingWholeSlideImages.Any())
+                        {
+                            foreach (var wsi in existingWholeSlideImages)
+                            {
+                                foreach (var oldblock in wsi.WholeSlideImageBlock?.WholeSlideImageBlockItems)
+                                {
+                                    retVal.Add(oldblock.WholeSlideImage?.File?.FilePath);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
 
             return retVal;
         }


### PR DESCRIPTION
### JIRA link
TD-3023

### Description
Delete resource files associated with resources with only one version.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
