### PR TITLE
TD-3694-After updating a resource, last accessed date not displayed on admin user learning record

### DIFF
--- a/AdminUI/LearningHub.Nhs.AdminUI/Views/User/_UserLearningRecord.cshtml
+++ b/AdminUI/LearningHub.Nhs.AdminUI/Views/User/_UserLearningRecord.cshtml
@@ -36,7 +36,7 @@
         <tr>
           <td>
             <span class="nhsuk-u-text-align-left table-content-spacing">
-              @if (userLearningRecord.IsCurrentResourceVersion && userLearningRecord.ResourceReferenceId > 0 && userLearningRecord.VersionStatusId != (int?)VersionStatusEnum.Unpublished)
+              @if (userLearningRecord.ResourceReferenceId > 0 && userLearningRecord.VersionStatusId != (int?)VersionStatusEnum.Unpublished)
               {
                 <span>
                   <a class="learning-td" href="@resourceUrl/@userLearningRecord.ResourceReferenceId" target="_blank">@userLearningRecord.Title</a><br />


### PR DESCRIPTION
### JIRA link
_TD-3694

### Description
After updating a resource, last accessed date not displayed on admin user learning record

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [X] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
