### PR TITLE
Td-4584: Adding content to, or re-aranging content within, a referenc…

### DIFF
--- a/AdminUI/LearningHub.Nhs.AdminUI/Scripts/vuesrc/content-structure/contentStructureState.ts
+++ b/AdminUI/LearningHub.Nhs.AdminUI/Scripts/vuesrc/content-structure/contentStructureState.ts
@@ -457,6 +457,7 @@ const actions = <ActionTree<State, any>>{
             await refreshNodeContents(payload.destinationNode, true).then(async x => {
                 await refreshNodeContents(state.editingTreeNode.parent, true).then(y => {
                 });
+                refreshHierarchyEdit(state);
                 state.rootNode.children.forEach(async (child) => {
                     if (child.nodeId != null) {
                         await refreshNodeContents(child, false);

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/content-structure-admin/contentStructureState.ts
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/content-structure-admin/contentStructureState.ts
@@ -454,6 +454,12 @@ const actions = <ActionTree<State, any>>{
             await refreshNodeContents(payload.destinationNode, true).then(async x => {
                 await refreshNodeContents(state.editingTreeNode.parent, true).then(y => {
                 });
+                refreshHierarchyEdit(state);
+                state.rootNode.children.forEach(async (child) => {
+                    if (child.nodeId != null) {
+                        await refreshNodeContents(child, false);
+                    }
+                });
             });
         }).catch(e => {
             state.inError = true;
@@ -492,8 +498,9 @@ const actions = <ActionTree<State, any>>{
         state.inError = false;
         contentStructureData.removeReferenceNode(payload.node.hierarchyEditDetailId).then(async response => {
             await refreshNodeContents(payload.node.parent, false);
-            await refreshNodeContents(payload.node.parent.parent, false);
-            await refreshNodeIfMatchingNodeId(payload.node.parent, state.editingTreeNode.nodeId, state.editingTreeNode.hierarchyEditDetailId);
+            if (payload.node.parent.parent != null) {
+                await refreshNodeContents(payload.node.parent.parent, false);
+            }
         }).catch(e => {
             state.inError = true;
             state.lastErrorMessage = "Error removing resource refrence.";

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/HierarchyEditPublish.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/HierarchyEditPublish.sql
@@ -18,6 +18,8 @@
 -- 03-06-2024  DB	Publish NodePathDisplayVersion records.
 -- 13-06-2024  DB	Publish ResourceReferenceDisplayVersion records.
 -- 26-07-2024  SA   Remove references to be implemented
+-- 27-08-2024  SA   Moving a folder into a referenced folder should affect all instances of the referenced folder.[added
+                    -- condition to avoid duplicate entries in to NodeLink table]
 -------------------------------------------------------------------------------
 CREATE PROCEDURE [hierarchy].[HierarchyEditPublish] 
 (
@@ -62,7 +64,7 @@ BEGIN
 		----------------------------------------------------------
 		-- Create new NodeLinks (arising from Create or Reference Node)
 		INSERT INTO [hierarchy].[NodeLink] ([ParentNodeId],[ChildNodeId],[DisplayOrder],[Deleted],[CreateUserId],[CreateDate],[AmendUserId],[AmendDate])
-		SELECT
+		SELECT DISTINCT
 			ParentNodeId,
 			NodeId AS ChildNodeId, 
 			DisplayOrder,
@@ -283,21 +285,6 @@ BEGIN
 			AND hed.DisplayOrder != nr.DisplayOrder
 			AND hed.Deleted = 0
 			AND nr.Deleted = 0
-
-			-- Update NodeResource Deleted status , if the reference is removed.
-		UPDATE 
-			nr
-		SET
-			Deleted = 1,
-			AmendUserId = @AmendUserId,
-			AmendDate = @AmendDate
-		FROM
-			hierarchy.HierarchyEditDetail hed
-		INNER JOIN
-			hierarchy.NodeResource nr ON hed.NodeResourceId = nr.Id
-		WHERE 
-			HierarchyEditId = @HierarchyEditId
-			AND hed.Deleted =1
 
 		----------------------------------------------------------
 		-- NodeVersion


### PR DESCRIPTION
…ed path does not update all references

### JIRA link

https://hee-tis.atlassian.net/browse/TD-4584

### Description
Moving a folder into a referenced folder only affects the specific instance of the folder, it should affect all instances of the referenced folder.

Moving a resource into a referenced folder only affects the specific instance of the folder, it should affect all instances of the referenced folder.

Moving a folder within referenced folder only affects the specific instance of the folder, it should affect all instances of the referenced folder.

Moving a resource within referenced folder only affects the specific instance of the folder, it should affect all instances of the referenced folder.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
