### PR TITLE
TD-4038: Message updated for empty search in AllCatalogues and main search pages

### DIFF
--- a/LearningHub.Nhs.WebUI/Views/Catalogue/AllCatalogueSearch.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Catalogue/AllCatalogueSearch.cshtml
@@ -7,7 +7,7 @@
 
     var queryParams = QueryHelpers.ParseQuery(Context.Request.QueryString.ToString());
     var hasSearchTerm = queryParams.ContainsKey("term");
-    var searchTerm = hasSearchTerm ? queryParams["term"].ToString() : null;
+    var searchTerm = hasSearchTerm ? queryParams["term"].ToString().Trim() : null;
     string cardStyle = "card-provider-details--blank";
     var pageSize = this.ViewBag.PageSize;
 }
@@ -22,9 +22,9 @@
         var parms = new Dictionary<string, string> { { "term", searchTerm } };
         <vc:back-link asp-controller="Catalogue" asp-action="GetAllCatalogue" link-text="Back to A-Z of catalogues" />
     }
-    <h1 class="nhsuk-u-margin-bottom-5">
-        @(hasSearchTerm ? $"Search results for {searchTerm}" : "All catalogues")
-    </h1>
+        <h1 class="nhsuk-u-margin-bottom-5">
+        Search results @(!string.IsNullOrEmpty(searchTerm) ? "for " + searchTerm : string.Empty)
+        </h1>
 
     <div class="nhsuk-grid-row">
         <div id="searchTab" class="search-page">
@@ -139,7 +139,7 @@
     {
         <div class="nhsuk-grid-row">
             <div class="nhsuk-grid-column-full">
-                <h2 class="nhsuk-heading-l">No results found for @searchTerm</h2>
+                    <h2 class="nhsuk-heading-l">No results found @(!string.IsNullOrEmpty(searchTerm) ? "for " + searchTerm : string.Empty)</h2>
                 <p>You could try:</p>
                 <ul class="nhsuk-list nhsuk-list--bullet">
                     <li>checking your spelling</li>

--- a/LearningHub.Nhs.WebUI/Views/Search/Index.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Search/Index.cshtml
@@ -10,11 +10,10 @@
 
 <div class="search-page">
     <div class="nhsuk-width-container app-width-container">
-
-        <h1 class="nhsuk-u-margin-top-5 nhsuk-u-margin-bottom-6">
-            Search results for @Model.SearchString
-        </h1>
-
+            <h1 class="nhsuk-u-margin-top-5 nhsuk-u-margin-bottom-6">
+            Search results @(!string.IsNullOrEmpty(Model.SearchString) ? "for " + Model.SearchString : string.Empty)
+            </h1>
+            
         <div class="nhsuk-grid-row">
             <div class="nhsuk-grid-column-two-thirds">
                 @await Html.PartialAsync("_SearchBar", @Model.SearchString)
@@ -48,7 +47,7 @@
         {
             <div class="nhsuk-grid-row">
                 <div class="nhsuk-grid-column-full">
-                    <h2 class="nhsuk-heading-l">No results found for @Model.SearchString</h2>
+                    <h2 class="nhsuk-heading-l">No results found @(!string.IsNullOrEmpty(Model.SearchString) ? "for " + Model.SearchString : string.Empty)</h2>
                     <p>You could try:</p>
                     <ul class="nhsuk-list nhsuk-list--bullet">
                         <li>checking your spelling</li>


### PR DESCRIPTION

### JIRA link
_[TD-4038](https://hee-tis.atlassian.net/browse/TD-4038)_

### Description
Message updated when doing an empty search in AllCatalogues and main search pages.

### Screenshots
After
![image](https://github.com/user-attachments/assets/26941de1-2d77-476d-92d1-7fdaa0dcd4d0)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4038]: https://hee-tis.atlassian.net/browse/TD-4038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ