### PR TITLE
TD-4783:Reference count not getting refreshed when folder is referenc…

### DIFF
--- a/AdminUI/LearningHub.Nhs.AdminUI/Scripts/vuesrc/content-structure/contentStructureState.ts
+++ b/AdminUI/LearningHub.Nhs.AdminUI/Scripts/vuesrc/content-structure/contentStructureState.ts
@@ -495,7 +495,6 @@ const actions = <ActionTree<State, any>>{
     },
     async referenceNode(context: ActionContext<State, State>, payload: { destinationNode: NodeContentAdminModel }) {
         state.inError = false;
-        debugger;
         contentStructureData.referenceNode(state.editingTreeNode.hierarchyEditDetailId, payload.destinationNode.hierarchyEditDetailId).then(async response => {
             context.commit("setEditMode", EditModeEnum.Structure);
             await refreshNodeContents(payload.destinationNode, true).then(async x => {

--- a/AdminUI/LearningHub.Nhs.AdminUI/Scripts/vuesrc/content-structure/contentStructureState.ts
+++ b/AdminUI/LearningHub.Nhs.AdminUI/Scripts/vuesrc/content-structure/contentStructureState.ts
@@ -495,12 +495,14 @@ const actions = <ActionTree<State, any>>{
     },
     async referenceNode(context: ActionContext<State, State>, payload: { destinationNode: NodeContentAdminModel }) {
         state.inError = false;
+        debugger;
         contentStructureData.referenceNode(state.editingTreeNode.hierarchyEditDetailId, payload.destinationNode.hierarchyEditDetailId).then(async response => {
             context.commit("setEditMode", EditModeEnum.Structure);
             await refreshNodeContents(payload.destinationNode, true).then(async x => {
                 state.editingTreeNode.parent.childrenLoaded = false; // force reload of current now to show references
                 await refreshNodeContents(state.editingTreeNode.parent, true).then(y => {
                 });
+                await refreshNodeIfMatchingNodeId(state.rootNode, state.editingTreeNode.nodeId, state.editingTreeNode.hierarchyEditDetailId, true);
             });
         }).catch(e => {
             state.inError = true;

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/content-structure-admin/contentStructureState.ts
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/content-structure-admin/contentStructureState.ts
@@ -500,6 +500,7 @@ const actions = <ActionTree<State, any>>{
                 state.editingTreeNode.parent.childrenLoaded = false; // force reload of current now to show references
                 await refreshNodeContents(state.editingTreeNode.parent, true).then(y => {
                 });
+                await refreshNodeIfMatchingNodeId(state.rootNode, state.editingTreeNode.nodeId, state.editingTreeNode.hierarchyEditDetailId, true);
             });
         }).catch(e => {
             state.inError = true;


### PR DESCRIPTION
…ed to the folder in parent level

### JIRA link
https://hee-tis.atlassian.net/browse/TD-4783

### Description
Fixed the issue related to the reference count not getting refreshed when folder is referenced to the folder in parent level.

### Screenshots
**Admin UI**
![image](https://github.com/user-attachments/assets/68924539-ff8d-46d1-bb36-8626f1f1439c)

**Web UI**

![image](https://github.com/user-attachments/assets/21ec4ec0-eb61-4f33-a937-b9a0a29f8c16)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
