### PR TITLE
TD-4704: Issue not showing the 'elfh' logo on 'Catalogue details' screen when accessed 'Search' & 'Catalogue cards' screens

### DIFF
--- a/LearningHub.Nhs.WebUI/Views/Catalogue/Index.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Catalogue/Index.cshtml
@@ -34,15 +34,6 @@
     return string.Empty;
   }
 
-  string GetBadgeUrl()
-  {
-    if (!string.IsNullOrEmpty(Model.Catalogue.BadgeUrl))
-    {
-      return GetFileLink(Model.Catalogue.BadgeUrl);
-    }
-    return string.Empty;
-  }
-
   string GetFileLink(string fileName)
   {
     return "/api/catalogue/download-image/" + Uri.EscapeDataString(fileName);
@@ -82,6 +73,9 @@
         CatalogueAccessRequest = Model.CatalogueAccessRequest,
         UserGroups = Model.UserGroups
       };
+
+   var provider = Model.Catalogue.Providers?.FirstOrDefault();
+   var hasBadge = !string.IsNullOrWhiteSpace(Model.Catalogue.BadgeUrl);
 }
 
 @section styles{
@@ -124,9 +118,13 @@
       }
 
       <div class="catalogue-title nhsuk-u-margin-bottom-7">
-        @if (!string.IsNullOrEmpty(Model.Catalogue.BadgeUrl))
+        @if (provider != null)
         {
-          <img alt="Provider's catalogue badge" src="@GetBadgeUrl()" class="catalogue-badge" />
+           <img src="~/images/provider-logos/@provider.Logo" alt="@provider.Name catalogue badge" class="provider-badge" />
+        }
+        else if (hasBadge)
+        {
+           <img src="@("/api/catalogue/download-image/" + Uri.EscapeDataString(Model.Catalogue.BadgeUrl))" alt="Provider's catalogue badgeTest" class="catalogue-card-badge" />
         }
 
         <h1 class="heading-lg title nhsuk-u-margin-bottom-0">@(ViewBag.ActiveTab == "browse" && Model.NodeDetails != null ? Model.NodeDetails.Name : Model.Catalogue.Name)</h1>

--- a/WebAPI/LearningHub.Nhs.Services/CatalogueService.cs
+++ b/WebAPI/LearningHub.Nhs.Services/CatalogueService.cs
@@ -198,6 +198,7 @@
             var bookmark = this.bookmarkRepository.GetAll().Where(b => b.NodeId == catalogue.NodeId && b.UserId == userId).FirstOrDefault();
             catalogueVM.BookmarkId = bookmark?.Id;
             catalogueVM.IsBookmarked = !bookmark?.Deleted ?? false;
+            catalogueVM.Providers = await this.providerService.GetByCatalogueVersionIdAsync(catalogueVM.Id);
             return catalogueVM;
         }
 

--- a/WebAPI/LearningHub.Nhs.Services/DashboardService.cs
+++ b/WebAPI/LearningHub.Nhs.Services/DashboardService.cs
@@ -51,6 +51,15 @@
 
             var cataloguesResponse = dashboardType.ToLower() == "my-catalogues" ? this.catalogueNodeVersionRepository.GetCatalogues(dashboardType, pageNumber, userId) : (TotalCount: 0, Catalogues: new List<DashboardCatalogueDto>());
 
+            var catalogueList = cataloguesResponse.Catalogues.Any() ? this.mapper.Map<List<DashboardCatalogueViewModel>>(cataloguesResponse.Catalogues) : new List<DashboardCatalogueViewModel>();
+            if (catalogueList.Any())
+            {
+                foreach (var catalogue in catalogueList)
+                {
+                    catalogue.Providers = await this.providerService.GetByCatalogueVersionIdAsync(catalogue.NodeVersionId);
+                }
+            }
+
             var resourceList = resources.Any() ? this.mapper.Map<List<DashboardResourceViewModel>>(resources) : new List<DashboardResourceViewModel>();
             if (resourceList.Any())
             {
@@ -64,7 +73,7 @@
             {
                 Type = dashboardType,
                 Resources = resourceList,
-                Catalogues = cataloguesResponse.Catalogues.Any() ? this.mapper.Map<List<DashboardCatalogueViewModel>>(cataloguesResponse.Catalogues) : new List<DashboardCatalogueViewModel>(),
+                Catalogues = catalogueList,
                 TotalCount = dashboardType.ToLower() == "my-catalogues" ? cataloguesResponse.TotalCount : resourceCount,
                 CurrentPage = pageNumber,
             };


### PR DESCRIPTION

### JIRA link
_[TD-4704](https://hee-tis.atlassian.net/browse/TD-4704)_

### Description
Issue fixed for showing 'elfh' logo on catalogue details page accessed from the dashboard and from the search results page. Also the provider name is now shown on the catalogue tray of my accessed learning.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
