### PR TITLE
TD-4394: Publishing catalogues needs to update referencing catalogues

### DIFF
--- a/WebAPI/LearningHub.Nhs.Database/LearningHub.Nhs.Database.sqlproj
+++ b/WebAPI/LearningHub.Nhs.Database/LearningHub.Nhs.Database.sqlproj
@@ -543,6 +543,7 @@
     <Build Include="Stored Procedures\Resources\GetScormContentServerDetailsForLHExternalReference.sql" />
     <None Include="Scripts\Post-Deploy\Scripts\Content_Referencing_DataSetup.sql" />
     <None Include="Scripts\Pre-Deploy\Scripts\Content Referencing Initialise.sql" />
+    <Build Include="Stored Procedures\Hierarchy\HierarchyNewNodePathForReferedCatalogue.sql" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Scripts\Pre-Deploy\Scripts\Card5766_AuthorTableChanges.PreDeployment.sql" />

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/HierarchyEditPublish.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/HierarchyEditPublish.sql
@@ -18,6 +18,7 @@
 -- 03-06-2024  DB	Publish NodePathDisplayVersion records.
 -- 13-06-2024  DB	Publish ResourceReferenceDisplayVersion records.
 -- 26-07-2024  SA   Remove references to be implemented
+-- 21-08-2024  SS	Publishing catalogues needs to update referencing catalogues
 -------------------------------------------------------------------------------
 CREATE PROCEDURE [hierarchy].[HierarchyEditPublish] 
 (
@@ -572,7 +573,11 @@ BEGIN
 			AND np.CatalogueNodeId != np.NodeId
 			AND hed.NodeId IS NULL
 
+	    ----------------------------------------------------------
+		-- NodePath: generate new NodePath/s for refered Catalogues
+		----------------------------------------------------------
 
+		EXEC [hierarchy].[HierarchyNewNodePathForReferedCatalogue] @HierarchyEditId,@AmendUserId,@AmendDate
 		----------------------------------------------------------
 		-- NodePathNode
 		----------------------------------------------------------		

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/HierarchyEditPublish.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/HierarchyEditPublish.sql
@@ -593,7 +593,7 @@ BEGIN
 		SET @NodePathCursor = CURSOR FORWARD_ONLY FOR
         SELECT  NodePathId, NodeId, ParentNodeId, InitialNodePath, NewNodePath, HierarchyEditDetailOperationId
         FROM    hierarchy.HierarchyEditDetail
-        WHERE   HierarchyEditId = 80
+        WHERE   HierarchyEditId = @HierarchyEditId
             AND ISNULL(InitialNodePath, '') != ISNULL(NewNodePath, InitialNodePath)
             AND (
                 HierarchyEditDetailTypeId = 4 -- Node Link

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/HierarchyNewNodePathForReferedCatalogue.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/HierarchyNewNodePathForReferedCatalogue.sql
@@ -1,0 +1,95 @@
+﻿-------------------------------------------------------------------------------
+-- Author       Sarathlal 
+-- Created      21-08-2024
+-- Purpose      Publishing catalogues needs to update referencing catalogues
+--
+-- Modification History
+-- 21-08-2024  SS	Initial version
+-------------------------------------------------------------------------------
+CREATE PROCEDURE [hierarchy].[HierarchyNewNodePathForReferedCatalogue]
+(
+	@HierarchyEditId INT,
+	@AmendUserId INT,
+	@AmendDate  datetimeoffset(7)
+)
+
+AS
+
+BEGIN
+	BEGIN TRY
+
+		BEGIN TRAN
+			DECLARE @NodePathId int
+			DECLARE @PrimaryCatalogueNodeId int
+			DECLARE @NodeId int
+			DECLARE @ParentNodeId int
+			DECLARE @NewNodePath as NVARCHAR(256)
+			DECLARE @DisplayOrder int
+			DECLARE @NewNodePathCursor as CURSOR
+			SET @NewNodePathCursor = CURSOR FORWARD_ONLY FOR
+				SELECT
+						PrimaryCatalogueNodeId,
+						ParentNodeId,
+						NodeId, 
+						hed.NewNodePath,
+						DisplayOrder,
+						NodePathId
+					FROM 
+						hierarchy.HierarchyEditDetail hed
+					WHERE
+						HierarchyEditId = @HierarchyEditId
+						AND 
+							(
+							HierarchyEditDetailTypeId = 4 -- Node Link
+							OR
+							HierarchyEditDetailTypeId = 3 -- Folder Node
+							)
+						AND (
+							HierarchyEditDetailOperationId = 1 -- Add
+							OR
+							HierarchyEditDetailOperationId = 2 -- Edit
+							)
+						AND NodeLinkId IS NULL
+						AND [Deleted] = 0
+			OPEN @NewNodePathCursor;
+					FETCH NEXT FROM @NewNodePathCursor INTO @PrimaryCatalogueNodeId,@ParentNodeId,@NodeId,@NewNodePath,@DisplayOrder,@NodePathId;
+						WHILE @@FETCH_STATUS = 0
+						BEGIN
+						IF NOT EXISTS (SELECT 1 FROM hierarchy.NodePath WHERE NodeId=@NodeId AND NodePath=NodePath+'\'+CAST(@NodeId AS VARCHAR(100)))
+							BEGIN
+								INSERT INTO hierarchy.NodePath (NodeId, NodePath, CatalogueNodeId, IsActive, Deleted, CreateUserId, CreateDate, AmendUserId, AmendDate)
+									SELECT @NodeId,NP.NodePath+'\'+CAST(@NodeId AS VARCHAR(100)),NP.CatalogueNodeId,1,0,@AmendUserId,@AmendDate,@AmendUserId,@AmendDate FROM 
+									hub.[fn_Split](@NewNodePath, '\') nodeInPath
+									INNER JOIN hierarchy.NodePath NP ON NP.NodeId=nodeInPath.value AND CatalogueNodeId!=@PrimaryCatalogueNodeId
+									WHERE nodeInPath.value=@ParentNodeId
+
+							END
+						
+
+						FETCH NEXT FROM @NewNodePathCursor INTO @PrimaryCatalogueNodeId,@ParentNodeId,@NodeId,@NewNodePath,@DisplayOrder,@NodePathId;
+
+					END
+
+			CLOSE @NewNodePathCursor;
+			DEALLOCATE @NewNodePathCursor;
+		COMMIT
+
+	END TRY
+	BEGIN CATCH
+	    DECLARE @ErrorMessage NVARCHAR(4000);  
+		DECLARE @ErrorSeverity INT;  
+		DECLARE @ErrorState INT;  
+  
+		SELECT   
+			@ErrorMessage = ERROR_MESSAGE(),  
+			@ErrorSeverity = ERROR_SEVERITY(),  
+			@ErrorState = ERROR_STATE();  
+  
+		IF @@TRANCOUNT > 0  
+			ROLLBACK TRAN;  
+
+		RAISERROR (@ErrorMessage, @ErrorSeverity, @ErrorState);  
+
+	END CATCH
+END
+GO


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4394

### Description
Publishing catalogues needs to update referencing catalogues

### Screenshots
**_Scenarios checked:_**

1. Created 2 Catalogues Ext1 and Ext2
                ![image](https://github.com/user-attachments/assets/65f5ed4a-46b3-457f-9582-65611509e034)
2. Created a new folder under Ext2
             ![image](https://github.com/user-attachments/assets/5c54bcc4-243b-427b-b998-05bf156c6353)
3. Added external reference of 10-Level1 (Ext1) to Ext2
         ![image](https://github.com/user-attachments/assets/ddb65620-3751-409e-8fd2-281a63ba7ea0)
4.  After publish created new folder 11-Level2 under 10-Level1
           ![image](https://github.com/user-attachments/assets/088718e6-8952-41ea-a594-0a9341427de6)
5. Renamed child folder 11-Level2 to Level2Rename which reflected under Ext1 too. 
            ![image](https://github.com/user-attachments/assets/12dba054-2564-4245-85c3-306e7811d478)
6. Added again new folder under 10-Level1 (Ext2) which reflects under Ext1 too.
           ![image](https://github.com/user-attachments/assets/45317f0f-8ff6-4dc8-92fe-a35ec5be1e5a)
7. Moved up folders which also reflected in Ext1
        ![image](https://github.com/user-attachments/assets/c7d03b98-0d23-477c-b704-f777371d7b72)
        ![image](https://github.com/user-attachments/assets/a779434e-dcb6-4de3-b1b9-899236c0e284)

8.  Contributed a new Resource to Ext2 > 10- Level1 which reflected in Ext1 > 100 -Level1 > 10 -Level1
        ![image](https://github.com/user-attachments/assets/9889fd85-5f12-4eca-993e-f53936a68777)

    
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
