### PR TITLE
TD-3023 exclude wsi that are still processing.

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/Api/ContributeController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/Api/ContributeController.cs
@@ -855,7 +855,7 @@
                                 {
                                     foreach (var wsi in existingWholeSlideImages)
                                     {
-                                        if (wsi.WholeSlideImage != null && wsi.WholeSlideImage.File != null && wsi.WholeSlideImage.File.WholeSlideImageFile != null)
+                                        if (wsi.WholeSlideImage != null && wsi.WholeSlideImage.File != null && wsi.WholeSlideImage.File.WholeSlideImageFile != null && (wsi.WholeSlideImage.File.WholeSlideImageFile.Status == WholeSlideImageFileStatus.ProcessingComplete || wsi.WholeSlideImage.File.WholeSlideImageFile.Status == WholeSlideImageFileStatus.ProcessingFailed))
                                         {
                                             filePath.Add(wsi.WholeSlideImage.File.FilePath);
                                         }

--- a/WebAPI/LearningHub.Nhs.Services/ResourceService.cs
+++ b/WebAPI/LearningHub.Nhs.Services/ResourceService.cs
@@ -29,6 +29,7 @@ namespace LearningHub.Nhs.Services
     using LearningHub.Nhs.Models.Resource.AzureMediaAsset;
     using LearningHub.Nhs.Models.Resource.Blocks;
     using LearningHub.Nhs.Models.Resource.Contribute;
+    using LearningHub.Nhs.Models.Resource.Files;
     using LearningHub.Nhs.Models.Resource.ResourceDisplay;
     using LearningHub.Nhs.Models.Validation;
     using LearningHub.Nhs.Repository;
@@ -5086,7 +5087,7 @@ namespace LearningHub.Nhs.Services
                                 {
                                     foreach (var wsi in existingWholeSlideImages)
                                     {
-                                        if (wsi.WholeSlideImage != null && wsi.WholeSlideImage.File != null && wsi.WholeSlideImage.File.WholeSlideImageFile != null)
+                                        if (wsi.WholeSlideImage != null && wsi.WholeSlideImage.File != null && wsi.WholeSlideImage.File.WholeSlideImageFile != null && (wsi.WholeSlideImage.File.WholeSlideImageFile.Status == WholeSlideImageFileStatus.ProcessingComplete || wsi.WholeSlideImage.File.WholeSlideImageFile.Status == WholeSlideImageFileStatus.ProcessingFailed))
                                         {
                                             filePath.Add(wsi.WholeSlideImage.File.FilePath);
                                         }


### PR DESCRIPTION
### JIRA link
TD-3023

### Description
exclude wsi that are still processing.  when purging case files

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
