### PR TITLE
disable script build for TD-4211

### DIFF
--- a/WebAPI/LearningHub.Nhs.Database/LearningHub.Nhs.Database.sqlproj
+++ b/WebAPI/LearningHub.Nhs.Database/LearningHub.Nhs.Database.sqlproj
@@ -518,7 +518,7 @@
     <None Include="Scripts\Post-Deploy\Scripts\TD-2929_ActivityStatusUpdates.sql" />
     <Build Include="Stored Procedures\Resources\BlockCollectionFileSearch.sql" />
     <None Include="Scripts\Post-Deploy\Scripts\TD-4031_AMStoMKIOMigration.sql" />
-    <Build Include="Scripts\Post-Deploy\Scripts\TD-4270_Archive_LogDb.sql" />
+    <None Include="Scripts\Post-Deploy\Scripts\TD-4270_Archive_LogDb.sql" />
     <Build Include="Stored Procedures\Resources\GetPopularDashboardResources.sql" />
     <Build Include="Stored Procedures\Resources\GetRatedDashboardResources.sql" />
     <Build Include="Stored Procedures\Resources\GetMyCertificatesDashboardResources.sql" />


### PR DESCRIPTION
### JIRA link
TD-4211

### Description
This script will now have to be manually executed against the db

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
