### PR TITLE
TD-4412: Moving a folder/resource from a referenced path should remov…

### DIFF
--- a/AdminUI/LearningHub.Nhs.AdminUI/Scripts/vuesrc/content-structure/contentStructureState.ts
+++ b/AdminUI/LearningHub.Nhs.AdminUI/Scripts/vuesrc/content-structure/contentStructureState.ts
@@ -457,6 +457,11 @@ const actions = <ActionTree<State, any>>{
             await refreshNodeContents(payload.destinationNode, true).then(async x => {
                 await refreshNodeContents(state.editingTreeNode.parent, true).then(y => {
                 });
+                state.rootNode.children.forEach(async (child) => {
+                    if (child.nodeId != null) {
+                        await refreshNodeContents(child, false);
+                    }
+                });
             });
         }).catch(e => {
             state.inError = true;
@@ -509,8 +514,9 @@ const actions = <ActionTree<State, any>>{
         state.inError = false;
         contentStructureData.removeReferenceNode(payload.node.hierarchyEditDetailId).then(async response => {
             await refreshNodeContents(payload.node.parent, false);
-            await refreshNodeContents(payload.node.parent.parent, false);
-            await refreshNodeIfMatchingNodeId(payload.node.parent, state.editingTreeNode.nodeId, state.editingTreeNode.hierarchyEditDetailId);
+            if (payload.node.parent.parent != null) {
+                await refreshNodeContents(payload.node.parent.parent, false);
+            }
         }).catch(e => {
             state.inError = true;
             state.lastErrorMessage = "Error removing resource refrence.";

--- a/WebAPI/LearningHub.Nhs.Database/LearningHub.Nhs.Database.sqlproj
+++ b/WebAPI/LearningHub.Nhs.Database/LearningHub.Nhs.Database.sqlproj
@@ -522,6 +522,8 @@
     <Build Include="Stored Procedures\Resources\GetMyCertificatesDashboardResources.sql" />
     <Build Include="Stored Procedures\Activity\GetResourceActivityPerResourceMajorVersion.sql" />
     <Build Include="Stored Procedures\Resources\GetAchievedCertificatedResourcesWithOptionalPagination.sql" />
+    <Build Include="Stored Procedures\Hierarchy\HierarchyEditRemoveNodeReferencesOnMoveNode.sql" />
+    <Build Include="Stored Procedures\Hierarchy\HierarchyEditRemoveResourceReferencesOnMoveResource.sql" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Scripts\Pre-Deploy\Scripts\Card5766_AuthorTableChanges.PreDeployment.sql" />

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/HierarchyEditMoveNode.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/HierarchyEditMoveNode.sql
@@ -10,6 +10,7 @@
 -- 13-05-2024  DB	Addition of ParentNodePathId to the update statement.
 -- 20-05-2024  DB	Added the creation of a new NodePath record for the moved node and update child nodes.
 -- 29-05-2024  DB	Clear the NodePathId for moved nodes. NodePaths can not be updated incase susequent references are made to the original path.
+-- 07-08-2024  SA   Remove all instance of the referenced path when moving a referenced folder
 -------------------------------------------------------------------------------
 CREATE PROCEDURE [hierarchy].[HierarchyEditMoveNode]
 (
@@ -278,7 +279,9 @@ BEGIN
 			AND rrdv.Deleted = 0
 			AND hed.Deleted = 0
 
+        -- Remove all instance of the referenced path when moving a referenced folder
 
+		 EXEC hierarchy.HierarchyEditRemoveNodeReferencesOnMoveNode @HierarchyEditDetailId,@UserId,@UserTimezoneOffset
 		------------------------------------------------------------ 
 		-- Refresh HierarchyEditNodeResourceLookup
 		------------------------------------------------------------

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/HierarchyEditMoveResource.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/HierarchyEditMoveResource.sql
@@ -6,6 +6,7 @@
 -- Modification History
 --
 -- 11-01-2022  KD	Initial Revision.
+-- 08-08-2024 SA    Remove all instance of the referenced path when moving a referenced resource
 -------------------------------------------------------------------------------
 CREATE PROCEDURE [hierarchy].[HierarchyEditMoveResource]
 (
@@ -26,8 +27,8 @@ BEGIN
 		DECLARE @AmendDate datetimeoffset(7) = ISNULL(TODATETIMEOFFSET(DATEADD(mi, @UserTimezoneOffset, GETUTCDATE()), @UserTimezoneOffset), SYSDATETIMEOFFSET())
 
 		DECLARE @HierarchyEditId int
-		DECLARE @ResourceId int
-		SELECT @HierarchyEditId = HierarchyEditId, @ResourceId = ResourceId FROM [hierarchy].[HierarchyEditDetail] WHERE Id = @HierarchyEditDetailId
+		DECLARE @ResourceId int, @ParentNodeId INT
+		SELECT @HierarchyEditId = HierarchyEditId, @ResourceId = ResourceId,@ParentNodeId = ParentNodeId FROM [hierarchy].[HierarchyEditDetail] WHERE Id = @HierarchyEditDetailId
 
 		-- Decrement display order of sibling resources with higher display order.
 		UPDATE 
@@ -170,8 +171,10 @@ BEGIN
 		WHERE	hed.Id = @HierarchyEditDetailId
 			AND rrdv.Deleted = 0
 			AND hed.Deleted = 0
+        
+		-- Remove all instance of the referenced path when moving a referenced resource
 
-
+		EXEC hierarchy.HierarchyEditRemoveResourceReferencesOnMoveResource @HierarchyEditDetailId,@ParentNodeId,@UserId,@UserTimezoneOffset
 		------------------------------------------------------------ 
 		-- Refresh HierarchyEditNodeResourceLookup
 		------------------------------------------------------------

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/HierarchyEditPublish.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/HierarchyEditPublish.sql
@@ -126,22 +126,22 @@ BEGIN
 			AND hed.Deleted = 0
 			AND nl.Deleted = 0
 
-			-- UPDATE  NodeLink 'deleted' for remove reference
+		-- UPDATE  NodeLink 'deleted' for remove reference
 
-			UPDATE 
-				nl
-			SET
-				Deleted = 1,
-				AmendUserId = @AmendUserId,
-				AmendDate = @AmendDate
-			FROM
-				hierarchy.HierarchyEditDetail hed
-			INNER JOIN
-				hierarchy.NodeLink nl ON hed.NodeLinkId = nl.Id
-			WHERE 
-				HierarchyEditId = @HierarchyEditId
-				AND hed.HierarchyEditDetailTypeId = 4 -- Node Link
-				AND hed.Deleted = 1
+		UPDATE 
+			nl
+		SET
+			Deleted = 1,
+			AmendUserId = @AmendUserId,
+			AmendDate = @AmendDate
+		FROM
+			hierarchy.HierarchyEditDetail hed
+		INNER JOIN
+			hierarchy.NodeLink nl ON hed.NodeLinkId = nl.Id
+		WHERE 
+			HierarchyEditId = @HierarchyEditId
+            AND hed.HierarchyEditDetailTypeId = 4 -- Node Link
+			AND hed.Deleted = 1
 
 		-- For moved nodes, delete the original NodeLinks, providing they have not been used (by a reference to the original position).
 		UPDATE 
@@ -236,6 +236,7 @@ BEGIN
 			AND HierarchyEditDetailTypeId = 5 -- Node Resource
 			AND NodeResourceId IS NULL
 			AND ISNULL(InitialParentNodeId, 0) != ParentNodeId
+			AND Deleted =0
 
 		-- Create publication log entries for cache updates related to MoveResource.
 		INSERT INTO [hierarchy].[PublicationLog] ([PublicationId],[NodeId],[Deleted],[CreateUserId],[CreateDate],[AmendUserId],[AmendDate])

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/HierarchyEditRemoveNodeReferencesOnMoveNode.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/HierarchyEditRemoveNodeReferencesOnMoveNode.sql
@@ -35,11 +35,6 @@ BEGIN
         FROM [hierarchy].[HierarchyEditDetail] hed
         WHERE hed.Id = @HierarchyEditDetailId
 
-        --SELECT @ReferenceHierarchyEditDetailId = hed.id,
-        --       @RootNodePathId = NodePathId
-        --FROM hierarchy.HierarchyEditDetail hed
-        --WHERE hed.NodeId = @CurrentNodeId
-        --      AND hed.Id != @HierarchyEditDetailId
         -- Declare the cursor
         DECLARE NodeCursor CURSOR FOR WITH RecursiveNodes
                                       AS (

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/HierarchyEditRemoveNodeReferencesOnMoveNode.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/HierarchyEditRemoveNodeReferencesOnMoveNode.sql
@@ -1,0 +1,169 @@
+﻿-------------------------------------------------------------------------------
+-- Author       Swapna Abraham
+-- Created      07-08-2024
+-- Purpose      Moving a folder from a referenced path should remove it from all instances of the referenced path
+--
+-- Modification History
+--
+-- 07-08-2024  SA	Initial Revision.
+-------------------------------------------------------------------------------
+CREATE PROCEDURE [hierarchy].[HierarchyEditRemoveNodeReferencesOnMoveNode]
+(
+    @HierarchyEditDetailId int,
+    @UserId int,
+    @UserTimezoneOffset int = NULL
+)
+AS
+BEGIN
+
+    BEGIN TRY
+
+        BEGIN TRAN
+
+        DECLARE @AmendDate datetimeoffset(7)
+            = ISNULL(
+                        TODATETIMEOFFSET(DATEADD(mi, @UserTimezoneOffset, GETUTCDATE()), @UserTimezoneOffset),
+                        SYSDATETIMEOFFSET()
+                    )
+
+        DECLARE @CurrentNodeId INT,
+                @ReferenceHierarchyEditDetailId INT,
+                @RootNodePathId INT,
+                @ChildHierachyEditDetailId INT
+
+        SELECT @CurrentNodeId = hed.NodeId
+        FROM [hierarchy].[HierarchyEditDetail] hed
+        WHERE hed.Id = @HierarchyEditDetailId
+
+        --SELECT @ReferenceHierarchyEditDetailId = hed.id,
+        --       @RootNodePathId = NodePathId
+        --FROM hierarchy.HierarchyEditDetail hed
+        --WHERE hed.NodeId = @CurrentNodeId
+        --      AND hed.Id != @HierarchyEditDetailId
+        -- Declare the cursor
+        DECLARE NodeCursor CURSOR FOR WITH RecursiveNodes
+                                      AS (
+                                         -- Anchor member: select the root node
+                                         SELECT id,
+                                                NodePathId,
+                                                ParentNodePathId
+                                         FROM hierarchy.HierarchyEditDetail
+                                         WHERE NodeId = @CurrentNodeId
+                                               AND Id != @HierarchyEditDetailId
+                                         UNION ALL
+
+                                         -- Recursive member: select child nodes
+                                         SELECT n.id,
+                                                n.NodePathId,
+                                                n.ParentNodePathId
+                                         FROM hierarchy.HierarchyEditDetail n
+                                             INNER JOIN RecursiveNodes rn
+                                                 ON n.ParentNodePathId = rn.NodePathId
+                                         )
+        SELECT Id AS ChildHierachyEditDetailId
+        FROM RecursiveNodes
+        order by Id
+
+        -- Open the cursor
+        OPEN NodeCursor;
+
+        -- Fetch the first row from the cursor
+        FETCH NEXT FROM NodeCursor
+        INTO @ChildHierachyEditDetailId;
+
+        -- Loop until no more rows are returned
+        WHILE @@FETCH_STATUS = 0
+        BEGIN
+            -- Execute the update statement for the current row
+            UPDATE hed
+            SET HierarchyEditDetailOperationId = CASE
+                                                     WHEN HierarchyEditDetailOperationId = 1 THEN
+                                                         HierarchyEditDetailOperationId
+                                                     ELSE
+                                                         5
+                                                 END, -- Remove reference
+                Deleted = 1,
+                AmendUserId = @UserId,
+                AmendDate = @AmendDate
+            FROM [hierarchy].[HierarchyEditDetail] hed
+            WHERE hed.Id = @ChildHierachyEditDetailId;
+
+            -- Fetch the next row from the cursor
+            FETCH NEXT FROM NodeCursor
+            INTO @ChildHierachyEditDetailId;
+        END
+
+        -- Close and deallocate the cursor
+        CLOSE NodeCursor;
+        DEALLOCATE NodeCursor;
+
+        -- Decrement display order of sibling nodes with higher display order
+
+        -- Declare the cursor
+        DECLARE HierarchyCursor CURSOR FOR
+        SELECT hed.Id AS ReferenceHierarchyEditDetailId
+        FROM hierarchy.HierarchyEditDetail hed
+        WHERE hed.NodeId = @CurrentNodeId
+              AND hed.Id != @HierarchyEditDetailId;
+
+        -- Open the cursor
+        OPEN HierarchyCursor;
+
+        -- Fetch the first row from the cursor
+        FETCH NEXT FROM HierarchyCursor
+        INTO @ReferenceHierarchyEditDetailId;
+
+        -- Loop through all rows fetched by the cursor
+        WHILE @@FETCH_STATUS = 0
+        BEGIN
+            -- Process each row
+            UPDATE hed
+            SET HierarchyEditDetailOperationId = CASE
+                                                     WHEN hed.HierarchyEditDetailOperationId IS NULL THEN
+                                                         2
+                                                     ELSE
+                                                         hed.HierarchyEditDetailOperationId
+                                                 END,
+                DisplayOrder = hed.DisplayOrder - 1,
+                AmendUserId = @UserId,
+                AmendDate = @AmendDate
+            FROM [hierarchy].[HierarchyEditDetail] hed
+                INNER JOIN [hierarchy].[HierarchyEditDetail] hed_remove
+                    ON hed.HierarchyEditId = hed_remove.HierarchyEditId
+                       AND hed.ParentNodeId = hed_remove.ParentNodeId
+            WHERE hed_remove.Id = @ReferenceHierarchyEditDetailId
+                  AND hed.DisplayOrder > hed_remove.DisplayOrder
+                  AND hed.ResourceId IS NULL
+                  AND hed.Deleted = 0
+
+            -- Fetch the next row from the cursor
+            FETCH NEXT FROM HierarchyCursor
+            INTO @ReferenceHierarchyEditDetailId;
+        END;
+
+        -- Close the cursor
+        CLOSE HierarchyCursor;
+
+        -- Deallocate the cursor
+        DEALLOCATE HierarchyCursor;
+
+        COMMIT
+
+    END TRY
+    BEGIN CATCH
+        DECLARE @ErrorMessage NVARCHAR(4000);
+        DECLARE @ErrorSeverity INT;
+        DECLARE @ErrorState INT;
+
+        SELECT @ErrorMessage = ERROR_MESSAGE(),
+               @ErrorSeverity = ERROR_SEVERITY(),
+               @ErrorState = ERROR_STATE();
+
+        IF @@TRANCOUNT > 0
+            ROLLBACK TRAN;
+
+        RAISERROR(@ErrorMessage, @ErrorSeverity, @ErrorState);
+
+    END CATCH
+END
+GO

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/HierarchyEditRemoveResourceReferencesOnMoveResource.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/HierarchyEditRemoveResourceReferencesOnMoveResource.sql
@@ -7,7 +7,7 @@
 --
 -- 08-08-2024  SA	Initial Revision.
 -------------------------------------------------------------------------------
-ALTER PROCEDURE [hierarchy].[HierarchyEditRemoveResourceReferencesOnMoveResource]
+CREATE PROCEDURE [hierarchy].[HierarchyEditRemoveResourceReferencesOnMoveResource]
 (
     @HierarchyEditDetailId int,
 	@ParentNodeId INT,
@@ -30,7 +30,6 @@ BEGIN
         DECLARE @CurrentResourceId INT,
                 @ReferenceHierarchyEditDetailId INT,
                 @RootNodePathId INT
-               -- @ChildHierachyEditDetailId INT
 
         SELECT @CurrentResourceId = hed.ResourceId
         FROM [hierarchy].[HierarchyEditDetail] hed
@@ -39,8 +38,6 @@ BEGIN
         -- Declare the cursor
         DECLARE NodeCursor CURSOR FOR 
                   SELECT Id AS ReferenceHierarchyEditDetailId
-                         --NodePathId,
-                         --ParentNodePathId
                   FROM hierarchy.HierarchyEditDetail
 				  WHERE ResourceId = @CurrentResourceId
 				        AND ParentNodeId = @ParentNodeId

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/HierarchyEditRemoveResourceReferencesOnMoveResource.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/HierarchyEditRemoveResourceReferencesOnMoveResource.sql
@@ -1,0 +1,121 @@
+﻿-------------------------------------------------------------------------------
+-- Author       Swapna Abraham
+-- Created      07-08-2024
+-- Purpose      Moving a resource from a referenced path should remove it from all instances of the referenced path
+--
+-- Modification History
+--
+-- 08-08-2024  SA	Initial Revision.
+-------------------------------------------------------------------------------
+ALTER PROCEDURE [hierarchy].[HierarchyEditRemoveResourceReferencesOnMoveResource]
+(
+    @HierarchyEditDetailId int,
+	@ParentNodeId INT,
+    @UserId int,
+    @UserTimezoneOffset int = NULL
+)
+AS
+BEGIN
+
+    BEGIN TRY
+
+        BEGIN TRAN
+
+        DECLARE @AmendDate datetimeoffset(7)
+            = ISNULL(
+                        TODATETIMEOFFSET(DATEADD(mi, @UserTimezoneOffset, GETUTCDATE()), @UserTimezoneOffset),
+                        SYSDATETIMEOFFSET()
+                    )
+
+        DECLARE @CurrentResourceId INT,
+                @ReferenceHierarchyEditDetailId INT,
+                @RootNodePathId INT
+               -- @ChildHierachyEditDetailId INT
+
+        SELECT @CurrentResourceId = hed.ResourceId
+        FROM [hierarchy].[HierarchyEditDetail] hed
+        WHERE hed.Id = @HierarchyEditDetailId
+
+        -- Declare the cursor
+        DECLARE NodeCursor CURSOR FOR 
+                  SELECT Id AS ReferenceHierarchyEditDetailId
+                         --NodePathId,
+                         --ParentNodePathId
+                  FROM hierarchy.HierarchyEditDetail
+				  WHERE ResourceId = @CurrentResourceId
+				        AND ParentNodeId = @ParentNodeId
+                        AND Id != @HierarchyEditDetailId                                                                                
+
+        -- Open the cursor
+        OPEN NodeCursor;
+
+        -- Fetch the first row from the cursor
+        FETCH NEXT FROM NodeCursor
+        INTO @ReferenceHierarchyEditDetailId;
+
+        -- Loop until no more rows are returned
+        WHILE @@FETCH_STATUS = 0
+        BEGIN
+            -- Execute the update statement for the current row
+            UPDATE hed
+            SET HierarchyEditDetailOperationId = CASE
+                                                     WHEN HierarchyEditDetailOperationId = 1 THEN
+                                                         HierarchyEditDetailOperationId
+                                                     ELSE
+                                                         5
+                                                 END, -- Remove reference
+                Deleted = 1,
+                AmendUserId = @UserId,
+                AmendDate = @AmendDate
+            FROM [hierarchy].[HierarchyEditDetail] hed
+            WHERE hed.Id = @ReferenceHierarchyEditDetailId;
+
+			UPDATE hed
+            SET HierarchyEditDetailOperationId = CASE
+                                                     WHEN hed.HierarchyEditDetailOperationId IS NULL THEN
+                                                         2
+                                                     ELSE
+                                                         hed.HierarchyEditDetailOperationId
+                                                 END,
+                DisplayOrder = hed.DisplayOrder - 1,
+                AmendUserId = @UserId,
+                AmendDate = @AmendDate
+            FROM [hierarchy].[HierarchyEditDetail] hed
+                INNER JOIN [hierarchy].[HierarchyEditDetail] hed_remove
+                    ON hed.HierarchyEditId = hed_remove.HierarchyEditId
+                       AND hed.ParentNodeId = hed_remove.ParentNodeId
+            WHERE hed_remove.Id = @ReferenceHierarchyEditDetailId
+                  AND hed.DisplayOrder > hed_remove.DisplayOrder
+                  AND hed.ResourceId IS NULL
+                  AND hed.Deleted = 0
+
+            -- Fetch the next row from the cursor
+            FETCH NEXT FROM NodeCursor
+            INTO @ReferenceHierarchyEditDetailId;
+        END
+
+        -- Close and deallocate the cursor
+        CLOSE NodeCursor;
+        DEALLOCATE NodeCursor;
+
+        COMMIT
+
+    END TRY
+    BEGIN CATCH
+        DECLARE @ErrorMessage NVARCHAR(4000);
+        DECLARE @ErrorSeverity INT;
+        DECLARE @ErrorState INT;
+
+        SELECT @ErrorMessage = ERROR_MESSAGE(),
+               @ErrorSeverity = ERROR_SEVERITY(),
+               @ErrorState = ERROR_STATE();
+
+        IF @@TRANCOUNT > 0
+            ROLLBACK TRAN;
+
+        RAISERROR(@ErrorMessage, @ErrorSeverity, @ErrorState);
+
+    END CATCH
+END
+
+GO


### PR DESCRIPTION
…e it from all instances of the referenced path

### JIRA link
https://hee-tis.atlassian.net/browse/TD-4412

### Description
While Moving a resource/folder from a referenced path should remove it from all instances of the referenced path.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
