### PR TITLE
TD-4261: Duplicate entries for the assessment results(elearning) in the My Learning page

### DIFF
--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLatestActivityCheck.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLatestActivityCheck.sql
@@ -8,6 +8,7 @@
 -- Sarathlal	20-02-2024
 -- Sarathlal	23-04-2024 TD-2954: Audio/Video/Assessment issue resolved and duplicate issue also resolved
 -- Sarathlal	25-04-2024 TD-4067: Resource with muliple version issue resolved
+-- Arunima		11-10-2024	TD-4261: Duplicate entries for the assessment results(elearning) in the My Learning page
 -------------------------------------------------------------------------------
 
 CREATE PROCEDURE [activity].[GetUserLatestActivityCheck] (
@@ -175,54 +176,18 @@ FROM (
 ) AS [t2]
 LEFT JOIN [resources].[VideoResourceVersion] AS [VideoResourceVersion] ON [t2].[Id1] = [VideoResourceVersion].[ResourceVersionId]
 LEFT JOIN [resources].[AudioResourceVersion] AS [AudeoResourceVersion] ON [t2].[Id1] = [AudeoResourceVersion].[ResourceVersionId]
-LEFT JOIN (
-    SELECT [ScormResourceVersion2].[Id], [ScormResourceVersion2].[AmendDate], [ScormResourceVersion2].[AmendUserId], [ScormResourceVersion2].[CanDownload], [ScormResourceVersion2].[ClearSuspendData], [ScormResourceVersion2].[ContentFilePath], [ScormResourceVersion2].[CreateDate], [ScormResourceVersion2].[CreateUserId], [ScormResourceVersion2].[Deleted], [ScormResourceVersion2].[DevelopmentId], [ScormResourceVersion2].[EsrLinkTypeId], [ScormResourceVersion2].[FileId], [ScormResourceVersion2].[PopupHeight], [ScormResourceVersion2].[PopupWidth], [ScormResourceVersion2].[ResourceVersionId]
-    FROM [resources].[ScormResourceVersion] AS [ScormResourceVersion2]
-    WHERE [ScormResourceVersion2].[Deleted] = 0
-) AS [t3] ON [t2].[Id1] = [t3].[ResourceVersionId]
-LEFT JOIN (
-    SELECT [ScormResourceVersionManifest3].[Id], [ScormResourceVersionManifest3].[AmendDate], [ScormResourceVersionManifest3].[AmendUserId], [ScormResourceVersionManifest3].[Author], [ScormResourceVersionManifest3].[CatalogEntry], [ScormResourceVersionManifest3].[Copyright], [ScormResourceVersionManifest3].[CreateDate], [ScormResourceVersionManifest3].[CreateUserId], [ScormResourceVersionManifest3].[Deleted], [ScormResourceVersionManifest3].[Description], [ScormResourceVersionManifest3].[Duration], [ScormResourceVersionManifest3].[ItemIdentifier], [ScormResourceVersionManifest3].[Keywords], [ScormResourceVersionManifest3].[LaunchData], [ScormResourceVersionManifest3].[ManifestURL], [ScormResourceVersionManifest3].[MasteryScore], [ScormResourceVersionManifest3].[MaxTimeAllowed], [ScormResourceVersionManifest3].[QuicklinkId], [ScormResourceVersionManifest3].[ResourceIdentifier], [ScormResourceVersionManifest3].[ScormResourceVersionId], [ScormResourceVersionManifest3].[TemplateVersion], [ScormResourceVersionManifest3].[TimeLimitAction], [ScormResourceVersionManifest3].[Title]
-    FROM [resources].[ScormResourceVersionManifest] AS [ScormResourceVersionManifest3]
-    WHERE [ScormResourceVersionManifest3].[Deleted] = 0
-) AS [t4] ON [t3].[Id] = [t4].[ScormResourceVersionId]
-LEFT JOIN (
-    SELECT [BlockCollection].[Id], [BlockCollection].[AmendDate], [BlockCollection].[AmendUserId], [BlockCollection].[CreateDate], [BlockCollection].[CreateUserId], [BlockCollection].[Deleted]
-    FROM [resources].[BlockCollection] AS [BlockCollection]
-    WHERE [BlockCollection].[Deleted] = 0
-) AS [t5] ON [t2].[AssessmentContentId] = [t5].[Id]
-INNER JOIN (
-    SELECT [NodePath].[Id], [NodePath].[AmendDate], [NodePath].[AmendUserId], [NodePath].[CatalogueNodeId], [NodePath].[CreateDate], [NodePath].[CreateUserId], [NodePath].[Deleted], [NodePath].[IsActive], [NodePath].[NodeId], [NodePath].[NodePath]
-    FROM [hierarchy].[NodePath] AS [NodePath]
-    WHERE [NodePath].[Deleted] = 0
-) AS [t6] ON [t2].[NodePathId] = [t6].[Id]
-LEFT JOIN (
-    SELECT [ResourceReference5].[Id], [ResourceReference5].[AmendDate], [ResourceReference5].[AmendUserId], [ResourceReference5].[CreateDate], [ResourceReference5].[CreateUserId], [ResourceReference5].[Deleted], [ResourceReference5].[NodePathId], [ResourceReference5].[OriginalResourceReferenceId], [ResourceReference5].[ResourceId]
-    FROM [resources].[ResourceReference] AS [ResourceReference5]
-    WHERE [ResourceReference5].[Deleted] = 0
-) AS [t7] ON [t2].[Id0] = [t7].[ResourceId]
-LEFT JOIN (
-    SELECT [MediaResourceActivity3].[Id], [MediaResourceActivity3].[ActivityStart], [MediaResourceActivity3].[AmendDate], [MediaResourceActivity3].[AmendUserID], [MediaResourceActivity3].[CreateDate], [MediaResourceActivity3].[CreateUserID], [MediaResourceActivity3].[Deleted], [MediaResourceActivity3].[PercentComplete], [MediaResourceActivity3].[ResourceActivityId], [MediaResourceActivity3].[SecondsPlayed]
-    FROM [activity].[MediaResourceActivity] AS [MediaResourceActivity3]
-    WHERE [MediaResourceActivity3].[Deleted] = 0
-) AS [t8] ON [t2].[Id] = [t8].[ResourceActivityId]
-LEFT JOIN (
-    SELECT [ScormActivity4].[Id], [ScormActivity4].[AmendDate], [ScormActivity4].[AmendUserID], [ScormActivity4].[CmiCoreExit], [ScormActivity4].[CmiCoreLesson_location], [ScormActivity4].[CmiCoreLesson_status], [ScormActivity4].[CmiCoreScoreMax], [ScormActivity4].[CmiCoreScoreMin], [ScormActivity4].[CmiCoreScoreRaw], [ScormActivity4].[CmiCoreSession_time], [ScormActivity4].[CmiSuspend_data], [ScormActivity4].[CreateDate], [ScormActivity4].[CreateUserID], [ScormActivity4].[Deleted], [ScormActivity4].[DurationSeconds], [ScormActivity4].[ResourceActivityId]
-    FROM [activity].[ScormActivity] AS [ScormActivity4]
-    WHERE [ScormActivity4].[Deleted] = 0
-) AS [t9] ON [t2].[Id] = [t9].[ResourceActivityId]
-LEFT JOIN (
-    SELECT [Block0].[Id], [Block0].[AmendDate], [Block0].[AmendUserId], [Block0].[BlockCollectionId], [Block0].[BlockType], [Block0].[CreateDate], [Block0].[CreateUserId], [Block0].[Deleted], [Block0].[Order], [Block0].[Title]
-    FROM [resources].[Block] AS [Block0]
-    WHERE [Block0].[Deleted] = 0
-) AS [t10] ON [t5].[Id] = [t10].[BlockCollectionId]
+LEFT JOIN [resources].[ScormResourceVersion] AS [t3] ON [t2].[Id1] = [t3].[ResourceVersionId] and t3.Deleted=0
+LEFT JOIN [resources].[ScormResourceVersionManifest] AS [t4] ON [t3].[Id] = [t4].[ScormResourceVersionId] and [t4].[Deleted] = 0
+LEFT JOIN [resources].[BlockCollection]  AS [t5] ON [t2].[AssessmentContentId] = [t5].[Id] AND [t5].[Deleted] = 0
+INNER JOIN [hierarchy].[NodePath] AS [t6] ON [t2].[NodePathId] = [t6].[Id] AND [t6].[Deleted] = 0
+LEFT JOIN [resources].[ResourceReference] AS [t7] ON [t2].[Id0] = [t7].[ResourceId] AND [t7].[Deleted] = 0
+LEFT JOIN [activity].[MediaResourceActivity] AS [t8] ON [t2].[Id] = [t8].[ResourceActivityId] AND [t8].[Deleted] = 0
+LEFT JOIN [activity].[ScormActivity] AS [t9] ON [t2].[Id] = [t9].[ResourceActivityId] AND [t9].[Deleted] = 0
+LEFT JOIN [resources].[Block] AS [t10] ON [t5].[Id] = [t10].[BlockCollectionId] AND [t10].[Deleted] = 0
 LEFT JOIN (
     SELECT [AssessmentResourceActivity5].[Id], [AssessmentResourceActivity5].[AmendDate], [AssessmentResourceActivity5].[AmendUserID], [AssessmentResourceActivity5].[CreateDate], [AssessmentResourceActivity5].[CreateUserID], [AssessmentResourceActivity5].[Deleted], [AssessmentResourceActivity5].[Reason], [AssessmentResourceActivity5].[ResourceActivityId], [AssessmentResourceActivity5].[Score], [t12].[Id] AS [Id0], [t12].[AmendDate] AS [AmendDate0], [t12].[AmendUserID] AS [AmendUserID0], [t12].[AssessmentResourceActivityId], [t12].[CreateDate] AS [CreateDate0], [t12].[CreateUserID] AS [CreateUserID0], [t12].[Deleted] AS [Deleted0], [t12].[QuestionBlockId]
     FROM [activity].[AssessmentResourceActivity] AS [AssessmentResourceActivity5]
-    LEFT JOIN (
-        SELECT [AssessmentResourceActivityInteraction6].[Id], [AssessmentResourceActivityInteraction6].[AmendDate], [AssessmentResourceActivityInteraction6].[AmendUserID], [AssessmentResourceActivityInteraction6].[AssessmentResourceActivityId], [AssessmentResourceActivityInteraction6].[CreateDate], [AssessmentResourceActivityInteraction6].[CreateUserID], [AssessmentResourceActivityInteraction6].[Deleted], [AssessmentResourceActivityInteraction6].[QuestionBlockId]
-        FROM [activity].[AssessmentResourceActivityInteraction] AS [AssessmentResourceActivityInteraction6]
-        WHERE [AssessmentResourceActivityInteraction6].[Deleted] = 0
-    ) AS [t12] ON [AssessmentResourceActivity5].[Id] = [t12].[AssessmentResourceActivityId]
+	LEFT JOIN [activity].[AssessmentResourceActivityInteraction] AS [t12] ON [AssessmentResourceActivity5].[Id] = [t12].[AssessmentResourceActivityId] AND [t12].[Deleted] = 0
     WHERE [AssessmentResourceActivity5].[Deleted] = 0
 ) AS [t11] ON [t2].[Id] = [t11].[ResourceActivityId]
 WHERE t2.ResourceVersionId=@ResourceVersionId

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivities.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivities.sql
@@ -10,7 +10,8 @@
 -- Sarathlal	08-03-2024
 -- Sarathlal	23-04-2024 TD-2954: Audio/Video/Assessment issue resolved and duplicate issue also resolved
 -- Sarathlal	25-04-2024 TD-4067: Resource with muliple version issue resolved
--- Arunima	26-07-2024 TD-4411: "Completed" filter along with "Assessment" doesn't display the correct results
+-- Arunima		26-07-2024 TD-4411: "Completed" filter along with "Assessment" doesn't display the correct results
+-- Arunima		11-10-2024 TD-4261: Duplicate entries for the assessment results(elearning) in the My Learning page
 -------------------------------------------------------------------------------
 CREATE PROCEDURE [activity].[GetUserLearningActivities] (
 	 @userId INT	
@@ -215,7 +216,7 @@ FROM (
                      WHERE  ([ScormActivity].[Deleted] = 0 AND [ResourceActivity].[Id] = [ScormActivity].[ResourceActivityId])										 
 				) 
 					IS NULL
-			)		
+			)
 		AND   
 				(
 					(
@@ -227,11 +228,16 @@ FROM (
 								))
 					)
 				OR  
+				(
 					-- or launch resource activity completed
 					EXISTS
 					(
 							SELECT 1	FROM   [activity].[ResourceActivity] AS [ResAct2]
 							WHERE  [ResAct2].[Deleted] = 0 AND  [ResourceActivity].[Id] = [ResAct2].[LaunchResourceActivityId] AND  [ResAct2].[ActivityStatusId] in (3,7,5,4)
+					)
+					AND
+					(
+						[Res].[ResourceTypeId] <> 6)
 					)
 					
 				)
@@ -358,7 +364,7 @@ FROM (
 												(
 													(SELECT TOP(1) [ScormActivity1].[CmiCoreLesson_status]
 													FROM   [activity].[ScormActivity] AS [ScormActivity1]
-													WHERE [ScormActivity1].[Deleted] = 0 AND [ResourceActivity].[Id] = [ScormActivity1].[ResourceActivityId]) = 2
+													WHERE [ScormActivity1].[Deleted] = 0 AND [ResourceActivity].[Id] = [ScormActivity1].[ResourceActivityId]) = 7
 												)
 										)
 			
@@ -481,54 +487,18 @@ FROM (
 ) AS [t2]
 LEFT JOIN [resources].[VideoResourceVersion] AS [VideoResourceVersion] ON [t2].[Id1] = [VideoResourceVersion].[ResourceVersionId]
 LEFT JOIN [resources].[AudioResourceVersion] AS [AudeoResourceVersion] ON [t2].[Id1] = [AudeoResourceVersion].[ResourceVersionId]
-LEFT JOIN (
-    SELECT [ScormResourceVersion2].[Id], [ScormResourceVersion2].[AmendDate], [ScormResourceVersion2].[AmendUserId], [ScormResourceVersion2].[CanDownload], [ScormResourceVersion2].[ClearSuspendData], [ScormResourceVersion2].[ContentFilePath], [ScormResourceVersion2].[CreateDate], [ScormResourceVersion2].[CreateUserId], [ScormResourceVersion2].[Deleted], [ScormResourceVersion2].[DevelopmentId], [ScormResourceVersion2].[EsrLinkTypeId], [ScormResourceVersion2].[FileId], [ScormResourceVersion2].[PopupHeight], [ScormResourceVersion2].[PopupWidth], [ScormResourceVersion2].[ResourceVersionId]
-    FROM [resources].[ScormResourceVersion] AS [ScormResourceVersion2]
-    WHERE [ScormResourceVersion2].[Deleted] = 0
-) AS [t3] ON [t2].[Id1] = [t3].[ResourceVersionId]
-LEFT JOIN (
-    SELECT [ScormResourceVersionManifest3].[Id], [ScormResourceVersionManifest3].[AmendDate], [ScormResourceVersionManifest3].[AmendUserId], [ScormResourceVersionManifest3].[Author], [ScormResourceVersionManifest3].[CatalogEntry], [ScormResourceVersionManifest3].[Copyright], [ScormResourceVersionManifest3].[CreateDate], [ScormResourceVersionManifest3].[CreateUserId], [ScormResourceVersionManifest3].[Deleted], [ScormResourceVersionManifest3].[Description], [ScormResourceVersionManifest3].[Duration], [ScormResourceVersionManifest3].[ItemIdentifier], [ScormResourceVersionManifest3].[Keywords], [ScormResourceVersionManifest3].[LaunchData], [ScormResourceVersionManifest3].[ManifestURL], [ScormResourceVersionManifest3].[MasteryScore], [ScormResourceVersionManifest3].[MaxTimeAllowed], [ScormResourceVersionManifest3].[QuicklinkId], [ScormResourceVersionManifest3].[ResourceIdentifier], [ScormResourceVersionManifest3].[ScormResourceVersionId], [ScormResourceVersionManifest3].[TemplateVersion], [ScormResourceVersionManifest3].[TimeLimitAction], [ScormResourceVersionManifest3].[Title]
-    FROM [resources].[ScormResourceVersionManifest] AS [ScormResourceVersionManifest3]
-    WHERE [ScormResourceVersionManifest3].[Deleted] = 0
-) AS [t4] ON [t3].[Id] = [t4].[ScormResourceVersionId]
-LEFT JOIN (
-    SELECT [BlockCollection].[Id], [BlockCollection].[AmendDate], [BlockCollection].[AmendUserId], [BlockCollection].[CreateDate], [BlockCollection].[CreateUserId], [BlockCollection].[Deleted]
-    FROM [resources].[BlockCollection] AS [BlockCollection]
-    WHERE [BlockCollection].[Deleted] = 0
-) AS [t5] ON [t2].[AssessmentContentId] = [t5].[Id]
-INNER JOIN (
-    SELECT [NodePath].[Id], [NodePath].[AmendDate], [NodePath].[AmendUserId], [NodePath].[CatalogueNodeId], [NodePath].[CreateDate], [NodePath].[CreateUserId], [NodePath].[Deleted], [NodePath].[IsActive], [NodePath].[NodeId], [NodePath].[NodePath]
-    FROM [hierarchy].[NodePath] AS [NodePath]
-    WHERE [NodePath].[Deleted] = 0
-) AS [t6] ON [t2].[NodePathId] = [t6].[Id]
-LEFT JOIN (
-    SELECT [ResourceReference5].[Id], [ResourceReference5].[AmendDate], [ResourceReference5].[AmendUserId], [ResourceReference5].[CreateDate], [ResourceReference5].[CreateUserId], [ResourceReference5].[Deleted], [ResourceReference5].[NodePathId], [ResourceReference5].[OriginalResourceReferenceId], [ResourceReference5].[ResourceId]
-    FROM [resources].[ResourceReference] AS [ResourceReference5]
-    WHERE [ResourceReference5].[Deleted] = 0
-) AS [t7] ON [t2].[Id0] = [t7].[ResourceId]
-LEFT JOIN (
-    SELECT [MediaResourceActivity3].[Id], [MediaResourceActivity3].[ActivityStart], [MediaResourceActivity3].[AmendDate], [MediaResourceActivity3].[AmendUserID], [MediaResourceActivity3].[CreateDate], [MediaResourceActivity3].[CreateUserID], [MediaResourceActivity3].[Deleted], [MediaResourceActivity3].[PercentComplete], [MediaResourceActivity3].[ResourceActivityId], [MediaResourceActivity3].[SecondsPlayed]
-    FROM [activity].[MediaResourceActivity] AS [MediaResourceActivity3]
-    WHERE [MediaResourceActivity3].[Deleted] = 0
-) AS [t8] ON [t2].[Id] = [t8].[ResourceActivityId]
-LEFT JOIN (
-    SELECT [ScormActivity4].[Id], [ScormActivity4].[AmendDate], [ScormActivity4].[AmendUserID], [ScormActivity4].[CmiCoreExit], [ScormActivity4].[CmiCoreLesson_location], [ScormActivity4].[CmiCoreLesson_status], [ScormActivity4].[CmiCoreScoreMax], [ScormActivity4].[CmiCoreScoreMin], [ScormActivity4].[CmiCoreScoreRaw], [ScormActivity4].[CmiCoreSession_time], [ScormActivity4].[CmiSuspend_data], [ScormActivity4].[CreateDate], [ScormActivity4].[CreateUserID], [ScormActivity4].[Deleted], [ScormActivity4].[DurationSeconds], [ScormActivity4].[ResourceActivityId]
-    FROM [activity].[ScormActivity] AS [ScormActivity4]
-    WHERE [ScormActivity4].[Deleted] = 0
-) AS [t9] ON [t2].[Id] = [t9].[ResourceActivityId]
-LEFT JOIN (
-    SELECT [Block0].[Id], [Block0].[AmendDate], [Block0].[AmendUserId], [Block0].[BlockCollectionId], [Block0].[BlockType], [Block0].[CreateDate], [Block0].[CreateUserId], [Block0].[Deleted], [Block0].[Order], [Block0].[Title]
-    FROM [resources].[Block] AS [Block0]
-    WHERE [Block0].[Deleted] = 0
-) AS [t10] ON [t5].[Id] = [t10].[BlockCollectionId]
+LEFT JOIN [resources].[ScormResourceVersion] AS [t3] ON [t2].[Id1] = [t3].[ResourceVersionId] and t3.Deleted=0
+LEFT JOIN [resources].[ScormResourceVersionManifest] AS [t4] ON [t3].[Id] = [t4].[ScormResourceVersionId] and [t4].[Deleted] = 0
+LEFT JOIN [resources].[BlockCollection]  AS [t5] ON [t2].[AssessmentContentId] = [t5].[Id] AND [t5].[Deleted] = 0
+INNER JOIN [hierarchy].[NodePath] AS [t6] ON [t2].[NodePathId] = [t6].[Id] AND [t6].[Deleted] = 0
+LEFT JOIN [resources].[ResourceReference] AS [t7] ON [t2].[Id0] = [t7].[ResourceId] AND [t7].[Deleted] = 0
+LEFT JOIN [activity].[MediaResourceActivity] AS [t8] ON [t2].[Id] = [t8].[ResourceActivityId] AND [t8].[Deleted] = 0
+LEFT JOIN [activity].[ScormActivity] AS [t9] ON [t2].[Id] = [t9].[ResourceActivityId] AND [t9].[Deleted] = 0
+LEFT JOIN [resources].[Block] AS [t10] ON [t5].[Id] = [t10].[BlockCollectionId] AND [t10].[Deleted] = 0
 LEFT JOIN (
     SELECT [AssessmentResourceActivity5].[Id], [AssessmentResourceActivity5].[AmendDate], [AssessmentResourceActivity5].[AmendUserID], [AssessmentResourceActivity5].[CreateDate], [AssessmentResourceActivity5].[CreateUserID], [AssessmentResourceActivity5].[Deleted], [AssessmentResourceActivity5].[Reason], [AssessmentResourceActivity5].[ResourceActivityId], [AssessmentResourceActivity5].[Score], [t12].[Id] AS [Id0], [t12].[AmendDate] AS [AmendDate0], [t12].[AmendUserID] AS [AmendUserID0], [t12].[AssessmentResourceActivityId], [t12].[CreateDate] AS [CreateDate0], [t12].[CreateUserID] AS [CreateUserID0], [t12].[Deleted] AS [Deleted0], [t12].[QuestionBlockId]
     FROM [activity].[AssessmentResourceActivity] AS [AssessmentResourceActivity5]
-    LEFT JOIN (
-        SELECT [AssessmentResourceActivityInteraction6].[Id], [AssessmentResourceActivityInteraction6].[AmendDate], [AssessmentResourceActivityInteraction6].[AmendUserID], [AssessmentResourceActivityInteraction6].[AssessmentResourceActivityId], [AssessmentResourceActivityInteraction6].[CreateDate], [AssessmentResourceActivityInteraction6].[CreateUserID], [AssessmentResourceActivityInteraction6].[Deleted], [AssessmentResourceActivityInteraction6].[QuestionBlockId]
-        FROM [activity].[AssessmentResourceActivityInteraction] AS [AssessmentResourceActivityInteraction6]
-        WHERE [AssessmentResourceActivityInteraction6].[Deleted] = 0
-    ) AS [t12] ON [AssessmentResourceActivity5].[Id] = [t12].[AssessmentResourceActivityId]
+	LEFT JOIN [activity].[AssessmentResourceActivityInteraction] AS [t12] ON [AssessmentResourceActivity5].[Id] = [t12].[AssessmentResourceActivityId] AND [t12].[Deleted] = 0
     WHERE [AssessmentResourceActivity5].[Deleted] = 0
 ) AS [t11] ON [t2].[Id] = [t11].[ResourceActivityId]
 ORDER BY [t2].[ActivityStart] DESC, [t2].[Id], [t2].[Id0], [t2].[Id1], [t2].[Id2], [VideoResourceVersion].[Id], [AudeoResourceVersion].[Id], [t3].[Id], [t4].[Id], [t5].[Id], [t6].[Id], [t7].[Id], [t8].[Id], [t9].[Id], [t10].[Id], [t11].[Id]

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivitiesCount.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserLearningActivitiesCount.sql
@@ -9,7 +9,8 @@
 -- Sarathlal	18-12-2023
 -- Sarathlal	08-03-2024
 -- Sarathlal	23-04-2024	TD-2954: Audio/Video/Assessment issue resolved and duplicate issue also resolved
--- Arunima	26-07-2024  TD-4411: "Completed" filter along with "Assessment" doesn't display the correct results
+-- Arunima		26-07-2024  TD-4411: "Completed" filter along with "Assessment" doesn't display the correct results
+-- Arunima		11-10-2024	TD-4261: Duplicate entries for the assessment results(elearning) in the My Learning page
 -------------------------------------------------------------------------------
 CREATE PROCEDURE [activity].[GetUserLearningActivitiesCount] (
 	 @userId INT	
@@ -142,11 +143,15 @@ FROM (
 								))
 					)
 				OR  
+				(
 					-- or launch resource activity completed
 					EXISTS
 					(
 							SELECT 1	FROM   [activity].[ResourceActivity] AS [ResAct2]
 							WHERE  [ResAct2].[Deleted] = 0 AND  [ResourceActivity].[Id] = [ResAct2].[LaunchResourceActivityId] AND  [ResAct2].[ActivityStatusId] in (3,7,5,4)
+					)
+					AND
+					([Res].[ResourceTypeId] <> 6)
 					)
 					
 				)
@@ -273,7 +278,7 @@ FROM (
 												(
 													(SELECT TOP(1) [ScormActivity1].[CmiCoreLesson_status]
 													FROM   [activity].[ScormActivity] AS [ScormActivity1]
-													WHERE [ScormActivity1].[Deleted] = 0 AND [ResourceActivity].[Id] = [ScormActivity1].[ResourceActivityId]) = 2
+													WHERE [ScormActivity1].[Deleted] = 0 AND [ResourceActivity].[Id] = [ScormActivity1].[ResourceActivityId]) = 7
 												)
 										)
 			
@@ -393,54 +398,18 @@ FROM (
 ) AS [t2]
 LEFT JOIN [resources].[VideoResourceVersion] AS [VideoResourceVersion] ON [t2].[Id1] = [VideoResourceVersion].[ResourceVersionId]
 LEFT JOIN [resources].[AudioResourceVersion] AS [AudeoResourceVersion] ON [t2].[Id1] = [AudeoResourceVersion].[ResourceVersionId]
-LEFT JOIN (
-    SELECT [ScormResourceVersion2].[Id], [ScormResourceVersion2].[AmendDate], [ScormResourceVersion2].[AmendUserId], [ScormResourceVersion2].[CanDownload], [ScormResourceVersion2].[ClearSuspendData], [ScormResourceVersion2].[ContentFilePath], [ScormResourceVersion2].[CreateDate], [ScormResourceVersion2].[CreateUserId], [ScormResourceVersion2].[Deleted], [ScormResourceVersion2].[DevelopmentId], [ScormResourceVersion2].[EsrLinkTypeId], [ScormResourceVersion2].[FileId], [ScormResourceVersion2].[PopupHeight], [ScormResourceVersion2].[PopupWidth], [ScormResourceVersion2].[ResourceVersionId]
-    FROM [resources].[ScormResourceVersion] AS [ScormResourceVersion2]
-    WHERE [ScormResourceVersion2].[Deleted] = 0
-) AS [t3] ON [t2].[Id1] = [t3].[ResourceVersionId]
-LEFT JOIN (
-    SELECT [ScormResourceVersionManifest3].[Id], [ScormResourceVersionManifest3].[AmendDate], [ScormResourceVersionManifest3].[AmendUserId], [ScormResourceVersionManifest3].[Author], [ScormResourceVersionManifest3].[CatalogEntry], [ScormResourceVersionManifest3].[Copyright], [ScormResourceVersionManifest3].[CreateDate], [ScormResourceVersionManifest3].[CreateUserId], [ScormResourceVersionManifest3].[Deleted], [ScormResourceVersionManifest3].[Description], [ScormResourceVersionManifest3].[Duration], [ScormResourceVersionManifest3].[ItemIdentifier], [ScormResourceVersionManifest3].[Keywords], [ScormResourceVersionManifest3].[LaunchData], [ScormResourceVersionManifest3].[ManifestURL], [ScormResourceVersionManifest3].[MasteryScore], [ScormResourceVersionManifest3].[MaxTimeAllowed], [ScormResourceVersionManifest3].[QuicklinkId], [ScormResourceVersionManifest3].[ResourceIdentifier], [ScormResourceVersionManifest3].[ScormResourceVersionId], [ScormResourceVersionManifest3].[TemplateVersion], [ScormResourceVersionManifest3].[TimeLimitAction], [ScormResourceVersionManifest3].[Title]
-    FROM [resources].[ScormResourceVersionManifest] AS [ScormResourceVersionManifest3]
-    WHERE [ScormResourceVersionManifest3].[Deleted] = 0
-) AS [t4] ON [t3].[Id] = [t4].[ScormResourceVersionId]
-LEFT JOIN (
-    SELECT [BlockCollection].[Id], [BlockCollection].[AmendDate], [BlockCollection].[AmendUserId], [BlockCollection].[CreateDate], [BlockCollection].[CreateUserId], [BlockCollection].[Deleted]
-    FROM [resources].[BlockCollection] AS [BlockCollection]
-    WHERE [BlockCollection].[Deleted] = 0
-) AS [t5] ON [t2].[AssessmentContentId] = [t5].[Id]
-INNER JOIN (
-    SELECT [NodePath].[Id], [NodePath].[AmendDate], [NodePath].[AmendUserId], [NodePath].[CatalogueNodeId], [NodePath].[CreateDate], [NodePath].[CreateUserId], [NodePath].[Deleted], [NodePath].[IsActive], [NodePath].[NodeId], [NodePath].[NodePath]
-    FROM [hierarchy].[NodePath] AS [NodePath]
-    WHERE [NodePath].[Deleted] = 0
-) AS [t6] ON [t2].[NodePathId] = [t6].[Id]
-LEFT JOIN (
-    SELECT [ResourceReference5].[Id], [ResourceReference5].[AmendDate], [ResourceReference5].[AmendUserId], [ResourceReference5].[CreateDate], [ResourceReference5].[CreateUserId], [ResourceReference5].[Deleted], [ResourceReference5].[NodePathId], [ResourceReference5].[OriginalResourceReferenceId], [ResourceReference5].[ResourceId]
-    FROM [resources].[ResourceReference] AS [ResourceReference5]
-    WHERE [ResourceReference5].[Deleted] = 0
-) AS [t7] ON [t2].[Id0] = [t7].[ResourceId]
-LEFT JOIN (
-    SELECT [MediaResourceActivity3].[Id], [MediaResourceActivity3].[ActivityStart], [MediaResourceActivity3].[AmendDate], [MediaResourceActivity3].[AmendUserID], [MediaResourceActivity3].[CreateDate], [MediaResourceActivity3].[CreateUserID], [MediaResourceActivity3].[Deleted], [MediaResourceActivity3].[PercentComplete], [MediaResourceActivity3].[ResourceActivityId], [MediaResourceActivity3].[SecondsPlayed]
-    FROM [activity].[MediaResourceActivity] AS [MediaResourceActivity3]
-    WHERE [MediaResourceActivity3].[Deleted] = 0
-) AS [t8] ON [t2].[Id] = [t8].[ResourceActivityId]
-LEFT JOIN (
-    SELECT [ScormActivity4].[Id], [ScormActivity4].[AmendDate], [ScormActivity4].[AmendUserID], [ScormActivity4].[CmiCoreExit], [ScormActivity4].[CmiCoreLesson_location], [ScormActivity4].[CmiCoreLesson_status], [ScormActivity4].[CmiCoreScoreMax], [ScormActivity4].[CmiCoreScoreMin], [ScormActivity4].[CmiCoreScoreRaw], [ScormActivity4].[CmiCoreSession_time], [ScormActivity4].[CmiSuspend_data], [ScormActivity4].[CreateDate], [ScormActivity4].[CreateUserID], [ScormActivity4].[Deleted], [ScormActivity4].[DurationSeconds], [ScormActivity4].[ResourceActivityId]
-    FROM [activity].[ScormActivity] AS [ScormActivity4]
-    WHERE [ScormActivity4].[Deleted] = 0
-) AS [t9] ON [t2].[Id] = [t9].[ResourceActivityId]
-LEFT JOIN (
-    SELECT [Block0].[Id], [Block0].[AmendDate], [Block0].[AmendUserId], [Block0].[BlockCollectionId], [Block0].[BlockType], [Block0].[CreateDate], [Block0].[CreateUserId], [Block0].[Deleted], [Block0].[Order], [Block0].[Title]
-    FROM [resources].[Block] AS [Block0]
-    WHERE [Block0].[Deleted] = 0
-) AS [t10] ON [t5].[Id] = [t10].[BlockCollectionId]
+LEFT JOIN [resources].[ScormResourceVersion] AS [t3] ON [t2].[Id1] = [t3].[ResourceVersionId] and t3.Deleted=0
+LEFT JOIN [resources].[ScormResourceVersionManifest] AS [t4] ON [t3].[Id] = [t4].[ScormResourceVersionId] and [t4].[Deleted] = 0
+LEFT JOIN [resources].[BlockCollection]  AS [t5] ON [t2].[AssessmentContentId] = [t5].[Id] AND [t5].[Deleted] = 0
+INNER JOIN [hierarchy].[NodePath] AS [t6] ON [t2].[NodePathId] = [t6].[Id] AND [t6].[Deleted] = 0
+LEFT JOIN [resources].[ResourceReference] AS [t7] ON [t2].[Id0] = [t7].[ResourceId] AND [t7].[Deleted] = 0
+LEFT JOIN [activity].[MediaResourceActivity] AS [t8] ON [t2].[Id] = [t8].[ResourceActivityId] AND [t8].[Deleted] = 0
+LEFT JOIN [activity].[ScormActivity] AS [t9] ON [t2].[Id] = [t9].[ResourceActivityId] AND [t9].[Deleted] = 0
+LEFT JOIN [resources].[Block] AS [t10] ON [t5].[Id] = [t10].[BlockCollectionId] AND [t10].[Deleted] = 0
 LEFT JOIN (
     SELECT [AssessmentResourceActivity5].[Id], [AssessmentResourceActivity5].[AmendDate], [AssessmentResourceActivity5].[AmendUserID], [AssessmentResourceActivity5].[CreateDate], [AssessmentResourceActivity5].[CreateUserID], [AssessmentResourceActivity5].[Deleted], [AssessmentResourceActivity5].[Reason], [AssessmentResourceActivity5].[ResourceActivityId], [AssessmentResourceActivity5].[Score], [t12].[Id] AS [Id0], [t12].[AmendDate] AS [AmendDate0], [t12].[AmendUserID] AS [AmendUserID0], [t12].[AssessmentResourceActivityId], [t12].[CreateDate] AS [CreateDate0], [t12].[CreateUserID] AS [CreateUserID0], [t12].[Deleted] AS [Deleted0], [t12].[QuestionBlockId]
     FROM [activity].[AssessmentResourceActivity] AS [AssessmentResourceActivity5]
-    LEFT JOIN (
-        SELECT [AssessmentResourceActivityInteraction6].[Id], [AssessmentResourceActivityInteraction6].[AmendDate], [AssessmentResourceActivityInteraction6].[AmendUserID], [AssessmentResourceActivityInteraction6].[AssessmentResourceActivityId], [AssessmentResourceActivityInteraction6].[CreateDate], [AssessmentResourceActivityInteraction6].[CreateUserID], [AssessmentResourceActivityInteraction6].[Deleted], [AssessmentResourceActivityInteraction6].[QuestionBlockId]
-        FROM [activity].[AssessmentResourceActivityInteraction] AS [AssessmentResourceActivityInteraction6]
-        WHERE [AssessmentResourceActivityInteraction6].[Deleted] = 0
-    ) AS [t12] ON [AssessmentResourceActivity5].[Id] = [t12].[AssessmentResourceActivityId]
+	LEFT JOIN [activity].[AssessmentResourceActivityInteraction] AS [t12] ON [AssessmentResourceActivity5].[Id] = [t12].[AssessmentResourceActivityId] AND [t12].[Deleted] = 0
     WHERE [AssessmentResourceActivity5].[Deleted] = 0
 ) AS [t11] ON [t2].[Id] = [t11].[ResourceActivityId]
 GROUP BY [t2].[Id]	


### PR DESCRIPTION

### JIRA link
_[TD-4261](https://hee-tis.atlassian.net/browse/TD-4261)_

### Description
Fixed the duplicate entries for the assessment results showing in my learning activities page. Also made changes to these sps 
as per the suggestions which was pending from EF to SP conversion.

### Screenshots
After

![image](https://github.com/user-attachments/assets/87b25510-2fa8-4cc6-a029-27144669dda4)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4261]: https://hee-tis.atlassian.net/browse/TD-4261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ