### PR TITLE
changed the sequence of execution of media duplication

### DIFF
--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Resources/QuestionBlockCreateDuplicate.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Resources/QuestionBlockCreateDuplicate.sql
@@ -134,9 +134,11 @@ BEGIN
     
     EXECUTE resources.TextBlockCreateDuplicate @CurrentQuestionContentBlockIds, @CopiedQuestionBlocksTable, @UserId, @UserTimezoneOffset
 
+    EXECUTE resources.WholeSlideImageCreateDuplicate @CurrentQuestionContentBlockIds, @CopiedQuestionBlocksTable, @UserId, @UserTimezoneOffset
+
     EXECUTE resources.MediaBlockCreateDuplicate @CurrentQuestionContentBlockIds, @CopiedQuestionBlocksTable, @UserId, @UserTimezoneOffset
     
-    EXECUTE resources.WholeSlideImageCreateDuplicate @CurrentQuestionContentBlockIds, @CopiedQuestionBlocksTable, @UserId, @UserTimezoneOffset
+    
 
     -- PART 3
     -- Duplicate the Text and Media Blocks in the FeedbackBlockCollections


### PR DESCRIPTION
### JIRA link
[TD-4638](https://hee-tis.atlassian.net/browse/TD-4638)

### Description
When question blocks are duplicated, media associated with match games fail to be copied to the new duplicated blocks.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4638]: https://hee-tis.atlassian.net/browse/TD-4638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ