### PR TITLE
TD-4057: Description limit moved to apsettings

### DIFF
--- a/WebAPI/LearningHub.Nhs.API/appsettings.json
+++ b/WebAPI/LearningHub.Nhs.API/appsettings.json
@@ -84,17 +84,18 @@
     },
 
     "FindWise": {
-      "IndexUrl": "",
-      "SearchUrl": "",
-      "CollectionIds": {
-        "Resource": "",
-        "Catalogue": ""
-      },
-      "UrlSearchComponent": "rest/apps/HEE/searchers/{0}",
-      "UrlClickComponent": "rest/apps/HEE/searchers/hee/signals/hee/signal/click",
-      "Token": "",
-      "MaximumDescriptionLength": 150,
-      "IndexMethod": "/rest/v2/collections/{0}/documents"
+        "IndexUrl": "",
+        "SearchUrl": "",
+        "CollectionIds": {
+            "Resource": "",
+            "Catalogue": ""
+        },
+        "UrlSearchComponent": "rest/apps/HEE/searchers/{0}",
+        "UrlClickComponent": "rest/apps/HEE/searchers/hee/signals/hee/signal/click",
+        "Token": "",
+        "MaximumDescriptionLength": 150,
+        "IndexMethod": "/rest/v2/collections/{0}/documents",
+        "DescriptionLengthLimit": 3000
     },
     "Notifications": {
       "PublishResourceTimeToProcessInSec": 30,

--- a/WebAPI/LearningHub.Nhs.Api.Shared/Configuration/FindwiseSettings.cs
+++ b/WebAPI/LearningHub.Nhs.Api.Shared/Configuration/FindwiseSettings.cs
@@ -44,5 +44,10 @@
         /// Gets or sets the collection ids.
         /// </summary>
         public FindwiseCollectionIdSettings CollectionIds { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Description length limit.
+        /// </summary>
+        public int DescriptionLengthLimit { get; set; }
     }
 }

--- a/WebAPI/LearningHub.Nhs.Services/CatalogueService.cs
+++ b/WebAPI/LearningHub.Nhs.Services/CatalogueService.cs
@@ -259,7 +259,7 @@
             if (cnv != null)
             {
                 var searchModel = this.mapper.Map<SearchCatalogueRequestModel>(cnv);
-                searchModel.Description = searchModel.Description.Substring(0, 2995) + "</p>";
+                searchModel.Description = searchModel.Description.Substring(0, this.settings.Findwise.DescriptionLengthLimit - 4) + "</p>";
                 await this.findwiseApiFacade.AddOrReplaceAsync(new List<SearchCatalogueRequestModel> { searchModel });
             }
 
@@ -481,6 +481,7 @@
             if (cnv != null)
             {
                 var searchModel = this.mapper.Map<SearchCatalogueRequestModel>(cnv);
+                searchModel.Description = searchModel.Description.Substring(0, this.settings.Findwise.DescriptionLengthLimit - 4) + "</p>";
                 await this.findwiseApiFacade.AddOrReplaceAsync(new List<SearchCatalogueRequestModel> { searchModel });
             }
 


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4057

### Description
Description limit included in update and moved to appsettings file

### Screenshots


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
