### PR TITLE
TD-3707: In Assessments - fixed issue on first question expanding after all questions answered.

### DIFF
--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/resource/blocks/BlocksView.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/resource/blocks/BlocksView.vue
@@ -35,6 +35,7 @@
                            :firstUnansweredQuestion="pagesProgress.map((e, i) => i < questionInFocus || e).findIndex(p => !p) === index"
                            :isQuestionInFocus="questionInFocus === index"
                            :answerInOrder="answerInOrder"
+                           :allQuestAnswered="allQuestionsAnswered"
                            @updateQuestionProgress="isComplete => pushUpdate(index, isComplete)"
                            @nextPage="$emit('nextPage')"
                            @submitAssessmentAnswers="answers => $emit(`submitAssessmentAnswers`, answers, block.blockRef)"

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/resource/blocks/QuestionBlock.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/resource/blocks/QuestionBlock.vue
@@ -179,7 +179,8 @@
             isQuestionInFocus: { type: Boolean, default: false },
             firstUnansweredQuestion: Boolean,
             matchQuestionsState: { type: Array } as PropOptions<MatchQuestionState[]>,
-            answerInOrder: Boolean
+            answerInOrder: Boolean,
+            allQuestAnswered: { type: Boolean, default: false }
         },
         components: {
             MatchGameSubmissionView,
@@ -268,6 +269,9 @@
             },
             isQuestionInFocus(value) {
                 this.isOpen = value;
+                if (this.allQuestAnswered) {
+                    this.isOpen = false;
+                }
             }
         },
         methods: {


### PR DESCRIPTION

### JIRA link
_[TD-3707](https://hee-tis.atlassian.net/browse/TD-3707)_

### Description
In Assessments fixed issue on first question expanding after all questions answered.

### Screenshots
After
<img width="901" alt="After" src="https://github.com/user-attachments/assets/d339f239-c86d-4856-b74f-200e5cd9c29c">


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-3707]: https://hee-tis.atlassian.net/browse/TD-3707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ