### PR TITLE
TD-4299-User Activity for Image/article resource  recorded after a delay 

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/ResourceController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/ResourceController.cs
@@ -189,6 +189,9 @@
                     ActivityStart = DateTime.UtcNow, // TODO: What about user's timezone offset when Javascript is disabled? Needs JavaScript.
                     ActivityStatus = ActivityStatusEnum.Completed,
                 };
+
+                // setting time delay to avoid  multiple records in same time-TD-4299
+                await Task.Delay(10000);
                 await this.activityService.CreateResourceActivityAsync(activity);
             }
 


### PR DESCRIPTION
### JIRA link
TD-4299

### Description
time limit that  SET(10 seconds, say) before which another launch is not recorded for image and article resource

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
