### PR TITLE
TD-4115: Issues on showing statuses on 'My accessed Learning' sectionof Learning Hub Home page

### DIFF
--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Resources/GetDashboardResources.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Resources/GetDashboardResources.sql
@@ -18,6 +18,7 @@
 -- 17 Jan 2024  SA  Changes to accomadate activity status changes
 -- 27 Feb 2024  SS  Fixed missing In progress resources in the My Accessed Learning tray issue
 -- 2 May 2024   SA  Fixed the issue on showing statuses on 'My accessed Learning' for resource type file
+-- 13 May 2024  SA  TD-4115
 -------------------------------------------------------------------------------
 
 CREATE PROCEDURE [resources].[GetDashboardResources]
@@ -238,11 +239,13 @@ BEGIN
 					 (r.ResourceTypeId IN (1, 5, 8, 9,10, 12) AND ra.ActivityStatusId <> 3)
 				    OR (r.ResourceTypeId IN (2, 7) AND (mar.Id IS NULL OR (mar.Id IS NOT NULL AND mar.PercentComplete < 100) OR ra.ActivityStart < '2020-09-07 00:00:00 +00:00'))
 					OR  (r.ResourceTypeId = 6 AND (sa.CmiCoreLesson_status NOT IN (3, 5) AND (ra.ActivityStatusId NOT IN(3, 5))))
-					OR (r.ResourceTypeId = 11 AND ((ara.Id IS NOT NULL AND ara.score < arv.PassMark) OR ra.ActivityStatusId = 7)) 
+					OR (r.ResourceTypeId IN (9) AND ra.ActivityStatusId NOT IN (3))
+					OR ((r.ResourceTypeId = 11 AND arv.AssessmentType = 2) AND ((ara.Id IS NOT NULL AND ara.score < arv.PassMark) OR ra.ActivityStatusId IN (7))) 
+					OR ((r.ResourceTypeId = 11 AND arv.AssessmentType = 1) AND ra.ActivityStatusId IN (7)) 
 					)		
 				GROUP BY ra.ResourceId	
 				ORDER BY ResourceActivityId DESC
-
+				
 		SELECT ma.ResourceActivityId, r.Id AS ResourceId
 			,(	SELECT TOP 1 rr.OriginalResourceReferenceId
 				FROM [resources].[ResourceReference] rr
@@ -384,7 +387,8 @@ BEGIN
 				AND (					
 					 (r.ResourceTypeId IN (2, 7) AND ra.ActivityStatusId IN (3) OR ra.ActivityStart < '2020-09-07 00:00:00 +00:00' OR mar.Id IS NOT NULL AND mar.PercentComplete = 100)
 					OR (r.ResourceTypeId = 6 AND (sa.CmiCoreLesson_status IN(3,5) OR (ra.ActivityStatusId IN(3, 5))))
-					OR (r.ResourceTypeId = 11 AND ara.Score >= arv.PassMark OR ra.ActivityStatusId IN(3, 5))
+					OR ((r.ResourceTypeId = 11 AND arv.AssessmentType = 2) AND (ara.Score >= arv.PassMark OR ra.ActivityStatusId IN(3, 5)))
+					OR ((r.ResourceTypeId = 11 AND arv.AssessmentType =1) AND (ara.Score >= arv.PassMark AND ra.ActivityStatusId IN(3, 5)))
 					OR (r.ResourceTypeId IN (1, 5, 8, 9, 10, 12) AND ra.ActivityStatusId IN (3)))		
 				GROUP BY ra.ResourceId
 				ORDER BY ResourceActivityId DESC


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4115

### Description
Issues on showing statuses on 'My accessed Learning' section of Learning Hub Home page

### Screenshots


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
