### PR TITLE
Td 4570 options are not poulating in the hierachy edit screen

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/Api/ContributeController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/Api/ContributeController.cs
@@ -465,7 +465,7 @@
             request.Description = Regex.Replace(request.Description, "<p> ", "<p>");
             request.Description = Regex.Replace(request.Description, "<p></p>", string.Empty);
             request.Description = Regex.Replace(request.Description, "\\n", string.Empty);
-
+            request.PrimaryCatalogueNodeId = (int)request.ResourceCatalogueId;
             int resourceVersionId = await this.contributeService.SaveResourceDetailAsync(request);
             return this.Ok(resourceVersionId);
         }

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/CatalogueCreate.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/CatalogueCreate.sql
@@ -101,6 +101,9 @@ BEGIN
 
 			SELECT @NodeVersionId = SCOPE_IDENTITY()
 
+			UPDATE nv SET PrimaryCatalogueNodeId = CatalogueNodeId from hierarchy.NodePath np 
+            INNER JOIN hierarchy.NodeVersion nv ON nv.NodeId = np.NodeId where nv.Id =@NodeVersionId
+
 			UPDATE [hierarchy].[Node]
 			SET CurrentNodeVersionId = @NodeVersionId
 			WHERE Id = @NodeId

--- a/WebAPI/LearningHub.Nhs.Repository/Resources/ResourceVersionRepository.cs
+++ b/WebAPI/LearningHub.Nhs.Repository/Resources/ResourceVersionRepository.cs
@@ -337,6 +337,7 @@
                 resourceVersionUpdate.ResourceLicenceId = resourceVersion.ResourceLicenceId == 0 ? null : resourceVersion.ResourceLicenceId;
                 resourceVersionUpdate.SensitiveContent = resourceVersion.SensitiveContent;
                 resourceVersionUpdate.CertificateEnabled = resourceVersion.CertificateEnabled;
+                resourceVersionUpdate.PrimaryCatalogueNodeId = resourceVersion.PrimaryCatalogueNodeId;
                 this.SetAuditFieldsForUpdate(userId, resourceVersionUpdate);
             }
 


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4570

### Description
Options are not getting populated in Hierarchy Edit Screen -For Newly created resources or folders from Contribute screen.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
