### PR TITLE
TD-4430 : Issue when adding duplicate keywords on 'Keywords' section when contributing resources and on Admin section

### DIFF
--- a/AdminUI/LearningHub.Nhs.AdminUI/Views/Catalogue/Edit.cshtml
+++ b/AdminUI/LearningHub.Nhs.AdminUI/Views/Catalogue/Edit.cshtml
@@ -162,6 +162,11 @@
             <span class="input-validation-error keyword-maxlength" style="display: none;">The maximum length is 50 characters.</span>
           </div>
         </div>
+        <div class="row">
+          <div class="col-12">
+            <span id="keyword-error-span" class="field-validation-error" style="display: none;"></span>
+          </div>
+        </div>
 
       </div>
       <div class="col-12">
@@ -341,6 +346,9 @@
         } else {
           $('#add-keyword').removeAttr('disabled');
         }
+
+        $('#keyword-error-span').hide();
+        $('#keyword-error-span').html('');
       });
 
       $('#add-keyword').on('click', function () {
@@ -355,6 +363,8 @@
           return item.trim();
         });
 
+        var duplicateKeywords = [];
+        $('#keyword-error-span').hide();
         values.forEach(function (value) {
           if (value && keywords.indexOf(value) === -1) {
             keywords.push(value);
@@ -367,6 +377,12 @@
             $('.keyword-value').each(function (i, x) {
               $(x).attr('name', "Keywords[" + i + "]");
             });
+          }
+          else
+          {
+            duplicateKeywords.push(value);
+            $('#keyword-error-span').show();
+            $('#keyword-error-span').html('The keyword(s) have already been added : ' + duplicateKeywords.join(', '))
           }
         });
 

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/components/KeyWordsEditor.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/components/KeyWordsEditor.vue
@@ -4,7 +4,7 @@
         <div class="row">
             <div class="form-group" v-bind:class="{ 'input-validation-error': keywordError }">
                 <div class="col-12 mb-0 error-text" v-if="keywordError">
-                    <span class="text-danger">This keyword has already been added.</span>
+                    <span class="text-danger">The keyword(s) have already been added : {{formattedkeywordErrorMessage}}</span>
                 </div>
                 <div class="col-12 mb-0 error-text" v-if="keywordLengthExceeded">
                     <span class="text-danger">
@@ -60,6 +60,7 @@
                 newKeyword: '',
                 keywordError: false,
                 keywordLengthExceeded: false,
+                keywordErrorMessage: []
             }
         },
         computed: {
@@ -69,17 +70,20 @@
             newKeywordTrimmed(): string {
                 return this.newKeyword?.trim().replace(/ +(?= )/g, '').toLowerCase();
             },
+            formattedkeywordErrorMessage(): string {
+                return this.keywordErrorMessage.join(', ');
+            },
         },
         methods: {
             keywordChange() {
                 this.keywordError = false;
                 this.keywordLengthExceeded = false;
+                this.keywordErrorMessage = [];
             },
             async addKeyword() {  
                 if (this.newKeyword && this.newKeywordTrimmed.length > 0) {
                     let allTrimmedKeyword = this.newKeywordTrimmed.toLowerCase().split(',');
                     allTrimmedKeyword = allTrimmedKeyword.filter(e => String(e).trim());
-                    if (!this.resourceDetails.resourceKeywords.find(_keyword => allTrimmedKeyword.includes(_keyword.keyword.toLowerCase()))) {
                         for (var i = 0; i < allTrimmedKeyword.length; i++) {
                             let item = allTrimmedKeyword[i];
                             if (item.length > 0 && item.length <= 50) {
@@ -90,8 +94,10 @@
                                 newKeywordObj = await resourceData.addKeyword(this.resourceVersionId, newKeywordObj);
                                 if (newKeywordObj.id > 0) {
                                     this.resourceDetails.resourceKeywords.push(newKeywordObj);
-                                    this.keywordError = false;
                                     this.newKeyword = '';
+                                } else if (newKeywordObj.id == 0) {
+                                    this.keywordError = true;
+                                    this.keywordErrorMessage.push(item);
                                 }
                                 else {
                                     this.keywordError = true;
@@ -103,10 +109,6 @@
                                 this.keywordLengthExceeded = true;
                             }
                         }
-                    }                    
-                    else {
-                        this.keywordError = true;
-                    }
                 }
             },
             async deleteKeyword(keywordId: number) {

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/ContentCommon.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/ContentCommon.vue
@@ -84,7 +84,7 @@
         <div class="row">
             <div class="form-group" v-bind:class="{ 'input-validation-error': keywordError }">
                 <div class="col-12 mb-0 error-text" v-if="keywordError">
-                    <span class="text-danger">This keyword has already been added.</span>
+                    <span class="text-danger">The keyword(s) have already been added : {{formattedkeywordErrorMessage}}</span>
                 </div>
                 <div class="col-12 mb-0 error-text" v-if="keywordLengthExceeded">
                     <span class="text-danger">
@@ -292,6 +292,7 @@
                 ResourceType,
                 resourceProviderId: null,
                 keywordLengthExceeded: false,
+                keywordErrorMessage:[]
             };
         },
         computed: {
@@ -339,6 +340,9 @@
                 } else {
                     return this.$store.state.userProviders.length > 0;
                 }
+            },
+            formattedkeywordErrorMessage(): string {
+                return this.keywordErrorMessage.join(', ');
             },
         },
         created() {
@@ -485,6 +489,7 @@
                 keywordChange() {
                     this.keywordError = false;
                     this.keywordLengthExceeded = false;
+                    this.keywordErrorMessage = [];
                 },
                 resetSelectedLicence() {
                     this.resourceLicenceId = 0;
@@ -534,7 +539,6 @@
                     if (this.newKeyword && this.newKeywordTrimmed.length > 0) {
                         let allTrimmedKeyword = this.newKeywordTrimmed.toLowerCase().split(',');
                         allTrimmedKeyword = allTrimmedKeyword.filter(e => String(e).trim());
-                        if (!this.keywords.find(_keyword => allTrimmedKeyword.includes(_keyword.keyword.toLowerCase()))) {
                             for (var i = 0; i < allTrimmedKeyword.length; i++) {
                                 let item = allTrimmedKeyword[i];
                                 if (item.length > 0 && item.length <= 50) {
@@ -548,22 +552,21 @@
                                         if (this.resourceDetail.resourceVersionId == 0) {
                                             this.$store.commit('setResourceVersionId', newkeywordObj.resourceVersionId)
                                         }
-                                        this.keywordError = false;
                                         this.newKeyword = '';
-                                    } else {
+                                    } else if (newkeywordObj.id == 0) {
+                                        this.keywordError = true;
+                                        this.keywordErrorMessage.push(item);
+                                    }
+                                    else {
                                         this.keywordError = true;
                                         break;
-                                    }
+                                }
                                 }
                                 else {
                                     this.keywordLengthExceeded = true;
                                     break;
                                 }
                             }
-                        }
-                        else {
-                            this.keywordError = true;
-                        }
                     }
                     else {
                         this.newKeyword = '';

--- a/WebAPI/LearningHub.Nhs.Services/ResourceService.cs
+++ b/WebAPI/LearningHub.Nhs.Services/ResourceService.cs
@@ -1772,7 +1772,8 @@ namespace LearningHub.Nhs.Services
             bool doesKeywordAlreadyExist = await this.resourceVersionKeywordRepository.DoesResourceVersionKeywordAlreadyExistAsync(rvk.ResourceVersionId, rvk.Keyword);
             if (doesKeywordAlreadyExist)
             {
-                return new LearningHubValidationResult(false, "This keyword has already been added.");
+                retVal.CreatedId = 0;
+                return retVal;
             }
 
             retVal.CreatedId = await this.resourceVersionKeywordRepository.CreateAsync(userId, rvk);


### PR DESCRIPTION

### JIRA link
_[TD-4430](https://hee-tis.atlassian.net/browse/TD-4430)_

### Description
Fixed duplicate keywords issue in WebUI including case and assessment page and AdminUI.

### Screenshots
After
![image](https://github.com/user-attachments/assets/df71bcaa-a3ed-4fcf-9dba-fee0d2c0a32e)

![image](https://github.com/user-attachments/assets/fa7d7260-366c-41ca-aed1-784a1c855978)

![image](https://github.com/user-attachments/assets/c49aa28a-0dc4-490e-9962-b1c1c3364520)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4430]: https://hee-tis.atlassian.net/browse/TD-4430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ