### PR TITLE
TD-3948 refactored the SP BlockDelete call

### DIFF
--- a/WebAPI/LearningHub.Nhs.Repository/Resources/BlockCollectionRepository.cs
+++ b/WebAPI/LearningHub.Nhs.Repository/Resources/BlockCollectionRepository.cs
@@ -83,10 +83,22 @@ namespace LearningHub.Nhs.Repository.Resources
 
             foreach (var id in collectionIds)
             {
-                using (var lhContext = new LearningHubDbContext(this.DbContext.Options))
+                _ = Task.Run(async () =>
                 {
-                    _ = lhContext.Database.ExecuteSqlRawAsync("resources.BlockCollectionDelete @p0", new SqlParameter("@p0", SqlDbType.Int) { Value = id });
-                }
+                    var lhContext = new LearningHubDbContext(this.DbContext.Options);
+                    try
+                    {
+                        await lhContext.Database.ExecuteSqlRawAsync("resources.BlockCollectionDelete @p0", new SqlParameter("@p0", SqlDbType.Int) { Value = id });
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new Exception(ex.Message);
+                    }
+                    finally
+                    {
+                        await lhContext.DisposeAsync();
+                    }
+                });
             }
         }
 


### PR DESCRIPTION

### JIRA link
[TD-3948](https://hee-tis.atlassian.net/browse/TD-3948)

### Description
Refactored the SPBlockCollectionDelete call  not to use  "the using statement" during initialization which automatically disposes the DbContext immediately after the asynchronous call starts. The db context is now disposed manually in the finally block.

The initial code works within dev environment which runs more slowly, enabling the SP call to be successfully made before the db context is automatically disposed.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
