### PR TITLE
TD-4420: Issue viewing the resource when republished the HTML resourc…

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/ResourceController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/ResourceController.cs
@@ -437,12 +437,13 @@
         /// View HTML resource content.
         /// </summary>
         /// <param name="resourceReferenceId">Resource reference id.</param>
+        /// <param name="currentResourceVersionId">Resource version id.</param>
         /// <param name="path">Html resource content relative path.</param>
         /// <returns>The file content.</returns>
         [HttpGet]
         [Authorize]
-        [Route("resource/html/{resourceReferenceId}/{*path}")]
-        public async Task<IActionResult> HtmlResourceContent(int resourceReferenceId, string path)
+        [Route("resource/html/{resourceReferenceId}/{CurrentResourceVersionId}/{*path}")]
+        public async Task<IActionResult> HtmlResourceContent(int resourceReferenceId, int currentResourceVersionId, string path)
         {
             if (resourceReferenceId == 0 || string.IsNullOrWhiteSpace(path))
             {
@@ -452,8 +453,14 @@
             var userId = this.User.Identity.GetCurrentUserId();
             var cacheKey = $"HtmlContent:{userId}:{resourceReferenceId}";
             var (cacheExists, cacheValue) = await this.cacheService.TryGetAsync<string>(cacheKey);
+            var oldresourceVersionId = 0;
+            if (cacheExists)
+            {
+                var cachesplits = cacheValue.Split(":");
+                oldresourceVersionId = int.Parse(cachesplits[0]);
+            }
 
-            if (!cacheExists)
+            if (!cacheExists || (oldresourceVersionId != currentResourceVersionId))
             {
                 var resource = await this.resourceService.GetItemByIdAsync(resourceReferenceId);
 

--- a/LearningHub.Nhs.WebUI/Views/Resource/_ResourceItem.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Resource/_ResourceItem.cshtml
@@ -112,7 +112,7 @@
                 {
                     <div id="resourcePg" class="nhsuk-card nhsuk-bg-light-blue">
                         <div class="nhsuk-card__content">
-                            <a v-on:click=checkUserCertificateAvailability(@resourceItem.Id) href="@($"{Context.Request.Scheme}://{Context.Request.Host}/resource/html/{resourceItem.Id}/index.html")"
+                            <a v-on:click=checkUserCertificateAvailability(@resourceItem.Id) href="@($"{Context.Request.Scheme}://{Context.Request.Host}/resource/html/{resourceItem.Id}/{resourceItem.ResourceVersionId}/index.html")"
                                onclick="@($"window.open(this.href, 'scormDebugWindow', 'status=no,location=no,toolbar=no,menubar=no,dependent=no,width={resourceItem.HtmlDetails.PopupWidth},height={resourceItem.HtmlDetails.PopupHeight}'); return false;")">
                                 <button class="nhsuk-button">
                                     Launch HTML resource


### PR DESCRIPTION
…e second time

### JIRA link
https://hee-tis.atlassian.net/browse/TD-4420

### Description
Resolved the issue with viewing the resource after republishing the HTML resource a second time.

### Screenshots
Before change:

![image](https://github.com/user-attachments/assets/ca829278-c1e2-4bf4-984f-d2b5e039d541)


After change:

![image](https://github.com/user-attachments/assets/38b0eae4-277c-46da-af5f-881314d97961)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
