### PR TITLE
TD-4651-fix for Showing page '404' error for few links showing on footer pages

### DIFF
--- a/LearningHub.Nhs.WebUI/Views/Policies/PrivacyPolicy.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Policies/PrivacyPolicy.cshtml
@@ -140,7 +140,7 @@
                 </p>
                 <h2 class="nhsuk-heading-l">12. HOW LONG WE RETAIN YOUR PERSONAL DATA</h2>
                 <p>
-                    We will keep personal data for no longer than necessary to fulfill the purposes we collected it for, in accordance with our records management policy and the NHS records retention schedule within the NHS Records Management Code of Practice at: <a href="https://transform.england.nhs.uk/information-governance/guidance/records-management-code/records-management-code-of-practice-2021" target="_blank">https://transform.england.nhs.uk/information-governance/guidance/records-management-code/records-management-code-of-practice-2021</a> (as may be amended from time to time).
+                    We will keep personal data for no longer than necessary to fulfill the purposes we collected it for, in accordance with our records management policy and the NHS records retention schedule within the NHS Records Management Code of Practice at: <a href="https://www.england.nhs.uk/contact-us/privacy-notice/nhs-england-as-a-data-controller/" target="_blank">https://www.england.nhs.uk/contact-us/privacy-notice/nhs-england-as-a-data-controller/</a> (as may be amended from time to time).
                 </p>
                 <p>
                     In some circumstances, you can ask us to delete your data. Please see the “Your rights” section below for further information.


### PR DESCRIPTION
### JIRA link
TD-4651

### Description
_when clicked below  link on the footer pages seeing console ‘404’ error on the screen .  Modified  with correct link


### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
