### PR TITLE
Develop/fixes/td 4738 console errors on learning hub home page

### DIFF
--- a/LearningHub.Nhs.WebUI/Views/Shared/Tenant/LearningHub/_Layout.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Shared/Tenant/LearningHub/_Layout.cshtml
@@ -71,7 +71,7 @@
         <partial name="_CookieConsentPartial" />
     </div>
 
-    <header class="nhsuk-header" role="banner">
+    <header class="nhsuk-header" role="banner" id="header">
     <div id="content-header">
         <partial name="~/Views/Shared/_NavPartial.cshtml" />
     </div>

--- a/LearningHub.Nhs.WebUI/Views/Shared/Tenant/LearningHub/_Layout.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Shared/Tenant/LearningHub/_Layout.cshtml
@@ -72,7 +72,9 @@
     </div>
 
     <header class="nhsuk-header" role="banner">
+    <div id="content-header">
         <partial name="~/Views/Shared/_NavPartial.cshtml" />
+    </div>
     </header>
 
     <div class="nhsuk-width-container app-width-container beta-banner">


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4738

### Description
Fixed the issue showing console errors on 'Learning hub' home page when clicked the search button in Mobile view.

### Screenshots
![image](https://github.com/user-attachments/assets/3f1fee0d-bd60-400d-88fe-5c6b803400a9)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
