### PR TITLE
TD-3694-Fixes-For-HTML and  Case  Resource

### DIFF
--- a/AdminUI/LearningHub.Nhs.AdminUI/Helpers/LearningActivityHelper.cs
+++ b/AdminUI/LearningHub.Nhs.AdminUI/Helpers/LearningActivityHelper.cs
@@ -116,6 +116,12 @@
                     return "Played " + GetDurationText(myLearningDetailedItemViewModel.ActivityDurationSeconds * 1000);
                 case ResourceTypeEnum.WebLink:
                     return "Visited";
+                case ResourceTypeEnum.Html:
+                    return "Viewed";
+                case ResourceTypeEnum.Case:
+                    return "Accessed";
+                case ResourceTypeEnum.Assessment:
+                    return "Accessed";
                 default:
                     return string.Empty;
             }

--- a/LearningHub.Nhs.WebUI/Helpers/ViewActivityHelper.cs
+++ b/LearningHub.Nhs.WebUI/Helpers/ViewActivityHelper.cs
@@ -115,6 +115,12 @@
                     return "Played " + GetDurationText(activityDetailedItemViewModel.ActivityDurationSeconds * 1000);
                 case ResourceTypeEnum.WebLink:
                     return "Visited";
+                case ResourceTypeEnum.Html:
+                    return "Viewed";
+                case ResourceTypeEnum.Case:
+                    return "Accessed";
+                case ResourceTypeEnum.Assessment:
+                    return "Accessed";
                 default:
                     return string.Empty;
             }


### PR DESCRIPTION
### JIRA link
TD-3694

### Description
_After updating a resource, last accessed date not displayed on admin user learning record_

### Screenshots


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [X] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
