### PR TITLE
TD-4038: Implemented search bar in AllCatalogue search results page

### DIFF
--- a/LearningHub.Nhs.WebUI/Views/Catalogue/AllCatalogue.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Catalogue/AllCatalogue.cshtml
@@ -20,7 +20,7 @@
         <div class="nhsuk-grid-row">
             <div id="searchTab" class="search-page">
                 <div class="nhsuk-grid-column-two-thirds">
-                    @await Html.PartialAsync("_AllCatalogueSearchBar", Model)
+                    @await Html.PartialAsync("_AllCatalogueSearchBar", string.Empty)
                 </div>
             </div>
             

--- a/LearningHub.Nhs.WebUI/Views/Catalogue/AllCatalogueSearch.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Catalogue/AllCatalogueSearch.cshtml
@@ -14,26 +14,31 @@
 
 @section styles {
     <link rel="stylesheet" type="text/css" href="~/css/nhsuk/pages/catalogue.css" asp-append-version="true" />
+    <link rel="stylesheet" type="text/css" href="~/css/nhsuk/pages/search.css" asp-append-version="true" />
 }
-
 <div class="nhsuk-width-container app-width-container" style="width:100%">
     @if (hasSearchTerm)
     {
         var parms = new Dictionary<string, string> { { "term", searchTerm } };
         <vc:back-link asp-controller="Catalogue" asp-action="GetAllCatalogue" link-text="Back to A-Z of catalogues" />
     }
-    else
-    {
-        <vc:back-link asp-controller="Home" asp-action="Index" link-text="Back to: Learning Hub" />
-    }
     <h1 class="nhsuk-u-margin-bottom-5">
         @(hasSearchTerm ? $"Search results for {searchTerm}" : "All catalogues")
     </h1>
 
-    <h2 class="nhsuk-u-margin-bottom-5">
-        @($"{Model.TotalCount} catalogue results")
-    </h2>
-
+    <div class="nhsuk-grid-row">
+        <div id="searchTab" class="search-page">
+            <div class="nhsuk-grid-column-two-thirds">
+            @await Html.PartialAsync("_AllCatalogueSearchBar", searchTerm)
+            </div>
+        </div>
+    </div>
+    @if (Model.TotalCount > 0)
+    {
+        <h2 class="nhsuk-u-margin-bottom-5">
+            @($"{Model.TotalCount} catalogue results")
+        </h2>
+    }
 
     <ul class="nhsuk-grid-row nhsuk-card-group nhsuk-card-group--centred">
 
@@ -128,5 +133,19 @@
         var nextUrl = $"/allcataloguesearch?pageindex={currentPage + 1}{searchQueryParam}";
 
         @await Html.PartialAsync("_Pagination", new PaginationViewModel(currentPage, totalPage, prevUrl, nextUrl))
+    }
+
+    @if (Model.TotalCount == 0)
+    {
+        <div class="nhsuk-grid-row">
+            <div class="nhsuk-grid-column-full">
+                <h2 class="nhsuk-heading-l">No results found for @searchTerm</h2>
+                <p>You could try:</p>
+                <ul class="nhsuk-list nhsuk-list--bullet">
+                    <li>checking your spelling</li>
+                    <li>searching again using other words</li>
+                </ul>
+            </div>
+        </div>
     }
 </div>

--- a/LearningHub.Nhs.WebUI/Views/Catalogue/_AllCatalogueSearchBar.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Catalogue/_AllCatalogueSearchBar.cshtml
@@ -1,8 +1,8 @@
-﻿@model LearningHub.Nhs.Models.Catalogue.AllCatalogueResponseViewModel;
+﻿@model string
 <form id="search" asp-controller="catalogue" asp-action="GetAllCatalogueSearch" asp-fragment="searchTab" method="get" role="search">
     <div class="nhsuk-form-group  nhsuk-header__search-form--search-results">
         <label class="nhsuk-label nhsuk-u-visually-hidden" for="sub-search-field">Search</label>
-        <input class="nhsuk-input nhsuk-search__input" type="search" name="term" autocomplete="off" id="sub-search-field" placeholder="Search for a catalogue">
+        <input class="nhsuk-input nhsuk-search__input" type="search" value="@Model" name="term" autocomplete="off" id="sub-search-field" placeholder="Search for a catalogue">
         <button class="nhsuk-search__submit" type="submit">
             <span class="nhsuk-u-visually-hidden">Search</span>
             <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">


### PR DESCRIPTION
### JIRA link
_[TD-4038](https://hee-tis.atlassian.net/browse/TD-4038)_

### Description
Implemented search bar in AllCatalogue search results page and updated the wordings.

### Screenshots
After

![image](https://github.com/user-attachments/assets/b9a31053-606a-4275-8ed5-b36b8005ed11)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4038]: https://hee-tis.atlassian.net/browse/TD-4038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ