### PR TITLE
TD-4234: Modified GetExternalContentDetailsById (Web API) API call and change it to async Call

### DIFF
--- a/WebAPI/LearningHub.Nhs.API/Controllers/ResourceController.cs
+++ b/WebAPI/LearningHub.Nhs.API/Controllers/ResourceController.cs
@@ -496,9 +496,9 @@ namespace LearningHub.Nhs.Api.Controllers
         /// <param name="resourceVersionId">The resourceVersionId<see cref="int"/>.</param>
         /// <returns>The <see cref="Task{ActionResult}"/>.</returns>
         [HttpGet("GetExternalContentDetailsById/{resourceVersionId}")]
-        public ActionResult GetScormContentDetailsById(int resourceVersionId)
+        public async Task<ActionResult> GetScormContentDetailsById(int resourceVersionId)
         {
-            return this.Ok(this.resourceService.GetExternalContentDetails(resourceVersionId, this.CurrentUserId));
+            return this.Ok(await this.resourceService.GetExternalContentDetails(resourceVersionId, this.CurrentUserId));
         }
 
         /// <summary>

--- a/WebAPI/LearningHub.Nhs.Repository.Interface/Resources/IResourceVersionRepository.cs
+++ b/WebAPI/LearningHub.Nhs.Repository.Interface/Resources/IResourceVersionRepository.cs
@@ -262,6 +262,6 @@ namespace LearningHub.Nhs.Repository.Interface.Resources
         /// <param name="resourceVersionId">resourceVersionId.</param>
         /// <param name="userId">userId.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        ExternalContentDetailsViewModel GetExternalContentDetails(int resourceVersionId, int userId);
+        Task<ExternalContentDetailsViewModel> GetExternalContentDetails(int resourceVersionId, int userId);
     }
 }

--- a/WebAPI/LearningHub.Nhs.Repository/Resources/ResourceVersionRepository.cs
+++ b/WebAPI/LearningHub.Nhs.Repository/Resources/ResourceVersionRepository.cs
@@ -679,15 +679,15 @@
         /// <param name="resourceVersionId">resourceVersionId.</param>
         /// <param name="userId">userId.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        public ExternalContentDetailsViewModel GetExternalContentDetails(int resourceVersionId, int userId)
+        public async Task<ExternalContentDetailsViewModel> GetExternalContentDetails(int resourceVersionId, int userId)
         {
             try
             {
                 var param0 = new SqlParameter("@resourceVersionId", SqlDbType.Int) { Value = resourceVersionId };
                 var param1 = new SqlParameter("@userId", SqlDbType.Int) { Value = userId };
 
-                var externalContentDetailsViewModel = this.DbContext.ExternalContentDetailsViewModel.FromSqlRaw("[resources].[GetExternalContentDetails] @resourceVersionId, @userId", param0, param1).AsEnumerable().FirstOrDefault();
-
+                var retVal = await this.DbContext.ExternalContentDetailsViewModel.FromSqlRaw("[resources].[GetExternalContentDetails] @resourceVersionId, @userId", param0, param1).AsNoTracking().ToListAsync();
+                ExternalContentDetailsViewModel externalContentDetailsViewModel = retVal.AsEnumerable().FirstOrDefault();
                 return externalContentDetailsViewModel;
             }
             catch (Exception ex)

--- a/WebAPI/LearningHub.Nhs.Services.Interface/IResourceService.cs
+++ b/WebAPI/LearningHub.Nhs.Services.Interface/IResourceService.cs
@@ -104,7 +104,7 @@ namespace LearningHub.Nhs.Services.Interface
         /// <param name="resourceVersionId">The resourceVersionId<see cref="int"/>.</param>
         /// <param name="userId">userId.</param>
         /// <returns>The <see cref="Task{ScormContentDetailsViewModel}"/>.</returns>
-        ExternalContentDetailsViewModel GetExternalContentDetails(int resourceVersionId, int userId);
+        Task<ExternalContentDetailsViewModel> GetExternalContentDetails(int resourceVersionId, int userId);
 
         /// <summary>
         /// The get image details by id async.

--- a/WebAPI/LearningHub.Nhs.Services/ResourceService.cs
+++ b/WebAPI/LearningHub.Nhs.Services/ResourceService.cs
@@ -2793,7 +2793,7 @@ namespace LearningHub.Nhs.Services
             var vm = this.mapper.Map<GenericFileViewModel>(genericFile);
 
             // User id is used to populate a field we aren't going to use, so we can just pass in the system user id.
-            var externalContentDetails = this.resourceVersionRepository.GetExternalContentDetails(resourceVersionId, 4);
+            var externalContentDetails = await this.resourceVersionRepository.GetExternalContentDetails(resourceVersionId, 4);
             if (!string.IsNullOrEmpty(externalContentDetails?.ExternalReference))
             {
                 vm.HostedContentUrl = $"{this.settings.LearningHubContentServerUrl}/{externalContentDetails.ExternalReference}/".ToLower();
@@ -2814,7 +2814,7 @@ namespace LearningHub.Nhs.Services
             var vm = this.mapper.Map<HtmlResourceViewModel>(htmlFile);
 
             // User id is used to populate a field we aren't going to use, so we can just pass in the system user id.
-            var externalContentDetails = this.resourceVersionRepository.GetExternalContentDetails(resourceVersionId, 4);
+            var externalContentDetails = await this.resourceVersionRepository.GetExternalContentDetails(resourceVersionId, 4);
             if (!string.IsNullOrEmpty(externalContentDetails?.ExternalReference))
             {
                 vm.HostedContentUrl = $"{this.settings.LearningHubContentServerUrl}/{externalContentDetails.ExternalReference}/".ToLower();
@@ -2835,7 +2835,7 @@ namespace LearningHub.Nhs.Services
             var vm = this.mapper.Map<ScormViewModel>(scorm);
 
             // User id is used to populate a field we aren't going to use, so we can just pass in the system user id.
-            var externalContentDetails = this.resourceVersionRepository.GetExternalContentDetails(resourceVersionId, 4);
+            var externalContentDetails = await this.resourceVersionRepository.GetExternalContentDetails(resourceVersionId, 4);
             if (!string.IsNullOrEmpty(externalContentDetails?.ExternalReference))
             {
                 vm.HostedContentUrl = $"{this.settings.LearningHubContentServerUrl}/{externalContentDetails.ExternalReference}/".ToLower();
@@ -2851,9 +2851,9 @@ namespace LearningHub.Nhs.Services
         /// <param name="resourceVersionId">The resourceVersionId<see cref="int"/>.</param>
         /// <param name="userId">userId.</param>
         /// <returns>The <see cref="Task{ExternalContentDetailsViewModel}"/>.</returns>
-        public ExternalContentDetailsViewModel GetExternalContentDetails(int resourceVersionId, int userId)
+        public async Task<ExternalContentDetailsViewModel> GetExternalContentDetails(int resourceVersionId, int userId)
         {
-            var viewModel = this.resourceVersionRepository.GetExternalContentDetails(resourceVersionId, userId);
+            var viewModel = await this.resourceVersionRepository.GetExternalContentDetails(resourceVersionId, userId);
             if (viewModel != null)
             {
                 viewModel.HostedContentUrl = $"{this.settings.LearningHubContentServerUrl}/{viewModel.ExternalReference}/".ToLower();


### PR DESCRIPTION

### JIRA link
https://hee-tis.atlassian.net/browse/TD-4234

### Description
Modified GetExternalContentDetailsById (Web API) API call and change it to async Call

### Screenshots
**_Before and after the code changes, the Resource details page is working as expected._**
![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/120369940/0436044e-cc57-4b53-86d7-abb1d9f85a8f)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
