### PR TITLE
TD-3694-defect fix for URL  Issue

### DIFF
--- a/AdminUI/LearningHub.Nhs.AdminUI/Views/User/_UserLearningRecord.cshtml
+++ b/AdminUI/LearningHub.Nhs.AdminUI/Views/User/_UserLearningRecord.cshtml
@@ -36,7 +36,7 @@
         <tr>
           <td>
             <span class="nhsuk-u-text-align-left table-content-spacing">
-              @if (userLearningRecord.ResourceReferenceId > 0 && userLearningRecord.VersionStatusId != (int?)VersionStatusEnum.Unpublished)
+              @if (userLearningRecord.IsCurrentResourceVersion && userLearningRecord.ResourceReferenceId > 0 && userLearningRecord.VersionStatusId != (int?)VersionStatusEnum.Unpublished)
               {
                 <span>
                   <a class="learning-td" href="@resourceUrl/@userLearningRecord.ResourceReferenceId" target="_blank">@userLearningRecord.Title</a><br />
@@ -47,6 +47,7 @@
               {
                 <span class="learning-td">
                   @userLearningRecord.Title
+                  <b>Last @LearningActivityHelper.GetResourceTypeVerb(userLearningRecord).ToLower() on : </b>  @userLearningRecord.ActivityDate.DateTime.ToString("dd MMM yyyy") at @userLearningRecord.ActivityDate.DateTime.ToShortTimeString()<br />
                 </span>
 
               }


### PR DESCRIPTION
### JIRA link
TD-3694

### Description
Prior to any fixes, the Admin user learning record page removed the hyperlink for old versions of resources, as per the my learning page. 
Now a fix has been applied, there is a hyperlink for all admin user learning records, even if the resource has been updated. If you select the hyperlink on a record of a resource that has since been updated, it takes you to the latest version (which can be seen on Seema’s video).

Suggest removing hyperlinks on updated resources as per the my learning page. 

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
