### PR TITLE
TD-4401 Add fallback query for empty catalogues

### DIFF
--- a/WebAPI/LearningHub.Nhs.Repository/Hierarchy/CatalogueNodeVersionRepository.cs
+++ b/WebAPI/LearningHub.Nhs.Repository/Hierarchy/CatalogueNodeVersionRepository.cs
@@ -340,6 +340,27 @@
                              Hidden = n2.Hidden,
                              RootNodePathId = n2.NodePaths.Where(np => np.NodeId == np.CatalogueNodeId).FirstOrDefault().Id,
                          }).ToListAsync();
+
+            if (catalogues.Count == 0)
+            {
+                catalogues = await (from np in this.DbContext.NodePath.AsNoTracking()
+                             join n in this.DbContext.Node.AsNoTracking() on np.CatalogueNodeId equals n.Id
+                             join nv in this.DbContext.NodeVersion.AsNoTracking() on n.CurrentNodeVersionId equals nv.Id
+                             join cnv in this.DbContext.CatalogueNodeVersion.AsNoTracking() on nv.Id equals cnv.NodeVersionId
+                             where np.Id == nodePathId && nv.VersionStatusEnum == VersionStatusEnum.Published
+                             select new CatalogueBasicViewModel
+                             {
+                                 Id = cnv.Id,
+                                 NodeId = nv.NodeId,
+                                 BadgeUrl = cnv.BadgeUrl,
+                                 Name = cnv.Name,
+                                 Url = cnv.Url,
+                                 RestrictedAccess = cnv.RestrictedAccess,
+                                 Hidden = n.Hidden,
+                                 RootNodePathId = n.NodePaths.Where(np => np.NodeId == np.CatalogueNodeId).FirstOrDefault().Id,
+                             }).ToListAsync();
+            }
+
             return catalogues;
         }
 


### PR DESCRIPTION
Implemented a conditional check to address scenarios where the initial query to fetch catalogues yields an empty list. In such cases, a secondary, more targeted query is executed. This alternative query returns the original catalogue based on `NodePathId` to ensure at least one catalogue is returned.

### JIRA link
TD-4401

### Description
_Describe what has changed and how that will affect the app. If relevant, add references to the resources you used. Use this as your opportunity to highlight anything odd and give people context around particular decisions._

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
