### PR TITLE
TD-4252: elearning resource is marked completed when the elearning re…

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/Api/ResourceController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/Api/ResourceController.cs
@@ -97,15 +97,6 @@ namespace LearningHub.Nhs.WebUI.Controllers.Api
             var file = await this.fileService.DownloadFileAsync(filePath, fileName);
             if (file != null)
             {
-                var activity = new CreateResourceActivityViewModel()
-                {
-                    ResourceVersionId = resourceVersionId,
-                    NodePathId = nodePathId,
-                    ActivityStart = DateTime.UtcNow, // TODO: What about user's timezone offset when Javascript is disabled? Needs JavaScript.
-                    ActivityStatus = ActivityStatusEnum.Completed,
-                };
-                await this.activityService.CreateResourceActivityAsync(activity);
-
                 return this.File(file.Content, file.ContentType, fileName);
             }
             else


### PR DESCRIPTION
…source is downloaded

### JIRA link
https://hee-tis.atlassian.net/browse/TD-4252

### Description
When an eLearning resource is downloaded, it should not log this as “completed” in the activity table. 
### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
