### PR TITLE
TD-4226 AMS storage additional bugs

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/Api/ResourceController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/Api/ResourceController.cs
@@ -1,6 +1,7 @@
 namespace LearningHub.Nhs.WebUI.Controllers.Api
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using LearningHub.Nhs.Models.Enums;
     using LearningHub.Nhs.Models.Resource;
@@ -556,6 +557,33 @@ namespace LearningHub.Nhs.WebUI.Controllers.Api
         {
             var validationResult = await this.resourceService.DeleteAllResourceVersionProviderAsync(resourceVersionId);
             return this.Ok(validationResult);
+        }
+
+        /// <summary>
+        /// The ArchiveResourceFile.
+        /// </summary>
+        /// <param name="filePaths">filePaths.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        [HttpPost]
+        [Route("ArchiveResourceFile")]
+        public ActionResult ArchiveResourceFile(List<string> filePaths)
+        {
+            _ = Task.Run(async () => { await this.fileService.PurgeResourceFile(null, filePaths); });
+            return this.Ok();
+        }
+
+        /// <summary>
+        /// The GetObsoleteResourceFile.
+        /// </summary>
+        /// <param name="resourceVersionId">The resourceVersionId.</param>
+        /// <param name="deletedResource">.</param>
+        /// <returns>The <see cref="T:Task{List{FileTypeViewModel}}"/>.</returns>
+        [HttpGet]
+        [Route("GetObsoleteResourceFile/{resourceVersionId}/{deletedResource}")]
+        public async Task<List<string>> GetObsoleteResourceFile(int resourceVersionId, bool deletedResource)
+        {
+            var result = await this.resourceService.GetObsoleteResourceFile(resourceVersionId, deletedResource);
+            return result;
         }
     }
 }

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/Content.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/Content.vue
@@ -502,6 +502,8 @@
                 showError: false,
                 errorMessage: '',
                 contributeResourceAVFlag: true,
+                filePathBeforeFileChange: [] as string[],
+                filePathAfterFileChange: [] as string[]
             }
         },
         computed: {
@@ -837,6 +839,19 @@
                     if (uploadResult.resourceType === ResourceType.SCORM) {
                         this.$store.commit('populateScormDetails', uploadResult.resourceVersionId);
                     }
+
+                    if (this.filePathBeforeFileChange.length > 0) {
+                        this.getResourceFilePath('completed');
+                        if (this.filePathBeforeFileChange.length > 0 && this.filePathAfterFileChange.length > 0) {
+                            let filePaths = this.filePathBeforeFileChange.filter(item => !this.filePathAfterFileChange.includes(item));
+                            if (filePaths.length > 0) {
+                                resourceData.archiveResourceFile(filePaths);
+                                this.filePathBeforeFileChange.length = 0;
+                                this.filePathAfterFileChange.length = 0;
+                            }
+                        }
+                    }
+                   
                 } else {
                     this.fileUploadServerError = 'There was a problem uploading this file to the Learning Hub. Please try again and if it still does not upload, contact the support team.';
                     this.$store.commit('setSaveStatus', '');
@@ -894,6 +909,7 @@
             },
             fileChangedScorm() {
                 (this.$refs.fileUploadScorm as any).click();
+                this.getResourceFilePath('initialised');
             },
             childResourceFileChanged(newFile: File) {
                 this.uploadingFile = newFile;
@@ -943,6 +959,7 @@
             fileChanged() {
                 this.fileUploadRef.value = null;
                 this.fileUploadRef.click();
+                this.getResourceFilePath('initialised');
             },
             childFileUploadError(errorType: FileErrorTypeEnum, customError: string) {
                 this.fileErrorType = errorType;
@@ -1015,6 +1032,21 @@
                         break;
                 }
                 return errorTitle;
+            },
+            async getResourceFilePath(fileChangeStatus: string) {
+                let resource = this.$store.state.resourceDetail;
+                if (resource != null && resource.resourceVersionId > 0 &&(resource.resourceType != this.resourceType.CASE || resource.resourceType != this.resourceType.ASSESSMENT))
+                {
+                    await resourceData.getObsoleteResourceFile(resource.resourceVersionId).then(response => {
+                        if (fileChangeStatus == 'initialised') {
+                            this.filePathBeforeFileChange = response;
+                        }
+                        else if (fileChangeStatus == 'completed') {
+                            this.filePathAfterFileChange = response;
+                        }
+                    });
+                }
+
             }
         },
         validations: {

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/data/resource.ts
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/data/resource.ts
@@ -535,6 +535,29 @@ const getAVUnavailableView = async function (): Promise<string> {
         });
 };
 
+const getObsoleteResourceFile = async function (id: number): Promise<string[]> {
+    return await AxiosWrapper.axios.get<string[]>('/api/Resource/GetObsoleteResourceFile/' + id + '/' + true + `?timestamp=${new Date().getTime()}`)
+        .then(response => {
+            console.log(response.data);
+            return response.data;
+        })
+        .catch(e => {
+            console.log('getObsoleteResourceFiles:' + e);
+            throw e;
+        });
+};
+
+const archiveResourceFile = async function (filepaths: string[]): Promise<boolean> {
+    const params = {filePaths:filepaths};
+    return await AxiosWrapper.axios.post('/api/Resource/DuplicateBlocks', params).then(() => {
+        return true
+    }).catch(e => {
+            console.log('archiveResourceFile:' + e);
+            throw e;
+        });
+};
+
+
 export const resourceData = {
     getContributeConfiguration,
     getContributeSettings,
@@ -575,5 +598,7 @@ export const resourceData = {
     getMyContributions,
     getContributeAVResourceFlag,
     getDisplayAVResourceFlag,
-    getAVUnavailableView
+    getAVUnavailableView,
+    getObsoleteResourceFile,
+    archiveResourceFile
 };

--- a/WebAPI/LearningHub.Nhs.Services/ResourceService.cs
+++ b/WebAPI/LearningHub.Nhs.Services/ResourceService.cs
@@ -1411,7 +1411,7 @@ namespace LearningHub.Nhs.Services
                     var rvs = await this.resourceVersionRepository.GetResourceVersionsAsync(resourceVersion.ResourceId);
                     rvs = rvs.Where(x => x.Id != resourceVersionId && x.PublicationId > 0).OrderByDescending(x => x.PublicationId).ToList();
                     var rv = rvs.FirstOrDefault();
-                    var extendedResourceVersion = await this.GetResourceVersionExtendedViewModelAsync(rv.Id);
+                    var extendedResourceVersion = rv != null ? await this.GetResourceVersionExtendedViewModelAsync(rv.Id) : null;
                     switch (resourceVersion.ResourceType)
                     {
                         case ResourceTypeEnum.Scorm:
@@ -1432,7 +1432,7 @@ namespace LearningHub.Nhs.Services
                             }
                             else if (rv == null && deletedResource)
                             {
-                                retVal.Add(scormResource.ContentFilePath);
+                                retVal.Add(scormResource?.File?.FilePath);
                             }
 
                             break;
@@ -1454,7 +1454,7 @@ namespace LearningHub.Nhs.Services
                             }
                             else if (rv == null && deletedResource)
                             {
-                                retVal.Add(htmlResource.ContentFilePath);
+                                retVal.Add(htmlResource?.File?.FilePath);
                             }
 
                             break;


### PR DESCRIPTION
### JIRA link
[TD-4226](https://hee-tis.atlassian.net/browse/TD-4226)

### Description
Fix for files associated with draft resources

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4226]: https://hee-tis.atlassian.net/browse/TD-4226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ