### PR TITLE
TD-4388-Assessment resource settings need a required field marker

### DIFF
--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/ContributeAssessmentSettings.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/ContributeAssessmentSettings.vue
@@ -65,15 +65,14 @@
 
                         <div class="d-flex">
                             <div class="selection pr-50">
-                                <div>Provide guidance for the learner at the end of this assessment.</div>
-                                <EditSaveFieldWithCharacterCount   
-                                                                    v-model="assessmentDetails.endGuidance.blocks[0].title"
-                                                                    addEditLabel="title"
-                                                                    v-bind:characterLimit="60"
-                                                                    v-bind:isH3="true" />
-                                <ckeditorwithhint v-on:blur="setEndGuidance" 
+                                <div>Provide guidance for the learner at the end of this assessment. <i class="warningTriangle fas fa-exclamation-triangle warm-yellow"></i></div>
+                                <EditSaveFieldWithCharacterCount v-model="assessmentDetails.endGuidance.blocks[0].title"
+                                                                 addEditLabel="title"
+                                                                 v-bind:characterLimit="60"
+                                                                 v-bind:isH3="true" />
+                                <ckeditorwithhint v-on:blur="setEndGuidance"
                                                   v-on:inputValidity="setGuidanceValidity"
-                                                  :maxLength="1000" 
+                                                  :maxLength="1000"
                                                   :initialValue="endGuidance" />
                             </div>
                             <div class="tip">


### PR DESCRIPTION
### JIRA link
[_TD-###_](https://hee-tis.atlassian.net/browse/TD-4388)

### Description
Assessment resource settings need a required field marker
### Screenshots
![image](https://github.com/user-attachments/assets/f39715e4-9f84-4daa-9f92-0430d27b3570)
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [X] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
