### PR TITLE
TD-3023 QuestionBlock wsi and draft published case file  bugfix 

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/Api/ContributeController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/Api/ContributeController.cs
@@ -493,7 +493,7 @@
         public async Task<ActionResult> SaveCaseDetailAsync([FromBody] CaseViewModel request)
         {
             var existingResourceState = await this.resourceService.GetResourceVersionExtendedAsync(request.ResourceVersionId);
-            if (existingResourceState.CaseDetails?.BlockCollection != null)
+            if (existingResourceState?.CaseDetails?.BlockCollection != null)
             {
                 await this.RemoveBlockCollectionFiles(request.ResourceVersionId, existingResourceState.CaseDetails.BlockCollection, request.BlockCollection);
             }
@@ -903,7 +903,7 @@
                 }
             }
 
-            return filePath;
+            return filePath.Where(x => x != null).ToList();
         }
     }
 }

--- a/WebAPI/LearningHub.Nhs.Services/ResourceService.cs
+++ b/WebAPI/LearningHub.Nhs.Services/ResourceService.cs
@@ -1471,38 +1471,60 @@ namespace LearningHub.Nhs.Services
                         }
                     }
                 }
-                else if (resource.ResourceTypeEnum == ResourceTypeEnum.Assessment)
+                else if (extendedResourceVersion.ResourceTypeEnum == ResourceTypeEnum.Assessment)
                 {
-                    if (deletedResource)
-                    {
-                        if (resource.AssessmentDetails is { EndGuidance: { } } && resource.AssessmentDetails.EndGuidance.Blocks != null)
+                    var endGuidanceFiles = new List<string>();
+                    var assessmentContentFiles = new List<string>();
+
+                    if (resource.AssessmentDetails is { EndGuidance: { } } && resource.AssessmentDetails.EndGuidance.Blocks != null)
                         {
-                            var assessmentFiles = this.CheckBlockFile(extendedResourceVersion.AssessmentDetails.EndGuidance, resource.AssessmentDetails.EndGuidance);
-                            if (assessmentFiles.Any())
+                            if (deletedResource)
                             {
-                                retVal.AddRange(assessmentFiles);
+                                endGuidanceFiles = this.CheckBlockFile(extendedResourceVersion.AssessmentDetails.EndGuidance, resource.AssessmentDetails.EndGuidance);
+                            }
+                            else
+                            {
+                                endGuidanceFiles = this.CheckBlockFile(resource.AssessmentDetails.EndGuidance, extendedResourceVersion.AssessmentDetails.EndGuidance);
+                            }
+
+                            if (endGuidanceFiles.Any())
+                            {
+                                retVal.AddRange(endGuidanceFiles);
                             }
                         }
 
-                        if (resource.AssessmentDetails is { AssessmentContent: { } } && resource.AssessmentDetails.AssessmentContent.Blocks != null)
+                    if (resource.AssessmentDetails is { AssessmentContent: { } } && resource.AssessmentDetails.AssessmentContent.Blocks != null)
                         {
-                            var assessmentFiles = this.CheckBlockFile(extendedResourceVersion.AssessmentDetails.AssessmentContent, resource.AssessmentDetails.AssessmentContent);
-                            if (assessmentFiles.Any())
+                            if (deletedResource)
                             {
-                                retVal.AddRange(assessmentFiles);
+                                assessmentContentFiles = this.CheckBlockFile(extendedResourceVersion.AssessmentDetails.AssessmentContent, resource.AssessmentDetails.AssessmentContent);
+                            }
+                            else
+                            {
+                                assessmentContentFiles = this.CheckBlockFile(resource.AssessmentDetails.AssessmentContent, extendedResourceVersion.AssessmentDetails.AssessmentContent);
+                            }
+
+                            if (assessmentContentFiles.Any())
+                            {
+                                retVal.AddRange(assessmentContentFiles);
                             }
                         }
-                    }
                 }
-                else if (resource.ResourceTypeEnum == ResourceTypeEnum.Case)
+                else if (extendedResourceVersion.ResourceTypeEnum == ResourceTypeEnum.Case)
                 {
+                    var caseFiles = new List<string>();
                     if (deletedResource)
                     {
-                        var caseFiles = this.CheckBlockFile(extendedResourceVersion.CaseDetails.BlockCollection, resource.CaseDetails.BlockCollection);
-                        if (caseFiles.Any())
-                        {
-                            retVal.AddRange(caseFiles);
-                        }
+                        caseFiles = this.CheckBlockFile(extendedResourceVersion.CaseDetails.BlockCollection, resource.CaseDetails.BlockCollection);
+                    }
+                    else
+                    {
+                        caseFiles = this.CheckBlockFile(resource.CaseDetails.BlockCollection, extendedResourceVersion.CaseDetails.BlockCollection);
+                    }
+
+                    if (caseFiles.Any())
+                    {
+                        retVal.AddRange(caseFiles);
                     }
                 }
             }
@@ -4997,7 +5019,7 @@ namespace LearningHub.Nhs.Services
                 }
             }
 
-            return retVal;
+            return retVal.Where(x => x != null).ToList();
         }
 
         private List<string> CheckQuestionBlock(BlockCollectionViewModel model)
@@ -5112,7 +5134,7 @@ namespace LearningHub.Nhs.Services
                 }
             }
 
-            return filePath;
+            return filePath.Where(x => x != null).ToList();
         }
     }
 }


### PR DESCRIPTION
### JIRA link
[TD-3023](https://hee-tis.atlassian.net/browse/TD-3023)

### Description
added null check for wsi in question block.
added an inverse blockcollection file search when publishing new case resource version.


### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3023]: https://hee-tis.atlassian.net/browse/TD-3023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ