### PR TITLE
TD-3023 fix for deleted blocks which are valid in an active  resource version

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/Api/ContributeController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/Api/ContributeController.cs
@@ -496,7 +496,7 @@
             int resourceVersionId = await this.contributeService.SaveCaseDetailAsync(request);
             if (existingResourceState.CaseDetails?.BlockCollection != null)
             {
-                this.RemoveBlockCollectionFiles(existingResourceState.CaseDetails.BlockCollection, request.BlockCollection);
+               await this.RemoveBlockCollectionFiles(request.ResourceVersionId, existingResourceState.CaseDetails.BlockCollection, request.BlockCollection);
             }
 
             return this.Ok(resourceVersionId);
@@ -515,7 +515,7 @@
             int resourceVersionId = await this.contributeService.SaveAssessmentDetailAsync(request);
             if (existingResourceState != null && existingResourceState.AssessmentDetails != null)
             {
-                this.RemoveBlockCollectionFiles(existingResourceState.AssessmentDetails, request);
+               await this.RemoveBlockCollectionFiles(request.ResourceVersionId, existingResourceState.AssessmentDetails, request);
             }
 
             return this.Ok(resourceVersionId);
@@ -638,23 +638,24 @@
             return await this.catalogueService.CanCurrentUserEditCatalogue(catalogueId);
         }
 
-        private void RemoveBlockCollectionFiles(AssessmentViewModel existingModel, AssessmentViewModel newModel)
+        private async Task RemoveBlockCollectionFiles(int resourceVersionId, AssessmentViewModel existingModel, AssessmentViewModel newModel)
         {
             if (existingModel is { EndGuidance: { } } && existingModel.EndGuidance.Blocks != null)
             {
-               this.RemoveBlockCollectionFiles(existingModel.EndGuidance, newModel.EndGuidance);
+               await this.RemoveBlockCollectionFiles(resourceVersionId, existingModel.EndGuidance, newModel.EndGuidance);
             }
 
             if (existingModel is { AssessmentContent: { } } && existingModel.AssessmentContent.Blocks != null)
             {
-                this.RemoveBlockCollectionFiles(existingModel.AssessmentContent, newModel.AssessmentContent);
+                await this.RemoveBlockCollectionFiles(resourceVersionId, existingModel.AssessmentContent, newModel.AssessmentContent);
             }
         }
 
-        private void RemoveBlockCollectionFiles(BlockCollectionViewModel existingResource, BlockCollectionViewModel newResource)
+        private async Task RemoveBlockCollectionFiles(int resourceVersionId, BlockCollectionViewModel existingResource, BlockCollectionViewModel newResource)
         {
             try
             {
+                var obsoleteFiles = await this.resourceService.GetObsoleteResourceFile(resourceVersionId, true);
                 var filePaths = new List<string>();
                 if (existingResource != null)
                 {
@@ -706,8 +707,8 @@
                         {
                             foreach (var oldblock in existingImages)
                             {
-                                var entry = newBlocks.FirstOrDefault(x => x.BlockType == BlockType.Media && x.MediaBlock != null && x.MediaBlock.MediaType == MediaType.Image && x.MediaBlock.Image != null && x.MediaBlock?.Image?.File?.FileId == oldblock.MediaBlock?.Image?.File?.FileId);
-                                if (entry == null)
+                               var entry = newBlocks.FirstOrDefault(x => x.BlockType == BlockType.Media && x.MediaBlock != null && x.MediaBlock.MediaType == MediaType.Image && x.MediaBlock.Image != null && x.MediaBlock?.Image?.File?.FileId == oldblock.MediaBlock?.Image?.File?.FileId);
+                               if (entry == null)
                                 {
                                     filePaths.Add(oldblock?.MediaBlock?.Image?.File?.FilePath);
                                 }
@@ -771,7 +772,18 @@
 
                 if (filePaths != null && filePaths.Any())
                 {
-                    _ = Task.Run(async () => { await this.fileService.PurgeResourceFile(null, filePaths); });
+                    var deleteList = new List<string>();
+                    foreach (var e in filePaths)
+                    {
+                        if (!obsoleteFiles.Contains(e))
+                        {
+                            continue;
+                        }
+
+                        deleteList.Add(e);
+                    }
+
+                    _ = Task.Run(async () => { await this.fileService.PurgeResourceFile(null, deleteList); });
                 }
             }
             catch (Exception ex)
@@ -838,12 +850,15 @@
                             }
                             else if (questionBlock.BlockType == BlockType.WholeSlideImage && questionBlock.WholeSlideImageBlock != null)
                             {
-                                var existingWholeSlideImages = questionBlock.WholeSlideImageBlock.WholeSlideImageBlockItems.ToList();
-                                if (existingWholeSlideImages.Any())
+                                var existingWholeSlideImages = questionBlock.WholeSlideImageBlock?.WholeSlideImageBlockItems;
+                                if (existingWholeSlideImages != null && existingWholeSlideImages.Any())
                                 {
                                     foreach (var wsi in existingWholeSlideImages)
                                     {
-                                        filePath.Add(wsi.WholeSlideImage?.File?.FilePath);
+                                        if (wsi.WholeSlideImage != null && wsi.WholeSlideImage.File != null)
+                                        {
+                                            filePath.Add(wsi.WholeSlideImage.File.FilePath);
+                                        }
                                     }
                                 }
                             }

--- a/LearningHub.Nhs.WebUI/Controllers/Api/ContributeController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/Api/ContributeController.cs
@@ -493,12 +493,12 @@
         public async Task<ActionResult> SaveCaseDetailAsync([FromBody] CaseViewModel request)
         {
             var existingResourceState = await this.resourceService.GetResourceVersionExtendedAsync(request.ResourceVersionId);
-            int resourceVersionId = await this.contributeService.SaveCaseDetailAsync(request);
             if (existingResourceState.CaseDetails?.BlockCollection != null)
             {
-               await this.RemoveBlockCollectionFiles(request.ResourceVersionId, existingResourceState.CaseDetails.BlockCollection, request.BlockCollection);
+                await this.RemoveBlockCollectionFiles(request.ResourceVersionId, existingResourceState.CaseDetails.BlockCollection, request.BlockCollection);
             }
 
+            int resourceVersionId = await this.contributeService.SaveCaseDetailAsync(request);
             return this.Ok(resourceVersionId);
         }
 
@@ -512,12 +512,12 @@
         public async Task<ActionResult> SaveAssessmentDetailAsync([FromBody] AssessmentViewModel request)
         {
             var existingResourceState = await this.resourceService.GetResourceVersionExtendedAsync(request.ResourceVersionId);
-            int resourceVersionId = await this.contributeService.SaveAssessmentDetailAsync(request);
             if (existingResourceState != null && existingResourceState.AssessmentDetails != null)
             {
-               await this.RemoveBlockCollectionFiles(request.ResourceVersionId, existingResourceState.AssessmentDetails, request);
+                await this.RemoveBlockCollectionFiles(request.ResourceVersionId, existingResourceState.AssessmentDetails, request);
             }
 
+            int resourceVersionId = await this.contributeService.SaveAssessmentDetailAsync(request);
             return this.Ok(resourceVersionId);
         }
 


### PR DESCRIPTION

### JIRA link
TD-3023

### Description
Fix for WSI images in a question block
Fix for deleted blocks which are valid in a published resource.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
