### PR TITLE
TD-4408: Added code changes in WebUI too

### DIFF
--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/content-structure-admin/contentStructureState.ts
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/content-structure-admin/contentStructureState.ts
@@ -552,7 +552,8 @@ const actions = <ActionTree<State, any>>{
             await refreshNodeContents(state.referencingResource.parent, true).then(async x => {
                 await refreshNodeContents(payload.destinationNode, true);
             });
-
+            state.editingTreeNode.parent.childrenLoaded = false;
+            await refreshNodeContents(state.editingTreeNode.parent, true);
             context.commit("setEditMode", EditModeEnum.Structure);
         }).catch(e => {
             state.inError = true;


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4408

### Description
Creating a reference/folder to a resource does not refresh all instances of the resource

### Screenshots
![image](https://github.com/user-attachments/assets/635127f7-3625-413a-8049-ce4251d445ac)



-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
