### PR TITLE
TD-4335: CKEditor 4.14.0 version is not secure-Error Massage in Produ…

### DIFF
--- a/AdminUI/LearningHub.Nhs.AdminUI/Scripts/vuesrc/ckeditorwithhint.vue
+++ b/AdminUI/LearningHub.Nhs.AdminUI/Scripts/vuesrc/ckeditorwithhint.vue
@@ -23,7 +23,10 @@
         },
         data() {
             return {
-                editorConfig: { toolbar: CKEditorToolbar.default },
+                editorConfig: {
+                    toolbar: CKEditorToolbar.default,
+                    versionCheck: false
+                },
                 description: this.initialValue,
                 hint: `You have ${this.maxLength} characters remaining`,
                 valid: getRemainingCharactersFromHtml(this.maxLength, this.initialValue) >= 0,

--- a/AdminUI/LearningHub.Nhs.AdminUI/Scripts/vuesrc/content-structure/contentStructure.vue
+++ b/AdminUI/LearningHub.Nhs.AdminUI/Scripts/vuesrc/content-structure/contentStructure.vue
@@ -169,7 +169,10 @@ export default Vue.extend({
             isReady: false,
             EditModeEnum: EditModeEnum,
             HierarchyEditStatusEnum: HierarchyEditStatusEnum,
-            editorConfig: { toolbar: CKEditorToolbar.default },
+            editorConfig: {
+                toolbar: CKEditorToolbar.default,
+                versionCheck: false
+            },
             deleteFolderName: '',
             editFolderStructureButtonText: '',
             editFolderStructureButtonDisabled: true,

--- a/AdminUI/LearningHub.Nhs.AdminUI/Scripts/vuesrc/content/pageImageSection.vue
+++ b/AdminUI/LearningHub.Nhs.AdminUI/Scripts/vuesrc/content/pageImageSection.vue
@@ -257,6 +257,7 @@
                 SectionLayoutType: SectionLayoutType,
                 editorConfig: {
                     toolbar: CKEditorToolbar.landingPages,
+                    versionCheck: false,
                     stylesSet: 'landing-pages-image-text'
                 },
 

--- a/AdminUI/LearningHub.Nhs.AdminUI/Scripts/vuesrc/content/pageVideoSection.vue
+++ b/AdminUI/LearningHub.Nhs.AdminUI/Scripts/vuesrc/content/pageVideoSection.vue
@@ -263,6 +263,7 @@ Vue.use(Vuelidate as any);
                 SectionLayoutType: SectionLayoutType,
                 editorConfig: {
                     toolbar: CKEditorToolbar.landingPages,
+                    versionCheck: false,
                     stylesSet: 'landing-pages-video-text'
                 },
 

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/ckeditorwithhint.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/ckeditorwithhint.vue
@@ -23,7 +23,10 @@
         },
         data() {
             return {
-                editorConfig: { toolbar: CKEditorToolbar.default },
+                editorConfig: {
+                    toolbar: CKEditorToolbar.default,
+                    versionCheck: false
+                },
                 description: this.initialValue,
                 hint: `You have ${this.maxLength} characters remaining`,
                 valid: getRemainingCharactersFromHtml(this.maxLength, this.initialValue) >= 0,

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/content-structure-admin/contentStructure.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/content-structure-admin/contentStructure.vue
@@ -176,7 +176,10 @@
                 isReady: false,
                 EditModeEnum: EditModeEnum,
                 HierarchyEditStatusEnum: HierarchyEditStatusEnum,
-                editorConfig: { toolbar: CKEditorToolbar.default },
+                editorConfig: {
+                    toolbar: CKEditorToolbar.default,
+                    versionCheck: false
+                },
                 deleteFolderName: '',
                 editFolderStructureButtonText: '',
                 editFolderStructureButtonDisabled: true,

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/ContributeTextBlock.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/ContributeTextBlock.vue
@@ -32,7 +32,7 @@
         data() {
             return {
                 textBlockContent: this.textBlock.content,
-                ckEditorConfig: { toolbar: CKEditorToolbar.default },
+                ckEditorConfig: { toolbar: CKEditorToolbar.default, versionCheck: false },
                 prevHeight: undefined,
             };
         },

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/ContentArticle.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/ContentArticle.vue
@@ -75,7 +75,10 @@
         data() {
             return {
                 articleContent: '',
-                editorConfig: { toolbar: CKEditorToolbar.default },
+                editorConfig: {                
+                    toolbar: CKEditorToolbar.default,
+                     versionCheck: false
+                },
                 localArticleDetail: new ArticleResourceModel(),
                 uploadingFile: null as File,
                 changeingFileId: 0

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/ContentCommon.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/ContentCommon.vue
@@ -282,7 +282,7 @@
                 currentUserAuthor: false,
                 certificateEnabled: null,
                 newKeyword: '',
-                editorConfig: { toolbar: CKEditorToolbar.default },
+                editorConfig: { toolbar: CKEditorToolbar.default, versionCheck: false },
                 ResourceType,
                 resourceProviderId: null,
             };


### PR DESCRIPTION
…ction

### JIRA link
https://hee-tis.atlassian.net/browse/TD-4335 

### Description
Disabled the CKEditor version check from the configuration

### Screenshots
Before change: 
![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/121869435/d1f4d869-df98-4513-a4ed-42c9c1677e9e)

After Change:
![image](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.WebUI/assets/121869435/44a42cbb-4df5-4c51-9752-464c255cd126)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
