### PR TITLE
TD-4023: Considering only active users IN Catalogue access request

### DIFF
--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hub/RestrictedCatalogueGetAccessRequests.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hub/RestrictedCatalogueGetAccessRequests.sql
@@ -7,6 +7,7 @@
 --
 -- 25-03-2021  Killian Davies	Initial Revision
 -- 08-02-2024  SA				Included Role details.
+-- 31-05-2024  SS				Considering only active users
 -------------------------------------------------------------------------------
 CREATE PROCEDURE [hub].[RestrictedCatalogueGetAccessRequests] 
 (
@@ -38,7 +39,7 @@ BEGIN
 			hub.UserProfile up ON car.UserId = up.Id
 		WHERE
 			car.CatalogueNodeId = @catalogueNodeId
-			AND car.Deleted = 0
+			AND car.Deleted = 0 and up.Deleted=0
 	) AS T1
 	WHERE T1.[Sequence] = 1
 	AND ((@includeNew = 1 AND CatalogueAccessRequestStatus = 0)


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4203

### Description
Considering only active users IN Catalogue access request

### Screenshots

**_Before code change:_**
![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/120369940/c3690a7e-b2cf-4db5-98f2-ff16711bdd24)

**_After code change:_**
![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/120369940/a57c9696-d7e5-4279-b443-682bfc4edf61)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
