### PR TITLE
TD-3023 Update to search entire db for case and assessment blocks

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/Api/ContributeController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/Api/ContributeController.cs
@@ -668,7 +668,7 @@
                         {
                             foreach (var oldblock in existingAttachements)
                             {
-                                var entry = newBlocks.FirstOrDefault(x => x.BlockType == BlockType.Media && x.MediaBlock != null && x.MediaBlock.MediaType == MediaType.Attachment && x.MediaBlock.Attachment != null && x.MediaBlock.Attachment.File?.FileId == oldblock.MediaBlock.Attachment?.File?.FileId);
+                                var entry = newBlocks.FirstOrDefault(x => x.BlockType == BlockType.Media && x.MediaBlock != null && x.MediaBlock.MediaType == MediaType.Attachment && x.MediaBlock.Attachment != null && (x.MediaBlock.Attachment.File?.FileId == oldblock.MediaBlock.Attachment?.File?.FileId || x.MediaBlock.Attachment.File?.FilePath == oldblock.MediaBlock.Attachment?.File?.FilePath));
                                 if (entry == null)
                                 {
                                     filePaths.Add(oldblock.MediaBlock.Attachment?.File?.FilePath);
@@ -681,7 +681,7 @@
                         {
                             foreach (var oldblock in existingVideos)
                             {
-                                var entry = newBlocks.FirstOrDefault(x => x.BlockType == BlockType.Media && x.MediaBlock != null && x.MediaBlock.MediaType == MediaType.Video && x.MediaBlock.Video != null && x.MediaBlock.Video.VideoFile?.File?.FileId == oldblock.MediaBlock?.Video?.VideoFile?.File?.FileId);
+                                var entry = newBlocks.FirstOrDefault(x => x.BlockType == BlockType.Media && x.MediaBlock != null && x.MediaBlock.MediaType == MediaType.Video && x.MediaBlock.Video != null && (x.MediaBlock.Video.VideoFile?.File?.FileId == oldblock.MediaBlock?.Video?.VideoFile?.File?.FileId || x.MediaBlock.Video.VideoFile?.File?.FilePath == oldblock.MediaBlock?.Video?.VideoFile?.File?.FilePath));
                                 if (entry == null)
                                 {
                                     if (!string.IsNullOrWhiteSpace(oldblock.MediaBlock.Video.File.FilePath))
@@ -707,7 +707,7 @@
                         {
                             foreach (var oldblock in existingImages)
                             {
-                               var entry = newBlocks.FirstOrDefault(x => x.BlockType == BlockType.Media && x.MediaBlock != null && x.MediaBlock.MediaType == MediaType.Image && x.MediaBlock.Image != null && x.MediaBlock?.Image?.File?.FileId == oldblock.MediaBlock?.Image?.File?.FileId);
+                               var entry = newBlocks.FirstOrDefault(x => x.BlockType == BlockType.Media && x.MediaBlock != null && x.MediaBlock.MediaType == MediaType.Image && x.MediaBlock.Image != null && (x.MediaBlock?.Image?.File?.FileId == oldblock.MediaBlock?.Image?.File?.FileId || x.MediaBlock?.Image?.File?.FilePath == oldblock.MediaBlock?.Image?.File?.FilePath));
                                if (entry == null)
                                 {
                                     filePaths.Add(oldblock?.MediaBlock?.Image?.File?.FilePath);
@@ -722,7 +722,7 @@
                             {
                                 foreach (var oldblock in imageBlock?.ImageCarouselBlock?.ImageBlockCollection?.Blocks)
                                 {
-                                    var entry = newBlocks.FirstOrDefault(x => x.BlockType == BlockType.ImageCarousel && x.ImageCarouselBlock != null && x.ImageCarouselBlock.ImageBlockCollection != null && x.ImageCarouselBlock.ImageBlockCollection.Blocks != null && x.ImageCarouselBlock.ImageBlockCollection.Blocks.Where(x => x.MediaBlock?.Image?.File?.FileId == oldblock.MediaBlock?.Image?.File?.FileId).Any());
+                                    var entry = newBlocks.FirstOrDefault(x => x.BlockType == BlockType.ImageCarousel && x.ImageCarouselBlock != null && x.ImageCarouselBlock.ImageBlockCollection != null && x.ImageCarouselBlock.ImageBlockCollection.Blocks != null && x.ImageCarouselBlock.ImageBlockCollection.Blocks.Where(x => x.MediaBlock?.Image?.File?.FileId == oldblock.MediaBlock?.Image?.File?.FileId || x.MediaBlock?.Image?.File?.FilePath == oldblock.MediaBlock?.Image?.File?.FilePath).Any());
                                     if (entry == null)
                                     {
                                         filePaths.Add(oldblock.MediaBlock?.Image?.File?.FilePath);
@@ -738,7 +738,7 @@
                             {
                                 foreach (var oldblock in wsi?.WholeSlideImageBlock?.WholeSlideImageBlockItems)
                                 {
-                                    var entry = newBlocks.FirstOrDefault(x => x.WholeSlideImageBlock != null && x.WholeSlideImageBlock.WholeSlideImageBlockItems.Where(x => x.WholeSlideImage?.File?.FileId == oldblock.WholeSlideImage?.File?.FileId).Any());
+                                    var entry = newBlocks.FirstOrDefault(x => x.WholeSlideImageBlock != null && x.WholeSlideImageBlock.WholeSlideImageBlockItems.Where(x => x.WholeSlideImage?.File?.FileId == oldblock.WholeSlideImage?.File?.FileId || x.WholeSlideImage?.File?.FilePath == oldblock.WholeSlideImage?.File?.FilePath).Any());
                                     if (entry == null)
                                     {
                                         filePaths.Add(oldblock.WholeSlideImage?.File?.FilePath);

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Resources/AssessmentContentBlockCollectionGetAll.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Resources/AssessmentContentBlockCollectionGetAll.sql
@@ -1,0 +1,339 @@
+﻿-------------------------------------------------------------------------------
+-- Author       Tobi Awe
+-- Created      30-05-2024
+-- Purpose      Get all assessment content block collections of all undeleted resource version including published(current version only) versions while excluding the version being edited. 
+--
+-- Modification History
+--
+-- 30-05-2024  TD-3023	Initial Revision
+-------------------------------------------------------------------------------
+CREATE PROCEDURE [resources].[AssessmentContentBlockCollectionGetAll] (
+	@excludeResourceVersionId INT
+)
+AS
+BEGIN
+    -- Table to hold BlockCollectionIds
+    DECLARE @BlockCollectionId TABLE (Id INT);
+
+    -- Insert BlockCollectionIds based on the provided query
+    INSERT INTO @BlockCollectionId (Id)
+    SELECT DISTINCT [c].AssessmentContentId as [BlockCollectionId]
+    FROM [resources].AssessmentResourceVersion AS [c]
+    INNER JOIN (
+        SELECT [r].[Id], [r].[ResourceId], [r].[VersionStatusId]
+        FROM [resources].[ResourceVersion] AS [r]
+        WHERE [r].[Deleted] = CAST(0 AS bit)
+    ) AS [t] ON [c].[ResourceVersionId] = [t].[Id]
+    INNER JOIN (
+        SELECT [r0].[Id], [r0].[CurrentResourceVersionId]
+        FROM [resources].[Resource] AS [r0]
+        WHERE [r0].[Deleted] = CAST(0 AS bit)
+    ) AS [t0] ON [t].[ResourceId] = [t0].[Id]
+    WHERE ([c].[Deleted] = CAST(0 AS bit)) 
+      AND ((([c].[ResourceVersionId] <> @excludeResourceVersionId) 
+            AND ([c].[Deleted] = CAST(0 AS bit))) 
+           AND (([t].[VersionStatusId] <> 2) 
+                OR (([t].[VersionStatusId] = 2) 
+                    AND ([t0].[CurrentResourceVersionId] = [c].[ResourceVersionId])))) 
+      AND [c].AssessmentContentId IS NOT NULL;
+
+    -- Table to hold results for blocks
+    DECLARE @BlockResult TABLE (
+        Id INT,
+        [Order] INT,
+        Title NVARCHAR(200),
+        BlockType INT,
+        BlockCollectionId INT
+    );
+
+    -- Insert block data
+    INSERT INTO @BlockResult
+    SELECT Id, [Order], Title, BlockType, BlockCollectionId
+    FROM resources.Block
+    WHERE Deleted = 0 AND BlockCollectionId IN (SELECT Id FROM @BlockCollectionId);
+
+    -- Select block data
+    SELECT br.Id, [Order], Title, BlockType, BlockCollectionId
+    FROM @BlockResult br
+    JOIN @BlockCollectionId bc ON br.BlockCollectionId = bc.Id;
+
+    -- Select text block data
+    SELECT t.*
+    FROM resources.TextBlock t
+    INNER JOIN @BlockResult b ON b.Id = t.BlockId
+    WHERE t.Deleted = 0;
+
+    -- WholeSlide Image Block
+    DECLARE @WsibResult TABLE (
+        Id INT,
+        BlockId INT
+    );
+
+    INSERT INTO @WsibResult
+    SELECT w.Id, w.BlockId
+    FROM resources.WholeSlideImageBlock w
+    INNER JOIN @BlockResult b ON b.Id = w.BlockId
+    WHERE w.Deleted = 0;
+
+    SELECT * FROM @WsibResult;
+
+    -- WholeSlide Image Block Items
+    DECLARE @WsibiResult TABLE (
+        Id INT,
+        WholeSlideImageBlockId INT,
+        WholeSlideImageId INT,
+        PlaceholderText NVARCHAR(255),
+        [Order] INT
+    );
+
+    INSERT INTO @WsibiResult
+    SELECT wi.Id, wi.WholeSlideImageBlockId, wi.WholeSlideImageId, wi.PlaceholderText, wi.[Order]
+    FROM resources.WholeSlideImageBlockItem wi
+    INNER JOIN @WsibResult w ON wi.WholeSlideImageBlockId = w.Id
+    WHERE wi.Deleted = 0;
+
+    SELECT * FROM @WsibiResult;
+
+    -- WholeSlide Image
+    DECLARE @WsiResult TABLE (
+        Id INT,
+        Title NVARCHAR(1000),
+        FileId INT
+    );
+
+    INSERT INTO @WsiResult
+    SELECT wsi.Id, wsi.Title, wsi.FileId
+    FROM resources.WholeSlideImage wsi
+    INNER JOIN @WsibiResult wi ON wsi.Id = wi.WholeSlideImageId
+    WHERE wsi.Deleted = 0;
+
+    SELECT * FROM @WsiResult;
+
+    -- WholeSlide Image File
+    DECLARE @WsiFileResult TABLE (
+        Id INT,
+        FileTypeId INT,
+        FileChunkDetailId INT,
+        [FileName] NVARCHAR(255),
+        FilePath NVARCHAR(1024),
+        FileSizekb INT
+    );
+
+    INSERT INTO @WsiFileResult
+    SELECT f.Id, f.FileTypeId, f.FileChunkDetailId, f.[FileName], f.FilePath, f.FileSizeKb
+    FROM resources.[File] f
+    INNER JOIN @WsiResult wsi ON f.Id = wsi.FileId
+    WHERE f.Deleted = 0;
+
+    SELECT * FROM @WsiFileResult;
+
+    -- WholeSlide Image File - Partial File
+    SELECT pf.*
+    FROM resources.PartialFile pf
+    INNER JOIN @WsiFileResult wsi ON pf.FileId = wsi.Id
+    WHERE pf.Deleted = 0;
+
+    -- WholeSlide Image File - Image File
+    SELECT wsif.*
+    FROM resources.WholeSlideImageFile wsif
+    INNER JOIN @WsiFileResult wsi ON wsif.FileId = wsi.Id
+    WHERE wsif.Deleted = 0;
+
+    -- WholeSlide Image Annotation
+    DECLARE @WsiaResult TABLE (
+        Id INT,
+        WholeSlideImageId INT,
+        ImageId INT,
+        [Order] INT,
+        Label NVARCHAR(255),
+        Description NVARCHAR(1000),
+        PinXCoordinate DECIMAL(22,19),
+        PinYCoordinate DECIMAL(22,19),
+        Colour INT
+    );
+
+    INSERT INTO @WsiaResult
+    SELECT ia.Id, ia.WholeSlideImageId, ia.ImageId, ia.[Order], ia.Label, ia.Description, ia.PinXCoordinate, ia.PinYCoordinate, ia.Colour
+    FROM resources.ImageAnnotation ia
+    INNER JOIN @WsiResult wsi ON ia.WholeSlideImageId = wsi.Id
+    WHERE ia.Deleted = 0;
+
+    SELECT * FROM @WsiaResult;
+
+    -- WholeSlide Image Annotation Mark
+    SELECT iam.*
+    FROM resources.ImageAnnotationMark iam
+    INNER JOIN @WsiaResult wsia ON iam.ImageAnnotationId = wsia.Id
+    WHERE iam.Deleted = 0;
+
+    -- Media Block
+    DECLARE @MediaBlockResult TABLE (
+        Id INT,
+        BlockId INT,
+        MediaType INT,
+        AttachmentId INT,
+        ImageId INT,
+        VideoId INT
+    );
+
+    INSERT INTO @MediaBlockResult
+    SELECT mb.Id, mb.BlockId, mb.MediaType, mb.AttachmentId, mb.ImageId, mb.VideoId
+    FROM resources.MediaBlock mb
+    INNER JOIN @BlockResult b ON mb.BlockId = b.Id
+    WHERE mb.Deleted = 0;
+
+    SELECT * FROM @MediaBlockResult;
+
+    -- Attachment
+    DECLARE @AttachmentResult TABLE (
+        Id INT,
+        FileId INT
+    );
+
+    INSERT INTO @AttachmentResult
+    SELECT a.Id, a.FileId
+    FROM resources.Attachment a
+    INNER JOIN @MediaBlockResult mb ON a.Id = mb.AttachmentId
+    WHERE a.Deleted = 0;
+
+    SELECT * FROM @AttachmentResult;
+
+    -- Attachment File
+    DECLARE @AttachmentFileResult TABLE (
+        Id INT,
+        FileTypeId INT,
+        FileChunkDetailId INT,
+        [FileName] NVARCHAR(255),
+        FilePath NVARCHAR(1024),
+        FileSizekb INT
+    );
+
+    INSERT INTO @AttachmentFileResult
+    SELECT f.Id, f.FileTypeId, f.FileChunkDetailId, f.[FileName], f.FilePath, f.FileSizeKb
+    FROM resources.[File] f
+    INNER JOIN @AttachmentResult ar ON f.Id = ar.FileId
+    WHERE f.Deleted = 0;
+
+    SELECT * FROM @AttachmentFileResult;
+
+    -- Attachment File - Partial File
+    SELECT pf.*
+    FROM resources.PartialFile pf
+    INNER JOIN @AttachmentFileResult af ON pf.FileId = af.Id
+    WHERE pf.Deleted = 0;
+
+    -- Image
+    DECLARE @ImageResult TABLE (
+        Id INT,
+        FileId INT,
+        AltText NVARCHAR(125),
+        Description NVARCHAR(250)
+    );
+
+    INSERT INTO @ImageResult
+    SELECT i.Id, i.FileId, i.AltText, i.Description
+    FROM resources.Image i
+    INNER JOIN @MediaBlockResult mb ON i.Id = mb.ImageId
+    WHERE i.Deleted = 0;
+
+    SELECT * FROM @ImageResult;
+
+    -- Image File
+    DECLARE @ImageFileResult TABLE (
+        Id INT,
+        FileTypeId INT,
+        FileChunkDetailId INT,
+        [FileName] NVARCHAR(255),
+        FilePath NVARCHAR(1024),
+        FileSizekb INT
+    );
+
+    INSERT INTO @ImageFileResult
+    SELECT f.Id, f.FileTypeId, f.FileChunkDetailId, f.[FileName], f.FilePath, f.FileSizeKb
+    FROM resources.[File] f
+    INNER JOIN @ImageResult ir ON f.Id = ir.FileId
+    WHERE f.Deleted = 0;
+
+    SELECT * FROM @ImageFileResult;
+
+    -- Image File - Partial File
+    SELECT pf.*
+    FROM resources.PartialFile pf
+    INNER JOIN @ImageFileResult ifr ON pf.FileId = ifr.Id
+    WHERE pf.Deleted = 0;
+
+    -- Video
+    DECLARE @VideoResult TABLE (
+        Id INT,
+        FileId INT
+    );
+
+    INSERT INTO @VideoResult
+    SELECT v.Id, v.FileId
+    FROM resources.Video v
+    INNER JOIN @MediaBlockResult mb ON v.Id = mb.VideoId
+    WHERE v.Deleted = 0;
+
+    SELECT * FROM @VideoResult;
+
+    -- Video File
+    DECLARE @VideoFileResult TABLE (
+        Id INT,
+        FileTypeId INT,
+        FileChunkDetailId INT,
+        [FileName] NVARCHAR(255),
+        FilePath NVARCHAR(1024),
+        FileSizekb INT
+    );
+
+    INSERT INTO @VideoFileResult
+    SELECT f.Id, f.FileTypeId, f.FileChunkDetailId, f.[FileName], f.FilePath, f.FileSizeKb
+    FROM resources.[File] f
+    INNER JOIN @VideoResult vr ON f.Id = vr.FileId
+    WHERE f.Deleted = 0;
+
+    SELECT * FROM @VideoFileResult;
+
+    -- Video File - Partial File
+    SELECT pf.*
+    FROM resources.PartialFile pf
+    INNER JOIN @VideoFileResult vf ON pf.FileId = vf.Id
+    WHERE pf.Deleted = 0;
+
+    -- Video File Detail
+    SELECT vf.*
+    FROM resources.VideoFile vf
+    INNER JOIN @VideoFileResult vfr ON vf.FileId = vfr.Id
+    WHERE vf.Deleted = 0;
+
+    -- Question Block
+    DECLARE @QuestionResult TABLE (
+        Id INT,
+        BlockId INT,
+        QuestionBlockCollectionId INT,
+        FeedbackBlockCollectionId INT,
+        QuestionType INT,
+        AllowReveal BIT
+    );
+
+    INSERT INTO @QuestionResult
+    SELECT qb.Id, qb.BlockId, qb.QuestionBlockCollectionId, qb.FeedbackBlockCollectionId, qb.QuestionType, qb.AllowReveal
+    FROM resources.QuestionBlock qb
+    INNER JOIN @BlockResult b ON qb.BlockId = b.Id
+    WHERE qb.Deleted = 0;
+
+    SELECT * FROM @QuestionResult;
+
+    -- Question Answer
+    SELECT qa.*
+    FROM resources.QuestionAnswer qa
+    INNER JOIN @QuestionResult qr ON qa.QuestionBlockId = qr.Id
+    WHERE qa.Deleted = 0;
+
+    -- Image Carousel Block
+    SELECT icb.*
+    FROM resources.ImageCarouselBlock icb
+    INNER JOIN @BlockResult b ON icb.BlockId = b.Id
+    WHERE icb.Deleted = 0;
+END
+GO

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Resources/AssessmentGuidanceBlockCollectionGetAll.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Resources/AssessmentGuidanceBlockCollectionGetAll.sql
@@ -1,0 +1,339 @@
+﻿-------------------------------------------------------------------------------
+-- Author       Tobi Awe
+-- Created      30-05-2024
+-- Purpose      Get all assessment guidance block collections of all undeleted resource version including published(current version only) versions while excluding the version being edited. 
+--
+-- Modification History
+--
+-- 30-05-2024  TD-3023	Initial Revision
+-------------------------------------------------------------------------------
+CREATE PROCEDURE [resources].[AssessmentGuidanceBlockCollectionGetAll] (
+	@excludeResourceVersionId INT
+)
+AS
+BEGIN
+    -- Table to hold BlockCollectionIds
+    DECLARE @BlockCollectionId TABLE (Id INT);
+
+    -- Insert BlockCollectionIds based on the provided query
+    INSERT INTO @BlockCollectionId (Id)
+    SELECT DISTINCT [c].EndGuidanceId as [BlockCollectionId]
+    FROM [resources].AssessmentResourceVersion AS [c]
+    INNER JOIN (
+        SELECT [r].[Id], [r].[ResourceId], [r].[VersionStatusId]
+        FROM [resources].[ResourceVersion] AS [r]
+        WHERE [r].[Deleted] = CAST(0 AS bit)
+    ) AS [t] ON [c].[ResourceVersionId] = [t].[Id]
+    INNER JOIN (
+        SELECT [r0].[Id], [r0].[CurrentResourceVersionId]
+        FROM [resources].[Resource] AS [r0]
+        WHERE [r0].[Deleted] = CAST(0 AS bit)
+    ) AS [t0] ON [t].[ResourceId] = [t0].[Id]
+    WHERE ([c].[Deleted] = CAST(0 AS bit)) 
+      AND ((([c].[ResourceVersionId] <> @excludeResourceVersionId) 
+            AND ([c].[Deleted] = CAST(0 AS bit))) 
+           AND (([t].[VersionStatusId] <> 2) 
+                OR (([t].[VersionStatusId] = 2) 
+                    AND ([t0].[CurrentResourceVersionId] = [c].[ResourceVersionId])))) 
+      AND [c].EndGuidanceId IS NOT NULL;
+
+    -- Table to hold results for blocks
+    DECLARE @BlockResult TABLE (
+        Id INT,
+        [Order] INT,
+        Title NVARCHAR(200),
+        BlockType INT,
+        BlockCollectionId INT
+    );
+
+    -- Insert block data
+    INSERT INTO @BlockResult
+    SELECT Id, [Order], Title, BlockType, BlockCollectionId
+    FROM resources.Block
+    WHERE Deleted = 0 AND BlockCollectionId IN (SELECT Id FROM @BlockCollectionId);
+
+    -- Select block data
+    SELECT br.Id, [Order], Title, BlockType, BlockCollectionId
+    FROM @BlockResult br
+    JOIN @BlockCollectionId bc ON br.BlockCollectionId = bc.Id;
+
+    -- Select text block data
+    SELECT t.*
+    FROM resources.TextBlock t
+    INNER JOIN @BlockResult b ON b.Id = t.BlockId
+    WHERE t.Deleted = 0;
+
+    -- WholeSlide Image Block
+    DECLARE @WsibResult TABLE (
+        Id INT,
+        BlockId INT
+    );
+
+    INSERT INTO @WsibResult
+    SELECT w.Id, w.BlockId
+    FROM resources.WholeSlideImageBlock w
+    INNER JOIN @BlockResult b ON b.Id = w.BlockId
+    WHERE w.Deleted = 0;
+
+    SELECT * FROM @WsibResult;
+
+    -- WholeSlide Image Block Items
+    DECLARE @WsibiResult TABLE (
+        Id INT,
+        WholeSlideImageBlockId INT,
+        WholeSlideImageId INT,
+        PlaceholderText NVARCHAR(255),
+        [Order] INT
+    );
+
+    INSERT INTO @WsibiResult
+    SELECT wi.Id, wi.WholeSlideImageBlockId, wi.WholeSlideImageId, wi.PlaceholderText, wi.[Order]
+    FROM resources.WholeSlideImageBlockItem wi
+    INNER JOIN @WsibResult w ON wi.WholeSlideImageBlockId = w.Id
+    WHERE wi.Deleted = 0;
+
+    SELECT * FROM @WsibiResult;
+
+    -- WholeSlide Image
+    DECLARE @WsiResult TABLE (
+        Id INT,
+        Title NVARCHAR(1000),
+        FileId INT
+    );
+
+    INSERT INTO @WsiResult
+    SELECT wsi.Id, wsi.Title, wsi.FileId
+    FROM resources.WholeSlideImage wsi
+    INNER JOIN @WsibiResult wi ON wsi.Id = wi.WholeSlideImageId
+    WHERE wsi.Deleted = 0;
+
+    SELECT * FROM @WsiResult;
+
+    -- WholeSlide Image File
+    DECLARE @WsiFileResult TABLE (
+        Id INT,
+        FileTypeId INT,
+        FileChunkDetailId INT,
+        [FileName] NVARCHAR(255),
+        FilePath NVARCHAR(1024),
+        FileSizekb INT
+    );
+
+    INSERT INTO @WsiFileResult
+    SELECT f.Id, f.FileTypeId, f.FileChunkDetailId, f.[FileName], f.FilePath, f.FileSizeKb
+    FROM resources.[File] f
+    INNER JOIN @WsiResult wsi ON f.Id = wsi.FileId
+    WHERE f.Deleted = 0;
+
+    SELECT * FROM @WsiFileResult;
+
+    -- WholeSlide Image File - Partial File
+    SELECT pf.*
+    FROM resources.PartialFile pf
+    INNER JOIN @WsiFileResult wsi ON pf.FileId = wsi.Id
+    WHERE pf.Deleted = 0;
+
+    -- WholeSlide Image File - Image File
+    SELECT wsif.*
+    FROM resources.WholeSlideImageFile wsif
+    INNER JOIN @WsiFileResult wsi ON wsif.FileId = wsi.Id
+    WHERE wsif.Deleted = 0;
+
+    -- WholeSlide Image Annotation
+    DECLARE @WsiaResult TABLE (
+        Id INT,
+        WholeSlideImageId INT,
+        ImageId INT,
+        [Order] INT,
+        Label NVARCHAR(255),
+        Description NVARCHAR(1000),
+        PinXCoordinate DECIMAL(22,19),
+        PinYCoordinate DECIMAL(22,19),
+        Colour INT
+    );
+
+    INSERT INTO @WsiaResult
+    SELECT ia.Id, ia.WholeSlideImageId, ia.ImageId, ia.[Order], ia.Label, ia.Description, ia.PinXCoordinate, ia.PinYCoordinate, ia.Colour
+    FROM resources.ImageAnnotation ia
+    INNER JOIN @WsiResult wsi ON ia.WholeSlideImageId = wsi.Id
+    WHERE ia.Deleted = 0;
+
+    SELECT * FROM @WsiaResult;
+
+    -- WholeSlide Image Annotation Mark
+    SELECT iam.*
+    FROM resources.ImageAnnotationMark iam
+    INNER JOIN @WsiaResult wsia ON iam.ImageAnnotationId = wsia.Id
+    WHERE iam.Deleted = 0;
+
+    -- Media Block
+    DECLARE @MediaBlockResult TABLE (
+        Id INT,
+        BlockId INT,
+        MediaType INT,
+        AttachmentId INT,
+        ImageId INT,
+        VideoId INT
+    );
+
+    INSERT INTO @MediaBlockResult
+    SELECT mb.Id, mb.BlockId, mb.MediaType, mb.AttachmentId, mb.ImageId, mb.VideoId
+    FROM resources.MediaBlock mb
+    INNER JOIN @BlockResult b ON mb.BlockId = b.Id
+    WHERE mb.Deleted = 0;
+
+    SELECT * FROM @MediaBlockResult;
+
+    -- Attachment
+    DECLARE @AttachmentResult TABLE (
+        Id INT,
+        FileId INT
+    );
+
+    INSERT INTO @AttachmentResult
+    SELECT a.Id, a.FileId
+    FROM resources.Attachment a
+    INNER JOIN @MediaBlockResult mb ON a.Id = mb.AttachmentId
+    WHERE a.Deleted = 0;
+
+    SELECT * FROM @AttachmentResult;
+
+    -- Attachment File
+    DECLARE @AttachmentFileResult TABLE (
+        Id INT,
+        FileTypeId INT,
+        FileChunkDetailId INT,
+        [FileName] NVARCHAR(255),
+        FilePath NVARCHAR(1024),
+        FileSizekb INT
+    );
+
+    INSERT INTO @AttachmentFileResult
+    SELECT f.Id, f.FileTypeId, f.FileChunkDetailId, f.[FileName], f.FilePath, f.FileSizeKb
+    FROM resources.[File] f
+    INNER JOIN @AttachmentResult ar ON f.Id = ar.FileId
+    WHERE f.Deleted = 0;
+
+    SELECT * FROM @AttachmentFileResult;
+
+    -- Attachment File - Partial File
+    SELECT pf.*
+    FROM resources.PartialFile pf
+    INNER JOIN @AttachmentFileResult af ON pf.FileId = af.Id
+    WHERE pf.Deleted = 0;
+
+    -- Image
+    DECLARE @ImageResult TABLE (
+        Id INT,
+        FileId INT,
+        AltText NVARCHAR(125),
+        Description NVARCHAR(250)
+    );
+
+    INSERT INTO @ImageResult
+    SELECT i.Id, i.FileId, i.AltText, i.Description
+    FROM resources.Image i
+    INNER JOIN @MediaBlockResult mb ON i.Id = mb.ImageId
+    WHERE i.Deleted = 0;
+
+    SELECT * FROM @ImageResult;
+
+    -- Image File
+    DECLARE @ImageFileResult TABLE (
+        Id INT,
+        FileTypeId INT,
+        FileChunkDetailId INT,
+        [FileName] NVARCHAR(255),
+        FilePath NVARCHAR(1024),
+        FileSizekb INT
+    );
+
+    INSERT INTO @ImageFileResult
+    SELECT f.Id, f.FileTypeId, f.FileChunkDetailId, f.[FileName], f.FilePath, f.FileSizeKb
+    FROM resources.[File] f
+    INNER JOIN @ImageResult ir ON f.Id = ir.FileId
+    WHERE f.Deleted = 0;
+
+    SELECT * FROM @ImageFileResult;
+
+    -- Image File - Partial File
+    SELECT pf.*
+    FROM resources.PartialFile pf
+    INNER JOIN @ImageFileResult ifr ON pf.FileId = ifr.Id
+    WHERE pf.Deleted = 0;
+
+    -- Video
+    DECLARE @VideoResult TABLE (
+        Id INT,
+        FileId INT
+    );
+
+    INSERT INTO @VideoResult
+    SELECT v.Id, v.FileId
+    FROM resources.Video v
+    INNER JOIN @MediaBlockResult mb ON v.Id = mb.VideoId
+    WHERE v.Deleted = 0;
+
+    SELECT * FROM @VideoResult;
+
+    -- Video File
+    DECLARE @VideoFileResult TABLE (
+        Id INT,
+        FileTypeId INT,
+        FileChunkDetailId INT,
+        [FileName] NVARCHAR(255),
+        FilePath NVARCHAR(1024),
+        FileSizekb INT
+    );
+
+    INSERT INTO @VideoFileResult
+    SELECT f.Id, f.FileTypeId, f.FileChunkDetailId, f.[FileName], f.FilePath, f.FileSizeKb
+    FROM resources.[File] f
+    INNER JOIN @VideoResult vr ON f.Id = vr.FileId
+    WHERE f.Deleted = 0;
+
+    SELECT * FROM @VideoFileResult;
+
+    -- Video File - Partial File
+    SELECT pf.*
+    FROM resources.PartialFile pf
+    INNER JOIN @VideoFileResult vf ON pf.FileId = vf.Id
+    WHERE pf.Deleted = 0;
+
+    -- Video File Detail
+    SELECT vf.*
+    FROM resources.VideoFile vf
+    INNER JOIN @VideoFileResult vfr ON vf.FileId = vfr.Id
+    WHERE vf.Deleted = 0;
+
+    -- Question Block
+    DECLARE @QuestionResult TABLE (
+        Id INT,
+        BlockId INT,
+        QuestionBlockCollectionId INT,
+        FeedbackBlockCollectionId INT,
+        QuestionType INT,
+        AllowReveal BIT
+    );
+
+    INSERT INTO @QuestionResult
+    SELECT qb.Id, qb.BlockId, qb.QuestionBlockCollectionId, qb.FeedbackBlockCollectionId, qb.QuestionType, qb.AllowReveal
+    FROM resources.QuestionBlock qb
+    INNER JOIN @BlockResult b ON qb.BlockId = b.Id
+    WHERE qb.Deleted = 0;
+
+    SELECT * FROM @QuestionResult;
+
+    -- Question Answer
+    SELECT qa.*
+    FROM resources.QuestionAnswer qa
+    INNER JOIN @QuestionResult qr ON qa.QuestionBlockId = qr.Id
+    WHERE qa.Deleted = 0;
+
+    -- Image Carousel Block
+    SELECT icb.*
+    FROM resources.ImageCarouselBlock icb
+    INNER JOIN @BlockResult b ON icb.BlockId = b.Id
+    WHERE icb.Deleted = 0;
+END
+GO

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Resources/CaseBlockCollectionGetAll.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Resources/CaseBlockCollectionGetAll.sql
@@ -1,0 +1,339 @@
+﻿-------------------------------------------------------------------------------
+-- Author       Tobi Awe
+-- Created      30-05-2024
+-- Purpose      Get all case content block collections of all undeleted resource version including published(current version only) versions while excluding the version being edited. 
+--
+-- Modification History
+--
+-- 30-05-2024  TD-3023	Initial Revision
+-------------------------------------------------------------------------------
+CREATE PROCEDURE [resources].[CaseBlockCollectionGetAll] (
+    @excludeResourceVersionId INT
+)
+AS
+BEGIN
+    -- Table to hold BlockCollectionIds
+    DECLARE @BlockCollectionId TABLE (Id INT);
+
+    -- Insert BlockCollectionIds based on the provided query
+    INSERT INTO @BlockCollectionId (Id)
+    SELECT DISTINCT [c].[BlockCollectionId]
+    FROM [resources].[CaseResourceVersion] AS [c]
+    INNER JOIN (
+        SELECT [r].[Id], [r].[ResourceId], [r].[VersionStatusId]
+        FROM [resources].[ResourceVersion] AS [r]
+        WHERE [r].[Deleted] = CAST(0 AS bit)
+    ) AS [t] ON [c].[ResourceVersionId] = [t].[Id]
+    INNER JOIN (
+        SELECT [r0].[Id], [r0].[CurrentResourceVersionId]
+        FROM [resources].[Resource] AS [r0]
+        WHERE [r0].[Deleted] = CAST(0 AS bit)
+    ) AS [t0] ON [t].[ResourceId] = [t0].[Id]
+    WHERE ([c].[Deleted] = CAST(0 AS bit)) 
+      AND ((([c].[ResourceVersionId] <> @excludeResourceVersionId) 
+            AND ([c].[Deleted] = CAST(0 AS bit))) 
+           AND (([t].[VersionStatusId] <> 2) 
+                OR (([t].[VersionStatusId] = 2) 
+                    AND ([t0].[CurrentResourceVersionId] = [c].[ResourceVersionId])))) 
+      AND [c].[BlockCollectionId] IS NOT NULL;
+
+    -- Table to hold results for blocks
+    DECLARE @BlockResult TABLE (
+        Id INT,
+        [Order] INT,
+        Title NVARCHAR(200),
+        BlockType INT,
+        BlockCollectionId INT
+    );
+
+    -- Insert block data
+    INSERT INTO @BlockResult
+    SELECT Id, [Order], Title, BlockType, BlockCollectionId
+    FROM resources.Block
+    WHERE Deleted = 0 AND BlockCollectionId IN (SELECT Id FROM @BlockCollectionId);
+
+    -- Select block data
+    SELECT br.Id, [Order], Title, BlockType, BlockCollectionId
+    FROM @BlockResult br
+    JOIN @BlockCollectionId bc ON br.BlockCollectionId = bc.Id;
+
+    -- Select text block data
+    SELECT t.*
+    FROM resources.TextBlock t
+    INNER JOIN @BlockResult b ON b.Id = t.BlockId
+    WHERE t.Deleted = 0;
+
+    -- WholeSlide Image Block
+    DECLARE @WsibResult TABLE (
+        Id INT,
+        BlockId INT
+    );
+
+    INSERT INTO @WsibResult
+    SELECT w.Id, w.BlockId
+    FROM resources.WholeSlideImageBlock w
+    INNER JOIN @BlockResult b ON b.Id = w.BlockId
+    WHERE w.Deleted = 0;
+
+    SELECT * FROM @WsibResult;
+
+    -- WholeSlide Image Block Items
+    DECLARE @WsibiResult TABLE (
+        Id INT,
+        WholeSlideImageBlockId INT,
+        WholeSlideImageId INT,
+        PlaceholderText NVARCHAR(255),
+        [Order] INT
+    );
+
+    INSERT INTO @WsibiResult
+    SELECT wi.Id, wi.WholeSlideImageBlockId, wi.WholeSlideImageId, wi.PlaceholderText, wi.[Order]
+    FROM resources.WholeSlideImageBlockItem wi
+    INNER JOIN @WsibResult w ON wi.WholeSlideImageBlockId = w.Id
+    WHERE wi.Deleted = 0;
+
+    SELECT * FROM @WsibiResult;
+
+    -- WholeSlide Image
+    DECLARE @WsiResult TABLE (
+        Id INT,
+        Title NVARCHAR(1000),
+        FileId INT
+    );
+
+    INSERT INTO @WsiResult
+    SELECT wsi.Id, wsi.Title, wsi.FileId
+    FROM resources.WholeSlideImage wsi
+    INNER JOIN @WsibiResult wi ON wsi.Id = wi.WholeSlideImageId
+    WHERE wsi.Deleted = 0;
+
+    SELECT * FROM @WsiResult;
+
+    -- WholeSlide Image File
+    DECLARE @WsiFileResult TABLE (
+        Id INT,
+        FileTypeId INT,
+        FileChunkDetailId INT,
+        [FileName] NVARCHAR(255),
+        FilePath NVARCHAR(1024),
+        FileSizekb INT
+    );
+
+    INSERT INTO @WsiFileResult
+    SELECT f.Id, f.FileTypeId, f.FileChunkDetailId, f.[FileName], f.FilePath, f.FileSizeKb
+    FROM resources.[File] f
+    INNER JOIN @WsiResult wsi ON f.Id = wsi.FileId
+    WHERE f.Deleted = 0;
+
+    SELECT * FROM @WsiFileResult;
+
+    -- WholeSlide Image File - Partial File
+    SELECT pf.*
+    FROM resources.PartialFile pf
+    INNER JOIN @WsiFileResult wsi ON pf.FileId = wsi.Id
+    WHERE pf.Deleted = 0;
+
+    -- WholeSlide Image File - Image File
+    SELECT wsif.*
+    FROM resources.WholeSlideImageFile wsif
+    INNER JOIN @WsiFileResult wsi ON wsif.FileId = wsi.Id
+    WHERE wsif.Deleted = 0;
+
+    -- WholeSlide Image Annotation
+    DECLARE @WsiaResult TABLE (
+        Id INT,
+        WholeSlideImageId INT,
+        ImageId INT,
+        [Order] INT,
+        Label NVARCHAR(255),
+        Description NVARCHAR(1000),
+        PinXCoordinate DECIMAL(22,19),
+        PinYCoordinate DECIMAL(22,19),
+        Colour INT
+    );
+
+    INSERT INTO @WsiaResult
+    SELECT ia.Id, ia.WholeSlideImageId, ia.ImageId, ia.[Order], ia.Label, ia.Description, ia.PinXCoordinate, ia.PinYCoordinate, ia.Colour
+    FROM resources.ImageAnnotation ia
+    INNER JOIN @WsiResult wsi ON ia.WholeSlideImageId = wsi.Id
+    WHERE ia.Deleted = 0;
+
+    SELECT * FROM @WsiaResult;
+
+    -- WholeSlide Image Annotation Mark
+    SELECT iam.*
+    FROM resources.ImageAnnotationMark iam
+    INNER JOIN @WsiaResult wsia ON iam.ImageAnnotationId = wsia.Id
+    WHERE iam.Deleted = 0;
+
+    -- Media Block
+    DECLARE @MediaBlockResult TABLE (
+        Id INT,
+        BlockId INT,
+        MediaType INT,
+        AttachmentId INT,
+        ImageId INT,
+        VideoId INT
+    );
+
+    INSERT INTO @MediaBlockResult
+    SELECT mb.Id, mb.BlockId, mb.MediaType, mb.AttachmentId, mb.ImageId, mb.VideoId
+    FROM resources.MediaBlock mb
+    INNER JOIN @BlockResult b ON mb.BlockId = b.Id
+    WHERE mb.Deleted = 0;
+
+    SELECT * FROM @MediaBlockResult;
+
+    -- Attachment
+    DECLARE @AttachmentResult TABLE (
+        Id INT,
+        FileId INT
+    );
+
+    INSERT INTO @AttachmentResult
+    SELECT a.Id, a.FileId
+    FROM resources.Attachment a
+    INNER JOIN @MediaBlockResult mb ON a.Id = mb.AttachmentId
+    WHERE a.Deleted = 0;
+
+    SELECT * FROM @AttachmentResult;
+
+    -- Attachment File
+    DECLARE @AttachmentFileResult TABLE (
+        Id INT,
+        FileTypeId INT,
+        FileChunkDetailId INT,
+        [FileName] NVARCHAR(255),
+        FilePath NVARCHAR(1024),
+        FileSizekb INT
+    );
+
+    INSERT INTO @AttachmentFileResult
+    SELECT f.Id, f.FileTypeId, f.FileChunkDetailId, f.[FileName], f.FilePath, f.FileSizeKb
+    FROM resources.[File] f
+    INNER JOIN @AttachmentResult ar ON f.Id = ar.FileId
+    WHERE f.Deleted = 0;
+
+    SELECT * FROM @AttachmentFileResult;
+
+    -- Attachment File - Partial File
+    SELECT pf.*
+    FROM resources.PartialFile pf
+    INNER JOIN @AttachmentFileResult af ON pf.FileId = af.Id
+    WHERE pf.Deleted = 0;
+
+    -- Image
+    DECLARE @ImageResult TABLE (
+        Id INT,
+        FileId INT,
+        AltText NVARCHAR(125),
+        Description NVARCHAR(250)
+    );
+
+    INSERT INTO @ImageResult
+    SELECT i.Id, i.FileId, i.AltText, i.Description
+    FROM resources.Image i
+    INNER JOIN @MediaBlockResult mb ON i.Id = mb.ImageId
+    WHERE i.Deleted = 0;
+
+    SELECT * FROM @ImageResult;
+
+    -- Image File
+    DECLARE @ImageFileResult TABLE (
+        Id INT,
+        FileTypeId INT,
+        FileChunkDetailId INT,
+        [FileName] NVARCHAR(255),
+        FilePath NVARCHAR(1024),
+        FileSizekb INT
+    );
+
+    INSERT INTO @ImageFileResult
+    SELECT f.Id, f.FileTypeId, f.FileChunkDetailId, f.[FileName], f.FilePath, f.FileSizeKb
+    FROM resources.[File] f
+    INNER JOIN @ImageResult ir ON f.Id = ir.FileId
+    WHERE f.Deleted = 0;
+
+    SELECT * FROM @ImageFileResult;
+
+    -- Image File - Partial File
+    SELECT pf.*
+    FROM resources.PartialFile pf
+    INNER JOIN @ImageFileResult ifr ON pf.FileId = ifr.Id
+    WHERE pf.Deleted = 0;
+
+    -- Video
+    DECLARE @VideoResult TABLE (
+        Id INT,
+        FileId INT
+    );
+
+    INSERT INTO @VideoResult
+    SELECT v.Id, v.FileId
+    FROM resources.Video v
+    INNER JOIN @MediaBlockResult mb ON v.Id = mb.VideoId
+    WHERE v.Deleted = 0;
+
+    SELECT * FROM @VideoResult;
+
+    -- Video File
+    DECLARE @VideoFileResult TABLE (
+        Id INT,
+        FileTypeId INT,
+        FileChunkDetailId INT,
+        [FileName] NVARCHAR(255),
+        FilePath NVARCHAR(1024),
+        FileSizekb INT
+    );
+
+    INSERT INTO @VideoFileResult
+    SELECT f.Id, f.FileTypeId, f.FileChunkDetailId, f.[FileName], f.FilePath, f.FileSizeKb
+    FROM resources.[File] f
+    INNER JOIN @VideoResult vr ON f.Id = vr.FileId
+    WHERE f.Deleted = 0;
+
+    SELECT * FROM @VideoFileResult;
+
+    -- Video File - Partial File
+    SELECT pf.*
+    FROM resources.PartialFile pf
+    INNER JOIN @VideoFileResult vf ON pf.FileId = vf.Id
+    WHERE pf.Deleted = 0;
+
+    -- Video File Detail
+    SELECT vf.*
+    FROM resources.VideoFile vf
+    INNER JOIN @VideoFileResult vfr ON vf.FileId = vfr.Id
+    WHERE vf.Deleted = 0;
+
+    -- Question Block
+    DECLARE @QuestionResult TABLE (
+        Id INT,
+        BlockId INT,
+        QuestionBlockCollectionId INT,
+        FeedbackBlockCollectionId INT,
+        QuestionType INT,
+        AllowReveal BIT
+    );
+
+    INSERT INTO @QuestionResult
+    SELECT qb.Id, qb.BlockId, qb.QuestionBlockCollectionId, qb.FeedbackBlockCollectionId, qb.QuestionType, qb.AllowReveal
+    FROM resources.QuestionBlock qb
+    INNER JOIN @BlockResult b ON qb.BlockId = b.Id
+    WHERE qb.Deleted = 0;
+
+    SELECT * FROM @QuestionResult;
+
+    -- Question Answer
+    SELECT qa.*
+    FROM resources.QuestionAnswer qa
+    INNER JOIN @QuestionResult qr ON qa.QuestionBlockId = qr.Id
+    WHERE qa.Deleted = 0;
+
+    -- Image Carousel Block
+    SELECT icb.*
+    FROM resources.ImageCarouselBlock icb
+    INNER JOIN @BlockResult b ON icb.BlockId = b.Id
+    WHERE icb.Deleted = 0;
+END
+GO

--- a/WebAPI/LearningHub.Nhs.Repository.Interface/Resources/IBlockCollectionRepository.cs
+++ b/WebAPI/LearningHub.Nhs.Repository.Interface/Resources/IBlockCollectionRepository.cs
@@ -1,8 +1,10 @@
 ﻿namespace LearningHub.Nhs.Repository.Interface.Resources
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using LearningHub.Nhs.Models.Entities.Resource.Blocks;
+    using LearningHub.Nhs.Models.Enums;
 
     /// <summary>
     /// The BlockRepository interface.
@@ -30,5 +32,13 @@
         /// <param name="blockCollectionId">The Block Collection Id.</param>
         /// <returns>The <see cref="Task"/>.</returns>
         Task<List<Block>> GetQuestionBlocks(int blockCollectionId);
+
+        /// <summary>
+        /// Gets the Case, AssessmentContent, AssessmentGuidance Block Collections (including child Blocks, TextBlocks, WholeSlideImageBlocks and Files) except that of the provided resource version.
+        /// </summary>
+        /// <param name="excludeResourceVersionId">The excluded ResourceVersion Id.</param>
+        /// <param name="resourceTypeEnum">The resource type.</param>
+        /// <returns>The <see cref="Task"/>.</returns>
+        Task<Tuple<BlockCollection, BlockCollection, BlockCollection>> GetAllBlockCollections(int excludeResourceVersionId, ResourceTypeEnum resourceTypeEnum);
     }
 }

--- a/WebAPI/LearningHub.Nhs.Repository/Resources/BlockCollectionRepository.cs
+++ b/WebAPI/LearningHub.Nhs.Repository/Resources/BlockCollectionRepository.cs
@@ -167,6 +167,37 @@ namespace LearningHub.Nhs.Repository.Resources
         }
 
         /// <summary>
+        /// Gets the Case, AssessmentContent, AssessmentGuidance Block Collections (including child Blocks, TextBlocks, WholeSlideImageBlocks and Files) except that of the provided resource version.
+        /// </summary>
+        /// <param name="excludeResourceVersionId">The excluded ResourceVersion Id.</param>
+        /// <param name="resourceTypeEnum">The resource type.</param>
+        /// <returns>The <see cref="Task"/>.</returns>
+        public async Task<Tuple<BlockCollection, BlockCollection, BlockCollection>> GetAllBlockCollections(int excludeResourceVersionId, ResourceTypeEnum resourceTypeEnum)
+        {
+            if (resourceTypeEnum == ResourceTypeEnum.Case)
+            {
+                var caseContent = await this.GetAllCaseBlockCollections(excludeResourceVersionId);
+                return new Tuple<BlockCollection, BlockCollection, BlockCollection>(caseContent, null, null);
+            }
+            else if (resourceTypeEnum == ResourceTypeEnum.Assessment)
+            {
+                var assessmentContentTask = this.GetAllAssessmentContentBlockCollections(excludeResourceVersionId);
+                var assessmentGuidanceTask = this.GetAllAssessmentGuidanceBlockCollections(excludeResourceVersionId);
+
+                await Task.WhenAll(assessmentContentTask, assessmentGuidanceTask);
+
+                return new Tuple<BlockCollection, BlockCollection, BlockCollection>(
+                    null,
+                    await assessmentContentTask,
+                    await assessmentGuidanceTask);
+            }
+            else
+            {
+                return new Tuple<BlockCollection, BlockCollection, BlockCollection>(null, null, null);
+            }
+        }
+
+        /// <summary>
         /// Gets the Question blocks for a particular blockCollectionId.
         /// </summary>
         /// <param name="blockCollectionId">The Block Collection Id.</param>
@@ -415,6 +446,210 @@ namespace LearningHub.Nhs.Repository.Resources
 
             this.SetAuditFieldsForCreateOrDelete(userId, imageCarouselBlock.ImageBlockCollection, isCreate);
             this.SetAuditFieldsOnChildren(userId, imageCarouselBlock.ImageBlockCollection, isCreate);
+        }
+
+        private async Task<BlockCollection> GetAllCaseBlockCollections(int excludeResourceVersionId)
+        {
+            var command = new SqlCommand
+            {
+                CommandType = CommandType.StoredProcedure,
+                CommandText = "[resources].[CaseBlockCollectionGetAll]",
+                Parameters = { new SqlParameter("@excludeResourceVersionId", SqlDbType.Int) { Value = excludeResourceVersionId } },
+            };
+
+            var results = this.DbContext.MultipleResults(command)
+                            .With<Block>()
+                            .With<TextBlock>()
+                            .With<WholeSlideImageBlock>()
+                            .With<WholeSlideImageBlockItem>()
+                            .With<WholeSlideImage>()
+                            .With<File>()
+                            .With<PartialFile>()
+                            .With<WholeSlideImageFile>()
+                            .With<ImageAnnotation>()
+                            .With<ImageAnnotationMark>()
+                            .With<MediaBlock>()
+                            .With<Attachment>()
+                            .With<File>()
+                            .With<PartialFile>()
+                            .With<Image>()
+                            .With<File>()
+                            .With<PartialFile>()
+                            .With<Video>()
+                            .With<File>()
+                            .With<PartialFile>()
+                            .With<VideoFile>()
+                            .With<QuestionBlock>()
+                            .With<QuestionAnswer>()
+                            .With<ImageCarouselBlock>()
+                            .Execute();
+
+            var blocks = results[0].OfType<Block>().ToArray();
+            var textBlocks = results[1].OfType<TextBlock>();
+            var wholeSlideImgBlocks = GetWholeSlideImageBlocks(results);
+            var mediaBlocks = GetMediaBlocks(results);
+            var questionBlocks = GetQuestionBlocks(results);
+            var imgCarouselBlocks = results[23].OfType<ImageCarouselBlock>();
+
+            foreach (var block in blocks)
+            {
+                block.TextBlock = textBlocks.FirstOrDefault(t => t.BlockId == block.Id);
+                block.WholeSlideImageBlock = wholeSlideImgBlocks.FirstOrDefault(w => w.BlockId == block.Id);
+                block.MediaBlock = mediaBlocks.FirstOrDefault(m => m.BlockId == block.Id);
+                block.QuestionBlock = questionBlocks.FirstOrDefault(q => q.BlockId == block.Id);
+                block.ImageCarouselBlock = imgCarouselBlocks.FirstOrDefault(i => i.BlockId == block.Id);
+            }
+
+            var blockCollection = new BlockCollection
+            {
+                Blocks = blocks,
+            };
+
+            await Task.WhenAll(blockCollection.Blocks
+                .Where(block => block.QuestionBlock != null)
+                .Select(block => this.FillInPartialQuestionBlock(block.QuestionBlock)));
+
+            await Task.WhenAll(blockCollection.Blocks
+                .Where(block => block.ImageCarouselBlock != null)
+                .Select(block => this.FillInPartialImageCarouselBlock(block.ImageCarouselBlock)));
+
+            return blockCollection;
+        }
+
+        private async Task<BlockCollection> GetAllAssessmentContentBlockCollections(int excludeResourceVersionId)
+        {
+            var command = new SqlCommand
+            {
+                CommandType = CommandType.StoredProcedure,
+                CommandText = "[resources].[AssessmentContentBlockCollectionGetAll]",
+                Parameters = { new SqlParameter("@excludeResourceVersionId", SqlDbType.Int) { Value = excludeResourceVersionId } },
+            };
+
+            var results = this.DbContext.MultipleResults(command)
+                            .With<Block>()
+                            .With<TextBlock>()
+                            .With<WholeSlideImageBlock>()
+                            .With<WholeSlideImageBlockItem>()
+                            .With<WholeSlideImage>()
+                            .With<File>()
+                            .With<PartialFile>()
+                            .With<WholeSlideImageFile>()
+                            .With<ImageAnnotation>()
+                            .With<ImageAnnotationMark>()
+                            .With<MediaBlock>()
+                            .With<Attachment>()
+                            .With<File>()
+                            .With<PartialFile>()
+                            .With<Image>()
+                            .With<File>()
+                            .With<PartialFile>()
+                            .With<Video>()
+                            .With<File>()
+                            .With<PartialFile>()
+                            .With<VideoFile>()
+                            .With<QuestionBlock>()
+                            .With<QuestionAnswer>()
+                            .With<ImageCarouselBlock>()
+                            .Execute();
+
+            var blocks = results[0].OfType<Block>().ToArray();
+            var textBlocks = results[1].OfType<TextBlock>();
+            var wholeSlideImgBlocks = GetWholeSlideImageBlocks(results);
+            var mediaBlocks = GetMediaBlocks(results);
+            var questionBlocks = GetQuestionBlocks(results);
+            var imgCarouselBlocks = results[23].OfType<ImageCarouselBlock>();
+
+            foreach (var block in blocks)
+            {
+                block.TextBlock = textBlocks.FirstOrDefault(t => t.BlockId == block.Id);
+                block.WholeSlideImageBlock = wholeSlideImgBlocks.FirstOrDefault(w => w.BlockId == block.Id);
+                block.MediaBlock = mediaBlocks.FirstOrDefault(m => m.BlockId == block.Id);
+                block.QuestionBlock = questionBlocks.FirstOrDefault(q => q.BlockId == block.Id);
+                block.ImageCarouselBlock = imgCarouselBlocks.FirstOrDefault(i => i.BlockId == block.Id);
+            }
+
+            var blockCollection = new BlockCollection
+            {
+                Blocks = blocks,
+            };
+
+            await Task.WhenAll(blockCollection.Blocks
+                .Where(block => block.QuestionBlock != null)
+                .Select(block => this.FillInPartialQuestionBlock(block.QuestionBlock)));
+
+            await Task.WhenAll(blockCollection.Blocks
+                .Where(block => block.ImageCarouselBlock != null)
+                .Select(block => this.FillInPartialImageCarouselBlock(block.ImageCarouselBlock)));
+
+            return blockCollection;
+        }
+
+        private async Task<BlockCollection> GetAllAssessmentGuidanceBlockCollections(int excludeResourceVersionId)
+        {
+            var command = new SqlCommand
+            {
+                CommandType = CommandType.StoredProcedure,
+                CommandText = "[resources].[AssessmentGuidanceBlockCollectionGetAll]",
+                Parameters = { new SqlParameter("@excludeResourceVersionId", SqlDbType.Int) { Value = excludeResourceVersionId } },
+            };
+
+            var results = this.DbContext.MultipleResults(command)
+                            .With<Block>()
+                            .With<TextBlock>()
+                            .With<WholeSlideImageBlock>()
+                            .With<WholeSlideImageBlockItem>()
+                            .With<WholeSlideImage>()
+                            .With<File>()
+                            .With<PartialFile>()
+                            .With<WholeSlideImageFile>()
+                            .With<ImageAnnotation>()
+                            .With<ImageAnnotationMark>()
+                            .With<MediaBlock>()
+                            .With<Attachment>()
+                            .With<File>()
+                            .With<PartialFile>()
+                            .With<Image>()
+                            .With<File>()
+                            .With<PartialFile>()
+                            .With<Video>()
+                            .With<File>()
+                            .With<PartialFile>()
+                            .With<VideoFile>()
+                            .With<QuestionBlock>()
+                            .With<QuestionAnswer>()
+                            .With<ImageCarouselBlock>()
+                            .Execute();
+
+            var blocks = results[0].OfType<Block>().ToArray();
+            var textBlocks = results[1].OfType<TextBlock>();
+            var wholeSlideImgBlocks = GetWholeSlideImageBlocks(results);
+            var mediaBlocks = GetMediaBlocks(results);
+            var questionBlocks = GetQuestionBlocks(results);
+            var imgCarouselBlocks = results[23].OfType<ImageCarouselBlock>();
+
+            foreach (var block in blocks)
+            {
+                block.TextBlock = textBlocks.FirstOrDefault(t => t.BlockId == block.Id);
+                block.WholeSlideImageBlock = wholeSlideImgBlocks.FirstOrDefault(w => w.BlockId == block.Id);
+                block.MediaBlock = mediaBlocks.FirstOrDefault(m => m.BlockId == block.Id);
+                block.QuestionBlock = questionBlocks.FirstOrDefault(q => q.BlockId == block.Id);
+                block.ImageCarouselBlock = imgCarouselBlocks.FirstOrDefault(i => i.BlockId == block.Id);
+            }
+
+            var blockCollection = new BlockCollection
+            {
+                Blocks = blocks,
+            };
+
+            await Task.WhenAll(blockCollection.Blocks
+                .Where(block => block.QuestionBlock != null)
+                .Select(block => this.FillInPartialQuestionBlock(block.QuestionBlock)));
+
+            await Task.WhenAll(blockCollection.Blocks
+                .Where(block => block.ImageCarouselBlock != null)
+                .Select(block => this.FillInPartialImageCarouselBlock(block.ImageCarouselBlock)));
+
+            return blockCollection;
         }
     }
 }

--- a/WebAPI/LearningHub.Nhs.Services.Interface/IResourceService.cs
+++ b/WebAPI/LearningHub.Nhs.Services.Interface/IResourceService.cs
@@ -5,11 +5,13 @@ namespace LearningHub.Nhs.Services.Interface
     using System.Threading.Tasks;
     using LearningHub.Nhs.Models.Common;
     using LearningHub.Nhs.Models.Entities.Resource;
+    using LearningHub.Nhs.Models.Enums;
     using LearningHub.Nhs.Models.Paging;
     using LearningHub.Nhs.Models.Provider;
     using LearningHub.Nhs.Models.Resource;
     using LearningHub.Nhs.Models.Resource.Admin;
     using LearningHub.Nhs.Models.Resource.AzureMediaAsset;
+    using LearningHub.Nhs.Models.Resource.Blocks;
     using LearningHub.Nhs.Models.Resource.Contribute;
     using LearningHub.Nhs.Models.Resource.ResourceDisplay;
     using LearningHub.Nhs.Models.Validation;
@@ -437,6 +439,14 @@ namespace LearningHub.Nhs.Services.Interface
         Task<CaseViewModel> GetCaseDetailsByIdAsync(int resourceVersionId);
 
         /// <summary>
+        /// The get case resource version async.
+        /// </summary>
+        /// <param name="excludeResourceVersionId">The resource version id.</param>
+        /// <param name="resourceType">The resource type.</param>
+        /// <returns>The <see cref="Task"/>.</returns>
+        Task<BlockCollectionViewModel> GetAllCaseBlockCollectionsAsync(int excludeResourceVersionId, ResourceTypeEnum resourceType);
+
+        /// <summary>
         /// The update case resource version async.
         /// </summary>
         /// <param name="caseViewModel">The case view model.</param>
@@ -458,6 +468,14 @@ namespace LearningHub.Nhs.Services.Interface
         /// <param name="resourceVersionId">The resource version id.</param>
         /// <returns>The <see cref="Task"/>.</returns>
         Task<AssessmentResourceVersion> GetAssessmentBasicDetailsByIdAsync(int resourceVersionId);
+
+        /// <summary>
+        /// The assessment blocks for all published(current) and non published resource version async.
+        /// </summary>
+        /// <param name="excludeResourceVersionId">The resource version id to exclude.</param>
+        /// <param name="resourceType">The resource type enum.</param>
+        /// <returns>The <see cref="Task"/>.</returns>
+        Task<Tuple<BlockCollectionViewModel, BlockCollectionViewModel>> GetAssessmentBlockCollectionAsync(int excludeResourceVersionId, ResourceTypeEnum resourceType);
 
         /// <summary>
         /// This method updates the database entry with the assessment details, passed down as a parameter.


### PR DESCRIPTION
### JIRA link
[TD-3023](https://hee-tis.atlassian.net/browse/TD-3023)

### Description
 When archiving we need to ensure that files are only archived if there are no longer any references to them, by any resource including copies(cases and assessment)

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3023]: https://hee-tis.atlassian.net/browse/TD-3023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ