### PR TITLE
TD-4421 : Fixed issue on recording resource activity for resource type 'Files' when downloaded.

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/Api/ResourceController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/Api/ResourceController.cs
@@ -97,6 +97,14 @@ namespace LearningHub.Nhs.WebUI.Controllers.Api
             var file = await this.fileService.DownloadFileAsync(filePath, fileName);
             if (file != null)
             {
+                var activity = new CreateResourceActivityViewModel()
+                {
+                    ResourceVersionId = resourceVersionId,
+                    NodePathId = nodePathId,
+                    ActivityStart = DateTime.UtcNow, // TODO: What about user's timezone offset when Javascript is disabled? Needs JavaScript.
+                    ActivityStatus = ActivityStatusEnum.Completed,
+                };
+                await this.activityService.CreateResourceActivityAsync(activity);
                 return this.File(file.Content, file.ContentType, fileName);
             }
             else

--- a/LearningHub.Nhs.WebUI/Views/Resource/Resource.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Resource/Resource.cshtml
@@ -235,7 +235,7 @@
 
                         @{
                             var file = resource.ScormDetails.File;
-                            var downloadAndRecordLink = $"/api/resource/DownloadResourceAndRecordActivity?resourceVersionId={resource.ResourceVersionId}&nodePathId={resource.NodePathId}&filePath={file.FilePath}&fileName={Uri.EscapeDataString(file.FileName)}";
+                            var downloadAndRecordLink = $"/api/resource/DownloadResource?filePath={file.FilePath}&fileName={Uri.EscapeDataString(file.FileName)}";
                         }
                         @if (!(User.IsInRole("BasicUser") && resource.ResourceAccessibilityEnum == ResourceAccessibilityEnum.FullAccess))
                         {


### PR DESCRIPTION

### JIRA link
_[TD-4421](https://hee-tis.atlassian.net/browse/TD-4421)_

### Description
Fixed issue on recording resource activity for resource type 'Files' when downloaded. Also, redirected the method for downloading elearning resources.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4421]: https://hee-tis.atlassian.net/browse/TD-4421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ