### PR TITLE
TD-4283: Fixed download issue for elearning resource in firefox browser

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/LearningSessionsController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/LearningSessionsController.cs
@@ -68,6 +68,7 @@
         /// <param name="filePath">filePath.</param>
         /// <returns>bool.</returns>
         //// [ResponseCache(VaryByQueryKeys = new[] { "*" }, Duration = 0, NoStore = true)] // disable caching
+        //// Removed Request.Headers["Referer"] Referer URL checking based on issue reported in TD-4283
         [AllowAnonymous]
         [Route("ScormContent/{*filePath}")]
         public async Task<IActionResult> ScormContent(string filePath)
@@ -79,12 +80,6 @@
 
             try
             {
-                var referringUrl = this.Request.Headers["Referer"].ToString();
-                if (string.IsNullOrEmpty(referringUrl))
-                {
-                    throw new UnauthorizedAccessException("Referer URL is required.");
-                }
-
                 if (!this.User.Identity.IsAuthenticated)
                 {
                     throw new UnauthorizedAccessException("User is not authenticated.");


### PR DESCRIPTION
### JIRA link
_[TD-4283](https://hee-tis.atlassian.net/browse/TD-4283)_

### Description
_Removed the Referer URL checking when loading scorm contents._

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4283]: https://hee-tis.atlassian.net/browse/TD-4283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ