### PR TITLE
TD-4726: Issue showing blank screen when clicked the 'Go back' link o…

### DIFF
--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/catalogue/managecatalogue.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/catalogue/managecatalogue.vue
@@ -14,10 +14,14 @@
                 <div class="lh-padding-fluid">
                     <div class="lh-container-xl">
                         <div class="nhsuk-back-link">
-                            <router-link :to="'/Catalogue/' + reference" class="nhsuk-back-link__link" id="goBackLink"><svg class="nhsuk-icon nhsuk-icon__chevron-left" 
-                                xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-                                <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
-                                </svg> Go back</router-link>
+
+                            <a :href="'/catalogue/' + reference" class="nhsuk-back-link__link" id="goBackLink">
+                                <svg class="nhsuk-icon nhsuk-icon__chevron-left"
+                                     xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                                    <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
+                                </svg>
+                                Go back
+                            </a>
                         </div>
                         <h1>Catalogue Management</h1>
                         <div class="nhsuk-grid-row">


### PR DESCRIPTION
…n 'Manage catalogue' screen

### JIRA link
https://hee-tis.atlassian.net/browse/TD-4726

### Description

Fixed the issue with back link not working in the manage catalogue page.


### Screenshots
https://github.com/user-attachments/assets/b026dc4c-52e3-4dbc-bf50-e0aa6b74a618

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
