### PR TITLE
Cache hub.RoleUserGroupGetByUserId in webui

### DIFF
--- a/LearningHub.Nhs.WebUI/Services/UserGroupService.cs
+++ b/LearningHub.Nhs.WebUI/Services/UserGroupService.cs
@@ -52,26 +52,8 @@
         /// <inheritdoc />
         public async Task<List<RoleUserGroupViewModel>> GetRoleUserGroupDetailForUserAsync(int userId)
         {
-            List<RoleUserGroupViewModel> viewmodel = null;
-
-            var client = await this.LearningHubHttpClient.GetClientAsync();
-
-            var request = $"UserGroup/GetUserGroupRoleDetailByUserId/{userId}";
-            var response = await client.GetAsync(request).ConfigureAwait(false);
-
-            if (response.IsSuccessStatusCode)
-            {
-                var result = response.Content.ReadAsStringAsync().Result;
-                viewmodel = JsonConvert.DeserializeObject<List<RoleUserGroupViewModel>>(result);
-            }
-            else if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized
-                        ||
-                     response.StatusCode == System.Net.HttpStatusCode.Forbidden)
-            {
-                throw new Exception("AccessDenied");
-            }
-
-            return viewmodel;
+            var cacheKey = $"{userId}:AllRolesWithPermissions";
+            return await this.cacheService.GetOrFetchAsync(cacheKey, () => this.FetchRoleUserGroupDetailForUserAsync(userId));
         }
 
         /// <inheritdoc />
@@ -97,6 +79,30 @@
             var client = await this.LearningHubHttpClient.GetClientAsync();
 
             var request = $"UserGroup/GetUserGroupRoleDetail";
+            var response = await client.GetAsync(request).ConfigureAwait(false);
+
+            if (response.IsSuccessStatusCode)
+            {
+                var result = response.Content.ReadAsStringAsync().Result;
+                viewmodel = JsonConvert.DeserializeObject<List<RoleUserGroupViewModel>>(result);
+            }
+            else if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized
+                        ||
+                     response.StatusCode == System.Net.HttpStatusCode.Forbidden)
+            {
+                throw new Exception("AccessDenied");
+            }
+
+            return viewmodel;
+        }
+
+        private async Task<List<RoleUserGroupViewModel>> FetchRoleUserGroupDetailForUserAsync(int userId)
+        {
+            List<RoleUserGroupViewModel> viewmodel = null;
+
+            var client = await this.LearningHubHttpClient.GetClientAsync();
+
+            var request = $"UserGroup/GetUserGroupRoleDetailByUserId/{userId}";
             var response = await client.GetAsync(request).ConfigureAwait(false);
 
             if (response.IsSuccessStatusCode)


### PR DESCRIPTION
### JIRA link
TD-4273

### Description
cache RoleUserGroupDetailForUser data

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
