### PR TITLE
TD-4450 : The problem with creating the subfolder has been resolved.

### DIFF
--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/HierarchyEditFolderCreate.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/HierarchyEditFolderCreate.sql
@@ -9,6 +9,7 @@
 -- 22-04-2024  DB	Included NULL NodeId and UserId in call to [hierarchy].[FolderNodeVersionCreate].
 -- 15-05-2024  DB	Accept @ParentNodePathId as input parameter, create NodePath and populate NodePathId and ParentNodePathId in HierarchyEditDetail.
 -- 10-07-2024  DB	Added PrimaryCatalogueNodeId to the NodeVersion table.
+-- 04-09-2024  SA   The problem with creating the subfolder has been resolved.
 -------------------------------------------------------------------------------
 CREATE PROCEDURE [hierarchy].[HierarchyEditFolderCreate]
 (
@@ -45,6 +46,22 @@ BEGIN
 			AND NodePathId = @ParentNodePathId
 			AND HierarchyEditDetailTypeId = 4 -- Node Link
 			AND Deleted = 0
+
+		IF @ParentNodeId IS NULL
+		BEGIN
+
+		SELECT	@ParentNodeId = NodeId,
+				@ParentNodePath = NodePath
+		FROM hierarchy.NodePath
+		WHERE Id = @ParentNodePathId
+			 AND Deleted = 0
+
+        SELECT TOP 1
+				 @PrimaryCatalogueNodeId = PrimaryCatalogueNodeId
+		FROM	hierarchy.HierarchyEditDetail
+		WHERE	HierarchyEditId = @HierarchyEditId
+			   AND Deleted = 0
+		END
 
 		EXECUTE [hierarchy].[FolderNodeVersionCreate] NULL, @Name, @Description, @PrimaryCatalogueNodeId, @UserId, @CreatedNodeVersionId OUTPUT
 


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4450

### Description
The problem with creating the subfolder has been resolved.

### Screenshots
Before change:

![image](https://github.com/user-attachments/assets/8fa87d17-26e6-49dc-9a63-46b44801e30b)

After Change:

![image](https://github.com/user-attachments/assets/d5e101ea-f9ff-424e-8f53-e4183c1d8cbf)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
