### PR TITLE
TD-4106: Issue with Formal assessments learning record showing as '0%' for completed, passed & failed assessments and showing date incorrect

### DIFF
--- a/LearningHub.Nhs.WebUI/Helpers/ViewActivityHelper.cs
+++ b/LearningHub.Nhs.WebUI/Helpers/ViewActivityHelper.cs
@@ -226,7 +226,7 @@
         /// <returns>The <see cref="bool"/>.</returns>
         public static bool CanShowScore(this ActivityDetailedItemViewModel activityDetailedItemViewModel)
         {
-            if ((activityDetailedItemViewModel.ResourceType == ResourceTypeEnum.Scorm && (activityDetailedItemViewModel.MasteryScore > 0 || activityDetailedItemViewModel.MasteryScore == null) && ((activityDetailedItemViewModel.ScorePercentage > 0 && activityDetailedItemViewModel.ActivityStatus == ActivityStatusEnum.Passed) || activityDetailedItemViewModel.ActivityStatus == ActivityStatusEnum.Failed)) || ((activityDetailedItemViewModel.ResourceType == ResourceTypeEnum.Assessment || activityDetailedItemViewModel.ResourceType == ResourceTypeEnum.Case) && activityDetailedItemViewModel.Complete))
+            if ((activityDetailedItemViewModel.ResourceType == ResourceTypeEnum.Scorm && (activityDetailedItemViewModel.MasteryScore > 0 || activityDetailedItemViewModel.MasteryScore == null) && ((activityDetailedItemViewModel.ScorePercentage > 0 && activityDetailedItemViewModel.ActivityStatus == ActivityStatusEnum.Passed) || activityDetailedItemViewModel.ActivityStatus == ActivityStatusEnum.Failed)) || (activityDetailedItemViewModel.ResourceType == ResourceTypeEnum.Assessment && (activityDetailedItemViewModel.ActivityStatus == ActivityStatusEnum.Completed || activityDetailedItemViewModel.ActivityStatus == ActivityStatusEnum.Passed || activityDetailedItemViewModel.ActivityStatus == ActivityStatusEnum.Failed)) || (activityDetailedItemViewModel.ResourceType == ResourceTypeEnum.Case && activityDetailedItemViewModel.Complete))
             {
                 return true;
             }
@@ -241,7 +241,7 @@
         /// <returns>The <see cref="bool"/>bool.</returns>
         public static bool CanViewPercentage(this ActivityDetailedItemViewModel activityDetailedItemViewModel)
         {
-            if (((activityDetailedItemViewModel.ResourceType == ResourceTypeEnum.Video || activityDetailedItemViewModel.ResourceType == ResourceTypeEnum.Audio) && activityDetailedItemViewModel.ActivityStatus == ActivityStatusEnum.InProgress) || (activityDetailedItemViewModel.ResourceType == ResourceTypeEnum.Assessment && activityDetailedItemViewModel.Complete == false))
+            if (((activityDetailedItemViewModel.ResourceType == ResourceTypeEnum.Video || activityDetailedItemViewModel.ResourceType == ResourceTypeEnum.Audio) && activityDetailedItemViewModel.ActivityStatus == ActivityStatusEnum.InProgress) || (activityDetailedItemViewModel.ResourceType == ResourceTypeEnum.Assessment && activityDetailedItemViewModel.ActivityStatus == ActivityStatusEnum.InProgress))
             {
                 return true;
             }

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLatestActivityCheck.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLatestActivityCheck.sql
@@ -162,7 +162,7 @@ FROM (
 					EXISTS
 					(
 							SELECT 1	FROM   [activity].[ResourceActivity] AS [ResAct2]
-							WHERE  [ResAct2].[Deleted] = 0 AND  [ResourceActivity].[Id] = [ResAct2].[LaunchResourceActivityId] AND  [ResAct2].[ActivityStatusId] in (3,7)
+							WHERE  [ResAct2].[Deleted] = 0 AND  [ResourceActivity].[Id] = [ResAct2].[LaunchResourceActivityId] AND  [ResAct2].[ActivityStatusId] in (3,7,5)
 					)
 					
 				)

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivities.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivities.sql
@@ -230,7 +230,7 @@ FROM (
 					EXISTS
 					(
 							SELECT 1	FROM   [activity].[ResourceActivity] AS [ResAct2]
-							WHERE  [ResAct2].[Deleted] = 0 AND  [ResourceActivity].[Id] = [ResAct2].[LaunchResourceActivityId] AND  [ResAct2].[ActivityStatusId] in (3,7)
+							WHERE  [ResAct2].[Deleted] = 0 AND  [ResourceActivity].[Id] = [ResAct2].[LaunchResourceActivityId] AND  [ResAct2].[ActivityStatusId] in (3,7,5)
 					)
 					
 				)

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivitiesCount.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivitiesCount.sql
@@ -145,7 +145,7 @@ FROM (
 					EXISTS
 					(
 							SELECT 1	FROM   [activity].[ResourceActivity] AS [ResAct2]
-							WHERE  [ResAct2].[Deleted] = 0 AND  [ResourceActivity].[Id] = [ResAct2].[LaunchResourceActivityId] AND  [ResAct2].[ActivityStatusId] in (3,7)
+							WHERE  [ResAct2].[Deleted] = 0 AND  [ResourceActivity].[Id] = [ResAct2].[LaunchResourceActivityId] AND  [ResAct2].[ActivityStatusId] in (3,7,5)
 					)
 					
 				)


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4106
### Description
Issue with Formal assessments learning record showing as '0%' for completed, passed & failed assessments and showing date incorrect

### Screenshots
![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/120369940/48bc2fef-99b8-4023-8b9f-a01ce67e8bcf)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [x] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
