### PR TITLE
TD3828- Publish view, the vue store doesnt popultate the warning vie,…

### DIFF
--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/components/published-view/ContributeMediaBlockPublishedView.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/components/published-view/ContributeMediaBlockPublishedView.vue
@@ -43,7 +43,8 @@
             return {
                 FileStore: FileStore,
                 MediaTypeEnum: MediaTypeEnum,
-                contributeResourceAVFlag: true
+                contributeResourceAVFlag: true,
+                audioVideoUnavailableView: ''
             }
         },
         created() {
@@ -51,6 +52,7 @@
             // So, when the file processing succeeds/fails, this is can be reflected in the published view.
             this.FileStore.enablePolling();
             this.getContributeResAVResourceFlag();
+            this.getContributeResAVUnavailableView();
         },
         computed: {
             mediaType(): MediaTypeEnum {
@@ -64,15 +66,17 @@
             },
             video(): VideoMediaModel {
                 return this.mediaBlock.video;
-            },
-            audioVideoUnavailableView(): string {
-                return this.$store.state.getAVUnavailableView;
             }
         },
         methods: {
             getContributeResAVResourceFlag() {
                 resourceData.getContributeAVResourceFlag().then(response => {
                     this.contributeResourceAVFlag = response;
+                });
+            },
+            getContributeResAVUnavailableView() {
+                resourceData.getAVUnavailableView().then(response => {
+                    this.audioVideoUnavailableView = response;
                 });
             },
         }


### PR DESCRIPTION
https://hee-tis.atlassian.net/browse/TD-3828

### Description
_Describe what has changed and how that will affect the app. If relevant, add references to the resources you used. Use this as your opportunity to highlight anything odd and give people context around particular decisions._

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
