### PR TITLE
TD-3308 : Added additional error message on the contribute screen

### DIFF
--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/ContentCommon.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/ContentCommon.vue
@@ -86,6 +86,12 @@
                 <div class="col-12 mb-0 error-text" v-if="keywordError">
                     <span class="text-danger">This keyword has already been added.</span>
                 </div>
+                <div class="col-12 mb-0 error-text" v-if="keywordLengthExceeded">
+                    <span class="text-danger">
+                        Each keyword must be no longer than 50 characters.
+                    </span>
+                </div>
+
                 <div class="col-12">
                     To help learners find this resource, type one or more relevant keywords separated by commas and click 'Add'.
                 </div>
@@ -285,6 +291,7 @@
                 editorConfig: { toolbar: CKEditorToolbar.default, versionCheck: false },
                 ResourceType,
                 resourceProviderId: null,
+                keywordLengthExceeded: false,
             };
         },
         computed: {
@@ -477,6 +484,7 @@
                 },
                 keywordChange() {
                     this.keywordError = false;
+                    this.keywordLengthExceeded = false;
                 },
                 resetSelectedLicence() {
                     this.resourceLicenceId = 0;
@@ -546,6 +554,10 @@
                                         this.keywordError = true;
                                         break;
                                     }
+                                }
+                                else {
+                                    this.keywordLengthExceeded = true;
+                                    break;
                                 }
                             }
                         }


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3308

### Description
Implemented additional validation message , if the user enter a keywords with more than 50 characters. 
![image](https://github.com/user-attachments/assets/e6c98839-a711-485e-8f93-0d7e49abbed4)


### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
