### PR TITLE
TD-4388: Assessment resource settings need a required field marker

### DIFF
--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/ContributeAssessmentSettings.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/ContributeAssessmentSettings.vue
@@ -65,7 +65,7 @@
 
                         <div class="d-flex">
                             <div class="selection pr-50">
-                                <div>Provide guidance for the learner at the end of this assessment. <i class="warningTriangle fas fa-exclamation-triangle warm-yellow"></i></div>
+                                <div>Provide guidance for the learner at the end of this assessment. <i v-if="!IsVisible" class="warningTriangle fas fa-exclamation-triangle warm-yellow"></i></div>
                                 <EditSaveFieldWithCharacterCount v-model="assessmentDetails.endGuidance.blocks[0].title"
                                                                  addEditLabel="title"
                                                                  v-bind:characterLimit="60"
@@ -79,7 +79,7 @@
                                 <h3>Tip</h3>
                                 You can offer guidance to the learner at the end of the assessment such as next steps or recommendations on other learning resources to try.                            </div>
                         </div>
-                        <Button class="mt-5" color="green" v-on:click="isOpen = false" :disabled="!canSaveAll">Save settings</Button>
+                        <Button class="mt-5" color="green" v-on:click="isOpen = false" :disabled="!IsVisible">Save settings</Button>
                     </div>
                 </div>
             </v-card>
@@ -131,6 +131,7 @@
                 endGuidance: "",
                 initialGuidance: "",
                 guidanceValid: true,
+                IsVisible: false,
             }
         },
         watch: {
@@ -139,7 +140,7 @@
                 {
                     this.assessmentDetails.endGuidance.addBlock(BlockTypeEnum.Text);
                 }
-                this.assessmentDetails.endGuidance.blocks[0].textBlock.content = this.endGuidance;
+                this.assessmentDetails.endGuidance.blocks[0].textBlock.content = this.endGuidance;            
             },
             ["assessmentDetails.passMark"](value){ this.assessmentDetails.passMark = this.capNumberFieldBy(value, 100)},
             ["assessmentDetails.maximumAttempts"](value){ this.assessmentDetails.maximumAttempts = this.capNumberFieldBy(value, 10)},
@@ -156,6 +157,14 @@
                 } 
                 
                 this.assessmentDetails.assessmentSettingsAreValid = settingsAreValid;
+
+                if (this.endGuidance != "") {
+                    this.IsVisible = true;
+                }
+                else {
+                    this.IsVisible = false;
+                }
+
                 return settingsAreValid;
             },
         },
@@ -169,9 +178,23 @@
                 {
                     this.endGuidance = description;
                 }
+
+                if (this.endGuidance != "") {
+                    this.IsVisible = true;
+                }
+                else {
+                    this.IsVisible = false;
+                }
             },
             setGuidanceValidity(valid: boolean) {
-                this.guidanceValid = valid;
+                if (this.endGuidance == "") {
+                    this.guidanceValid = false;
+                    this.IsVisible = false;
+                }
+                else {
+                    this.guidanceValid = valid;
+                    this.IsVisible = true;
+                }
             }
         }
     });


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4388

### Description
Assessment resource settings need a required field marker - Fixed the SIT defects

### Screenshots
**Without description**

![image](https://github.com/user-attachments/assets/01c0be74-6745-4bd8-96cb-925ad45156ff)

**With Description**

![image](https://github.com/user-attachments/assets/3a3e3cff-f158-47ad-9ff0-4190c22bb398)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
