### PR TITLE
TD-4411: Fixed filter result for 'Completed' filter along with 'Assessment'.

### DIFF
--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivities.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivities.sql
@@ -300,7 +300,6 @@ FROM (
 													)
 										
 											)
-										  -- OR	([Res].[ResourceTypeId]  IN (11) AND  [ResourceActivity].[ActivityStatusId] = 3 AND [AssessResVer].[AssessmentType]=1)
 										--OR         
 										--(
 										--		([Res].[ResourceTypeId] IN (1,5,10,12) AND  [ResourceActivity].[ActivityStatusId] = 3)

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivities.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivities.sql
@@ -300,12 +300,6 @@ FROM (
 													)
 										
 											)
-										--OR         
-										--(
-										--		([Res].[ResourceTypeId] IN (1,5,10,12) AND  [ResourceActivity].[ActivityStatusId] = 3)
-										--	  AND
-										--		([Res].[ResourceTypeId] NOT IN (2,7,8) AND  [ResourceActivity].[ActivityStatusId] = 3)
-										--)
 									)
 						)
 						OR	

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivities.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivities.sql
@@ -10,6 +10,7 @@
 -- Sarathlal	08-03-2024
 -- Sarathlal	23-04-2024 TD-2954: Audio/Video/Assessment issue resolved and duplicate issue also resolved
 -- Sarathlal	25-04-2024 TD-4067: Resource with muliple version issue resolved
+-- Arunima		26-07-2024 TD-4411: "Completed" filter along with "Assessment" doesn't display the correct results
 -------------------------------------------------------------------------------
 CREATE PROCEDURE [activity].[GetUserLearningActivities] (
 	 @userId INT	
@@ -271,8 +272,35 @@ FROM (
 												)
 										  )
 										  OR
-												([Res].[ResourceTypeId]  IN (6,11) AND  [ResourceActivity].[ActivityStatusId] = 3)
-										  OR	([Res].[ResourceTypeId]  IN (11) AND  [ResourceActivity].[ActivityStatusId] = 3 AND [AssessResVer].[AssessmentType]=1)
+												([Res].[ResourceTypeId]  IN (6) AND  [ResourceActivity].[ActivityStatusId] = 3)
+										OR (
+												EXISTS (SELECT 1 FROM @tmpActivityStatus WHERE ActivityStatusId = 3)
+												AND
+													(
+														[Res].[ResourceTypeId] = 11 AND [AssessResVer].[AssessmentType]=1
+														AND
+														EXISTS
+															(
+																SELECT 1
+																FROM   [activity].[AssessmentResourceActivity] AS [AssessmentResourceActivity6]
+																WHERE  
+																[AssessmentResourceActivity6].[Deleted] = 0
+																AND    
+																[ResourceActivity].[Id] = [AssessmentResourceActivity6].[ResourceActivityId]
+															)
+														AND 
+															(
+																(SELECT TOP(1)
+																[AssessmentResourceActivity7].[Score]
+																FROM   [activity].[AssessmentResourceActivity] AS [AssessmentResourceActivity7]
+																WHERE  
+																[AssessmentResourceActivity7].[Deleted] = 0
+																AND    [ResourceActivity].[Id] = [AssessmentResourceActivity7].[ResourceActivityId]) >= 0.0
+															)
+													)
+										
+											)
+										  -- OR	([Res].[ResourceTypeId]  IN (11) AND  [ResourceActivity].[ActivityStatusId] = 3 AND [AssessResVer].[AssessmentType]=1)
 										--OR         
 										--(
 										--		([Res].[ResourceTypeId] IN (1,5,10,12) AND  [ResourceActivity].[ActivityStatusId] = 3)
@@ -507,5 +535,3 @@ LEFT JOIN (
 ORDER BY [t2].[ActivityStart] DESC, [t2].[Id], [t2].[Id0], [t2].[Id1], [t2].[Id2], [VideoResourceVersion].[Id], [AudeoResourceVersion].[Id], [t3].[Id], [t4].[Id], [t5].[Id], [t6].[Id], [t7].[Id], [t8].[Id], [t9].[Id], [t10].[Id], [t11].[Id]
 		
 END
-
-

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivities.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivities.sql
@@ -10,7 +10,7 @@
 -- Sarathlal	08-03-2024
 -- Sarathlal	23-04-2024 TD-2954: Audio/Video/Assessment issue resolved and duplicate issue also resolved
 -- Sarathlal	25-04-2024 TD-4067: Resource with muliple version issue resolved
--- Arunima		26-07-2024 TD-4411: "Completed" filter along with "Assessment" doesn't display the correct results
+-- Arunima	26-07-2024 TD-4411: "Completed" filter along with "Assessment" doesn't display the correct results
 -------------------------------------------------------------------------------
 CREATE PROCEDURE [activity].[GetUserLearningActivities] (
 	 @userId INT	

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivities.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivities.sql
@@ -300,6 +300,12 @@ FROM (
 													)
 										
 											)
+											--OR         
+										--(
+										--		([Res].[ResourceTypeId] IN (1,5,10,12) AND  [ResourceActivity].[ActivityStatusId] = 3)
+										--	  AND
+										--		([Res].[ResourceTypeId] NOT IN (2,7,8) AND  [ResourceActivity].[ActivityStatusId] = 3)
+										--)
 									)
 						)
 						OR	

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivitiesCount.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivitiesCount.sql
@@ -9,6 +9,7 @@
 -- Sarathlal	18-12-2023
 -- Sarathlal	08-03-2024
 -- Sarathlal	23-04-2024	TD-2954: Audio/Video/Assessment issue resolved and duplicate issue also resolved
+-- Arunima		26-07-2024  TD-4411: "Completed" filter along with "Assessment" doesn't display the correct results
 -------------------------------------------------------------------------------
 CREATE PROCEDURE [activity].[GetUserLearningActivitiesCount] (
 	 @userId INT	
@@ -186,8 +187,35 @@ FROM (
 												)
 										  )
 										  OR
-												([Res].[ResourceTypeId]  IN (6,11) AND  [ResourceActivity].[ActivityStatusId] = 3)
-												 OR	([Res].[ResourceTypeId]  IN (11) AND  [ResourceActivity].[ActivityStatusId] = 3 AND [AssessResVer].[AssessmentType]=1)
+												([Res].[ResourceTypeId]  IN (6) AND  [ResourceActivity].[ActivityStatusId] = 3)
+										  OR (
+												EXISTS (SELECT 1 FROM @tmpActivityStatus WHERE ActivityStatusId = 3)
+												AND
+													(
+														[Res].[ResourceTypeId] = 11 AND [AssessResVer].[AssessmentType]=1
+														AND
+														EXISTS
+															(
+																SELECT 1
+																FROM   [activity].[AssessmentResourceActivity] AS [AssessmentResourceActivity6]
+																WHERE  
+																[AssessmentResourceActivity6].[Deleted] = 0
+																AND    
+																[ResourceActivity].[Id] = [AssessmentResourceActivity6].[ResourceActivityId]
+															)
+														AND 
+															(
+																(SELECT TOP(1)
+																[AssessmentResourceActivity7].[Score]
+																FROM   [activity].[AssessmentResourceActivity] AS [AssessmentResourceActivity7]
+																WHERE  
+																[AssessmentResourceActivity7].[Deleted] = 0
+																AND    [ResourceActivity].[Id] = [AssessmentResourceActivity7].[ResourceActivityId]) >= 0.0
+															)
+													)
+										
+											)
+												 --OR	([Res].[ResourceTypeId]  IN (11) AND  [ResourceActivity].[ActivityStatusId] = 3 AND [AssessResVer].[AssessmentType]=1)
 
 										--OR         
 										--(

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivitiesCount.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivitiesCount.sql
@@ -215,14 +215,6 @@ FROM (
 													)
 										
 											)
-												 --OR	([Res].[ResourceTypeId]  IN (11) AND  [ResourceActivity].[ActivityStatusId] = 3 AND [AssessResVer].[AssessmentType]=1)
-
-										--OR         
-										--(
-										--		([Res].[ResourceTypeId] IN (1,5,10,12) AND  [ResourceActivity].[ActivityStatusId] = 3)
-										--	  AND
-										--		([Res].[ResourceTypeId] NOT IN (2,7,8) AND  [ResourceActivity].[ActivityStatusId] = 3)
-										--)
 									)
 						)
 						OR	

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivitiesCount.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivitiesCount.sql
@@ -215,6 +215,12 @@ FROM (
 													)
 										
 											)
+											--OR         
+										--(
+										--		([Res].[ResourceTypeId] IN (1,5,10,12) AND  [ResourceActivity].[ActivityStatusId] = 3)
+										--	  AND
+										--		([Res].[ResourceTypeId] NOT IN (2,7,8) AND  [ResourceActivity].[ActivityStatusId] = 3)
+										--)
 									)
 						)
 						OR	

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivitiesCount.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivitiesCount.sql
@@ -9,7 +9,7 @@
 -- Sarathlal	18-12-2023
 -- Sarathlal	08-03-2024
 -- Sarathlal	23-04-2024	TD-2954: Audio/Video/Assessment issue resolved and duplicate issue also resolved
--- Arunima		26-07-2024  TD-4411: "Completed" filter along with "Assessment" doesn't display the correct results
+-- Arunima	26-07-2024  TD-4411: "Completed" filter along with "Assessment" doesn't display the correct results
 -------------------------------------------------------------------------------
 CREATE PROCEDURE [activity].[GetUserLearningActivitiesCount] (
 	 @userId INT	


### PR DESCRIPTION

### JIRA link
_[TD-4411](https://hee-tis.atlassian.net/browse/TD-4411)_

### Description
Fixed the issue related to the result getting for 'Completed' filter along with 'Assessment' filter in MyLearning page.

### Screenshots
After:
![image](https://github.com/user-attachments/assets/6ef22474-e692-40ae-9c21-9a9dee3d9000)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4411]: https://hee-tis.atlassian.net/browse/TD-4411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ