### PR TITLE
TD-4373-Allow .ppsx file types

### DIFF
--- a/WebAPI/LearningHub.Nhs.Database/LearningHub.Nhs.Database.sqlproj
+++ b/WebAPI/LearningHub.Nhs.Database/LearningHub.Nhs.Database.sqlproj
@@ -550,6 +550,7 @@
     <Build Include="Stored Procedures\Hierarchy\HierarchyNewResourceReferenceForReferedCatalogue.sql" />
     <Build Include="Stored Procedures\Hierarchy\HierarchyEditCreateNodeReference.sql" />
     <Build Include="Stored Procedures\Hierarchy\HierarchyEditCreateResourceReference.sql" />
+    <None Include="Scripts\Post-Deploy\Scripts\PPSXFileType.sql" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Scripts\Pre-Deploy\Scripts\Card5766_AuthorTableChanges.PreDeployment.sql" />

--- a/WebAPI/LearningHub.Nhs.Database/Scripts/Post-Deploy/Scripts/PPSXFileType.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Scripts/Post-Deploy/Scripts/PPSXFileType.sql
@@ -1,0 +1,31 @@
+﻿IF NOT EXISTS(SELECT Id FROM [resources].[FileType] where Extension ='ppsx')
+BEGIN
+INSERT INTO [resources].[FileType]
+           (Id,
+            [DefaultResourceTypeId]
+           ,[Name]
+           ,[Description]
+           ,[Extension]
+           ,[Icon]
+           ,[NotAllowed]
+           ,[Deleted]
+           ,[CreateUserId]
+           ,[CreateDate]
+           ,[AmendUserId]
+           ,[AmendDate])
+     VALUES
+           (70,
+           9
+           ,'PowerPoint Open XML Slide Show'
+           ,'PowerPoint Open XML Slide Show'
+           ,'ppsx'
+           ,'a-mppoint-icon.svg'
+           ,0
+           ,0
+           ,57541
+           ,SYSDATETIMEOFFSET()
+           ,57541
+           ,SYSDATETIMEOFFSET())
+END
+GO
+


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4373

### Description
Allowed .ppsx file types on the learning hub

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

![image](https://github.com/user-attachments/assets/5155e3b0-7ab9-4431-ab5a-b4413c8e1723)
![image](https://github.com/user-attachments/assets/b56f5830-069a-4378-8e30-de7c993d7024)
![image](https://github.com/user-attachments/assets/d17dded4-c203-4330-80fb-741d5c8da3fe)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [x] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - Allowed File Types([Allowed File Types](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3960406046/File+Upload+-+Table+Identifying+What+File+Types+We+LH+Supports))
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
