### PR TITLE
TD-3023 refactor Case and assessment block collection obsolete file removal

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/Api/ContributeController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/Api/ContributeController.cs
@@ -512,7 +512,7 @@
         {
             var existingResourceState = await this.resourceService.GetResourceVersionExtendedAsync(request.ResourceVersionId);
             int resourceVersionId = await this.contributeService.SaveAssessmentDetailAsync(request);
-            if (existingResourceState != null)
+            if (existingResourceState != null && existingResourceState.AssessmentDetails != null)
             {
                 this.RemoveBlockCollectionFiles(existingResourceState.AssessmentDetails, request);
             }

--- a/LearningHub.Nhs.WebUI/Services/FileService.cs
+++ b/LearningHub.Nhs.WebUI/Services/FileService.cs
@@ -230,49 +230,9 @@
                 {
                     allContentPath.Add(vm.ScormDetails.ContentFilePath);
                 }
-                else if (vm.GenericFileDetails != null && !string.IsNullOrWhiteSpace(vm.GenericFileDetails.File.FilePath))
-                {
-                    allFilePath.Add(vm.GenericFileDetails.File.FilePath);
-                }
                 else if (vm.HtmlDetails != null && !string.IsNullOrWhiteSpace(vm.HtmlDetails.ContentFilePath))
                 {
                     allContentPath.Add(vm.HtmlDetails.ContentFilePath);
-                }
-                else if (vm.ImageDetails != null && !string.IsNullOrWhiteSpace(vm.ImageDetails.File?.FilePath))
-                {
-                    allFilePath.Add(vm.ImageDetails.File?.FilePath);
-                }
-                else if (vm.ArticleDetails != null)
-                {
-                    var files = vm.ArticleDetails.Files.ToList();
-                    if (files.Any())
-                    {
-                        foreach (var file in files)
-                        {
-                            allFilePath.Add(file.FilePath);
-                        }
-                    }
-                }
-                else if (vm.CaseDetails != null)
-                {
-                    var blockCollection = vm.CaseDetails.BlockCollection;
-                    foreach (var entry in blockCollection.Blocks)
-                    {
-                        if (entry.ImageCarouselBlock != null)
-                        {
-                            foreach (var item in entry.ImageCarouselBlock?.ImageBlockCollection?.Blocks)
-                            {
-                                allFilePath.Add(item?.MediaBlock?.Image?.File.FilePath);
-                            }
-                        }
-                        else if (entry.WholeSlideImageBlock != null)
-                        {
-                            foreach (var item in entry.WholeSlideImageBlock.WholeSlideImageBlockItems)
-                            {
-                                allFilePath.Add(item?.WholeSlideImage?.File.FilePath);
-                            }
-                        }
-                    }
                 }
 
                 // audio and video to be added

--- a/WebAPI/LearningHub.Nhs.Services/ResourceService.cs
+++ b/WebAPI/LearningHub.Nhs.Services/ResourceService.cs
@@ -1471,70 +1471,37 @@ namespace LearningHub.Nhs.Services
                         }
                     }
                 }
+                else if (resource.ResourceTypeEnum == ResourceTypeEnum.Assessment)
+                {
+                    if (deletedResource)
+                    {
+                        if (resource.AssessmentDetails is { EndGuidance: { } } && resource.AssessmentDetails.EndGuidance.Blocks != null)
+                        {
+                            var assessmentFiles = this.CheckBlockFile(resource.AssessmentDetails.EndGuidance);
+                            if (assessmentFiles.Any())
+                            {
+                                retVal.AddRange(assessmentFiles);
+                            }
+                        }
+
+                        if (resource.AssessmentDetails is { AssessmentContent: { } } && resource.AssessmentDetails.AssessmentContent.Blocks != null)
+                        {
+                            var assessmentFiles = this.CheckBlockFile(resource.AssessmentDetails.AssessmentContent);
+                            if (assessmentFiles.Any())
+                            {
+                                retVal.AddRange(assessmentFiles);
+                            }
+                        }
+                    }
+                }
                 else if (resource.ResourceTypeEnum == ResourceTypeEnum.Case)
                 {
                     if (deletedResource)
                     {
-                        if (resource != null)
+                        var caseFiles = this.CheckBlockFile(resource.CaseDetails.BlockCollection);
+                        if (caseFiles.Any())
                         {
-                            var allBlocks = resource.CaseDetails.BlockCollection.Blocks.ToList();
-                            if (allBlocks.Any())
-                            {
-                                var existingAttachements = allBlocks.Where(x => x.BlockType == BlockType.Media && x.MediaBlock != null && x.MediaBlock.MediaType == MediaType.Attachment && x.MediaBlock.Attachment != null).ToList();
-                                if (existingAttachements.Any())
-                                {
-                                    foreach (var oldblock in existingAttachements)
-                                    {
-                                        retVal.Add(oldblock.MediaBlock.Attachment?.File?.FilePath);
-                                    }
-                                }
-
-                                var existingVideos = allBlocks.Where(x => x.BlockType == BlockType.Media && x.MediaBlock != null && x.MediaBlock.MediaType == MediaType.Video && x.MediaBlock.Video != null).ToList();
-                                if (existingVideos.Any())
-                                {
-                                    foreach (var oldblock in existingVideos)
-                                    {
-                                        retVal.Add(oldblock.MediaBlock.Video?.VideoFile?.File?.FilePath);
-                                        if (oldblock.MediaBlock?.Video?.VideoFile.TranscriptFile?.File.FilePath != null)
-                                        {
-                                            retVal.Add(oldblock.MediaBlock.Video?.VideoFile?.TranscriptFile?.File?.FilePath);
-                                        }
-                                    }
-                                }
-
-                                var existingImages = allBlocks.Where(x => x.BlockType == BlockType.Media && x.MediaBlock != null && x.MediaBlock.MediaType == MediaType.Image && x.MediaBlock.Image != null).ToList();
-                                if (existingImages.Any())
-                                {
-                                    foreach (var oldblock in existingImages)
-                                    {
-                                        retVal.Add(oldblock.MediaBlock?.Image?.File?.FilePath);
-                                    }
-                                }
-
-                                var existingImageCarousel = allBlocks.Where(x => x.BlockType == BlockType.ImageCarousel && x.ImageCarouselBlock != null && x.ImageCarouselBlock.ImageBlockCollection != null && x.ImageCarouselBlock.ImageBlockCollection.Blocks != null).ToList();
-                                if (existingImageCarousel.Any())
-                                {
-                                    foreach (var imageBlock in existingImageCarousel)
-                                    {
-                                        foreach (var oldblock in imageBlock.ImageCarouselBlock.ImageBlockCollection.Blocks)
-                                        {
-                                            retVal.Add(oldblock.MediaBlock?.Image?.File?.FilePath);
-                                        }
-                                    }
-                                }
-
-                                var existingWholeSlideImages = allBlocks.Where(x => x.WholeSlideImageBlock != null && x.WholeSlideImageBlock.WholeSlideImageBlockItems.Any()).ToList();
-                                if (existingWholeSlideImages.Any())
-                                {
-                                    foreach (var wsi in existingWholeSlideImages)
-                                    {
-                                        foreach (var oldblock in wsi.WholeSlideImageBlock.WholeSlideImageBlockItems)
-                                        {
-                                            retVal.Add(oldblock.WholeSlideImage?.File?.FilePath);
-                                        }
-                                    }
-                                }
-                            }
+                            retVal.AddRange(caseFiles);
                         }
                     }
                 }
@@ -1559,7 +1526,7 @@ namespace LearningHub.Nhs.Services
                 }
                 else if (resource.ResourceTypeEnum == ResourceTypeEnum.Audio)
                 {
-                    retVal.Add(resource.AudioDetails.File.FilePath);
+                    retVal.Add(resource.AudioDetails?.File?.FilePath);
                     if (resource.AudioDetails?.ResourceAzureMediaAsset?.FilePath != null)
                     {
                             retVal.Add(resource.AudioDetails.ResourceAzureMediaAsset.FilePath);
@@ -1567,7 +1534,7 @@ namespace LearningHub.Nhs.Services
                 }
                 else if (resource.ResourceTypeEnum == ResourceTypeEnum.Video)
                 {
-                    retVal.Add(resource.VideoDetails.File.FilePath);
+                    retVal.Add(resource.VideoDetails?.File?.FilePath);
                     if (resource.VideoDetails?.ResourceAzureMediaAsset?.FilePath != null)
                     {
                          retVal.Add(resource.VideoDetails.ResourceAzureMediaAsset.FilePath);
@@ -1584,65 +1551,35 @@ namespace LearningHub.Nhs.Services
                             }
                         }
                     }
+                else if (resource.ResourceTypeEnum == ResourceTypeEnum.Assessment)
+                {
+                    if (deletedResource)
+                    {
+                        if (resource.AssessmentDetails is { EndGuidance: { } } && resource.AssessmentDetails.EndGuidance.Blocks != null)
+                        {
+                            var assessmentFiles = this.CheckBlockFile(resource.AssessmentDetails.EndGuidance);
+                            if (assessmentFiles.Any())
+                            {
+                                retVal.AddRange(assessmentFiles);
+                            }
+                        }
+
+                        if (resource.AssessmentDetails is { AssessmentContent: { } } && resource.AssessmentDetails.AssessmentContent.Blocks != null)
+                        {
+                            var assessmentFiles = this.CheckBlockFile(resource.AssessmentDetails.AssessmentContent);
+                            if (assessmentFiles.Any())
+                            {
+                                retVal.AddRange(assessmentFiles);
+                            }
+                        }
+                    }
+                }
                 else if (resource.ResourceTypeEnum == ResourceTypeEnum.Case)
                 {
-                    var allBlocks = resource.CaseDetails.BlockCollection.Blocks.ToList();
-                    if (allBlocks.Any())
+                    var caseFiles = this.CheckBlockFile(resource.CaseDetails.BlockCollection);
+                    if (caseFiles.Any())
                     {
-                        var existingAttachements = allBlocks.Where(x => x.BlockType == BlockType.Media && x.MediaBlock != null && x.MediaBlock.MediaType == MediaType.Attachment && x.MediaBlock.Attachment != null).ToList();
-                        if (existingAttachements.Any())
-                        {
-                            foreach (var oldblock in existingAttachements)
-                            {
-                                retVal.Add(oldblock.MediaBlock.Attachment?.File?.FilePath);
-                            }
-                        }
-
-                        var existingVideos = allBlocks.Where(x => x.BlockType == BlockType.Media && x.MediaBlock != null && x.MediaBlock.MediaType == MediaType.Video && x.MediaBlock.Video != null).ToList();
-                        if (existingVideos.Any())
-                        {
-                            foreach (var oldblock in existingVideos)
-                            {
-                                retVal.Add(oldblock.MediaBlock.Video?.VideoFile?.File?.FilePath);
-                                if (oldblock.MediaBlock?.Video?.VideoFile.TranscriptFile?.File.FilePath != null)
-                                {
-                                    retVal.Add(oldblock.MediaBlock.Video?.VideoFile?.TranscriptFile?.File?.FilePath);
-                                }
-                            }
-                        }
-
-                        var existingImages = allBlocks.Where(x => x.BlockType == BlockType.Media && x.MediaBlock != null && x.MediaBlock.MediaType == MediaType.Image && x.MediaBlock.Image != null).ToList();
-                        if (existingImages.Any())
-                        {
-                            foreach (var oldblock in existingImages)
-                            {
-                                retVal.Add(oldblock.MediaBlock?.Image?.File?.FilePath);
-                            }
-                        }
-
-                        var existingImageCarousel = allBlocks.Where(x => x.BlockType == BlockType.ImageCarousel && x.ImageCarouselBlock != null && x.ImageCarouselBlock.ImageBlockCollection != null && x.ImageCarouselBlock.ImageBlockCollection.Blocks != null).ToList();
-                        if (existingImageCarousel.Any())
-                        {
-                            foreach (var imageBlock in existingImageCarousel)
-                            {
-                                foreach (var oldblock in imageBlock?.ImageCarouselBlock?.ImageBlockCollection.Blocks)
-                                {
-                                    retVal.Add(oldblock.MediaBlock?.Image?.File?.FilePath);
-                                }
-                            }
-                        }
-
-                        var existingWholeSlideImages = allBlocks.Where(x => x.WholeSlideImageBlock != null && x.WholeSlideImageBlock.WholeSlideImageBlockItems.Any()).ToList();
-                        if (existingWholeSlideImages.Any())
-                        {
-                            foreach (var wsi in existingWholeSlideImages)
-                            {
-                                foreach (var oldblock in wsi.WholeSlideImageBlock?.WholeSlideImageBlockItems)
-                                {
-                                    retVal.Add(oldblock.WholeSlideImage?.File?.FilePath);
-                                }
-                            }
-                        }
+                        retVal.AddRange(caseFiles);
                     }
                 }
             }
@@ -4945,6 +4882,193 @@ namespace LearningHub.Nhs.Services
             }
 
             return resourceVersionId;
+        }
+
+        private List<string> CheckBlockFile(BlockCollectionViewModel model)
+        {
+            var retVal = new List<string>();
+            var caseBlockCollection = model;
+            if (caseBlockCollection != null)
+            {
+                var allBlocks = caseBlockCollection.Blocks.ToList();
+                if (allBlocks.Any())
+                {
+                    var existingAttachements = allBlocks.Where(x => x.BlockType == BlockType.Media && x.MediaBlock != null && x.MediaBlock.MediaType == MediaType.Attachment && x.MediaBlock.Attachment != null).ToList();
+                    if (existingAttachements.Any())
+                    {
+                        foreach (var oldblock in existingAttachements)
+                        {
+                            retVal.Add(oldblock.MediaBlock.Attachment?.File?.FilePath);
+                        }
+                    }
+
+                    var existingVideos = allBlocks.Where(x => x.BlockType == BlockType.Media && x.MediaBlock != null && x.MediaBlock.MediaType == MediaType.Video && x.MediaBlock.Video != null).ToList();
+                    if (existingVideos.Any())
+                    {
+                        foreach (var oldblock in existingVideos)
+                        {
+                            retVal.Add(oldblock.MediaBlock?.Video?.VideoFile?.File?.FilePath);
+                            if (oldblock.MediaBlock?.Video?.VideoFile?.TranscriptFile?.File?.FilePath != null)
+                            {
+                                retVal.Add(oldblock.MediaBlock.Video?.VideoFile?.TranscriptFile?.File?.FilePath);
+                            }
+                        }
+                    }
+
+                    var existingImages = allBlocks.Where(x => x.BlockType == BlockType.Media && x.MediaBlock != null && x.MediaBlock.MediaType == MediaType.Image && x.MediaBlock.Image != null).ToList();
+                    if (existingImages.Any())
+                    {
+                        foreach (var oldblock in existingImages)
+                        {
+                            retVal.Add(oldblock.MediaBlock?.Image?.File?.FilePath);
+                        }
+                    }
+
+                    var existingImageCarousel = allBlocks.Where(x => x.BlockType == BlockType.ImageCarousel && x.ImageCarouselBlock != null && x.ImageCarouselBlock.ImageBlockCollection != null && x.ImageCarouselBlock.ImageBlockCollection.Blocks != null).ToList();
+                    if (existingImageCarousel.Any())
+                    {
+                        foreach (var imageBlock in existingImageCarousel)
+                        {
+                            foreach (var oldblock in imageBlock.ImageCarouselBlock.ImageBlockCollection.Blocks)
+                            {
+                                retVal.Add(oldblock.MediaBlock?.Image?.File?.FilePath);
+                            }
+                        }
+                    }
+
+                    var existingWholeSlideImages = allBlocks.Where(x => x.WholeSlideImageBlock != null && x.WholeSlideImageBlock.WholeSlideImageBlockItems.Any()).ToList();
+                    if (existingWholeSlideImages.Any())
+                    {
+                        foreach (var wsi in existingWholeSlideImages)
+                        {
+                            foreach (var oldblock in wsi?.WholeSlideImageBlock?.WholeSlideImageBlockItems)
+                            {
+                                retVal.Add(oldblock.WholeSlideImage?.File?.FilePath);
+                            }
+                        }
+                    }
+                }
+
+                var questionFiles = this.CheckQuestionBlock(caseBlockCollection);
+                if (questionFiles.Any())
+                {
+                    retVal.AddRange(questionFiles);
+                }
+            }
+
+            return retVal;
+        }
+
+        private List<string> CheckQuestionBlock(BlockCollectionViewModel model)
+        {
+            var filePath = new List<string>();
+            foreach (var block in model.Blocks)
+            {
+                if (block.BlockType == BlockType.Question && block.QuestionBlock != null)
+                {
+                    if (block.QuestionBlock.QuestionType == QuestionTypeEnum.MatchGame && block.QuestionBlock.Answers != null)
+                    {
+                        foreach (var answerBlock in block.QuestionBlock.Answers)
+                        {
+                            if (answerBlock.BlockCollection != null && answerBlock.BlockCollection.Blocks != null)
+                            {
+                                foreach (var imageBlock in answerBlock.BlockCollection.Blocks)
+                                {
+                                    if (imageBlock.BlockType == BlockType.Media && imageBlock.MediaBlock != null)
+                                    {
+                                        filePath.Add(imageBlock.MediaBlock.Image.File.FilePath);
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    var questionBlockCollection = block.QuestionBlock.QuestionBlockCollection;
+                    if (questionBlockCollection != null && questionBlockCollection.Blocks != null)
+                    {
+                        foreach (var questionBlock in questionBlockCollection.Blocks)
+                        {
+                            if (questionBlock.BlockType == BlockType.Media && questionBlock.MediaBlock != null)
+                            {
+                                if (questionBlock.MediaBlock.Image != null)
+                                {
+                                    filePath.Add(questionBlock.MediaBlock.Image.File.FilePath);
+                                }
+
+                                if (questionBlock.MediaBlock.Video != null)
+                                {
+                                    if (questionBlock.MediaBlock.Video.File != null)
+                                    {
+                                        filePath.Add(questionBlock.MediaBlock.Video.File.FilePath);
+                                    }
+
+                                    if (questionBlock.MediaBlock.Video.VideoFile != null)
+                                    {
+                                        if (questionBlock.MediaBlock.Video.VideoFile.TranscriptFile != null)
+                                        {
+                                            filePath.Add(questionBlock.MediaBlock.Video.VideoFile.TranscriptFile.File.FilePath);
+                                        }
+
+                                        if (questionBlock.MediaBlock.Video.VideoFile.CaptionsFile != null)
+                                        {
+                                            filePath.Add(questionBlock.MediaBlock.Video.VideoFile.CaptionsFile.File.FilePath);
+                                        }
+                                    }
+                                }
+                            }
+                            else if (questionBlock.BlockType == BlockType.WholeSlideImage && questionBlock.WholeSlideImageBlock != null)
+                            {
+                                var existingWholeSlideImages = questionBlock.WholeSlideImageBlock.WholeSlideImageBlockItems.ToList();
+                                if (existingWholeSlideImages.Any())
+                                {
+                                    foreach (var wsi in existingWholeSlideImages)
+                                    {
+                                        filePath.Add(wsi.WholeSlideImage?.File?.FilePath);
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    var feedbackBlockCollection = block.QuestionBlock.FeedbackBlockCollection;
+                    if (feedbackBlockCollection != null && feedbackBlockCollection.Blocks != null)
+                    {
+                        foreach (var feedbackBlock in feedbackBlockCollection.Blocks)
+                        {
+                            if (feedbackBlock.BlockType == BlockType.Media && feedbackBlock.MediaBlock != null)
+                            {
+                                if (feedbackBlock.MediaBlock.Image != null)
+                                {
+                                    filePath.Add(feedbackBlock.MediaBlock.Image.File.FilePath);
+                                }
+
+                                if (feedbackBlock.MediaBlock.Video != null)
+                                {
+                                    if (feedbackBlock.MediaBlock.Video.File != null)
+                                    {
+                                        filePath.Add(feedbackBlock.MediaBlock.Video.File.FilePath);
+                                    }
+
+                                    if (feedbackBlock.MediaBlock.Video.VideoFile != null)
+                                    {
+                                        if (feedbackBlock.MediaBlock.Video.VideoFile.TranscriptFile != null)
+                                        {
+                                            filePath.Add(feedbackBlock.MediaBlock.Video.VideoFile.TranscriptFile.File.FilePath);
+                                        }
+
+                                        if (feedbackBlock.MediaBlock.Video.VideoFile.CaptionsFile != null)
+                                        {
+                                            filePath.Add(feedbackBlock.MediaBlock.Video.VideoFile.CaptionsFile.File.FilePath);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            return filePath;
         }
     }
 }


### PR DESCRIPTION

### JIRA link
TD-3023 

### Description
Extended Blockcollection method to work for both case and assesement blockcollection file check.


### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
