### PR TITLE
TD-2895: Modify Learning Resource endpoints to retrieve user status f…

### DIFF
--- a/AdminUI/LearningHub.Nhs.AdminUI/LearningHub.Nhs.AdminUI.csproj
+++ b/AdminUI/LearningHub.Nhs.AdminUI/LearningHub.Nhs.AdminUI.csproj
@@ -89,7 +89,7 @@
     <PackageReference Include="HtmlSanitizer" Version="6.0.453" />
 	<PackageReference Include="IdentityModel" Version="4.4.0" />
     <PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.2" />
-    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.40" />
+    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.41" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.19.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />

--- a/LearningHub.Nhs.WebUI/LearningHub.Nhs.WebUI.csproj
+++ b/LearningHub.Nhs.WebUI/LearningHub.Nhs.WebUI.csproj
@@ -108,7 +108,7 @@
 		<PackageReference Include="HtmlAgilityPack" Version="1.11.38" />
 		<PackageReference Include="IdentityModel" Version="4.3.0" />
 		<PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
-		<PackageReference Include="LearningHub.Nhs.Models" Version="3.0.40" />
+		<PackageReference Include="LearningHub.Nhs.Models" Version="3.0.41" />
 		<PackageReference Include="linqtotwitter" Version="6.9.0" />
 		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.19.0" />
 		<PackageReference Include="Microsoft.ApplicationInsights.EventCounterCollector" Version="2.21.0" />

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Models/LearningHub.Nhs.OpenApi.Models.csproj
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Models/LearningHub.Nhs.OpenApi.Models.csproj
@@ -16,7 +16,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.39" />
+      <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.41" />
       <PackageReference Include="NLog.Web.AspNetCore" Version="4.13.0" />
     </ItemGroup>
 

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Services.Interface/LearningHub.Nhs.OpenApi.Services.Interface.csproj
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Services.Interface/LearningHub.Nhs.OpenApi.Services.Interface.csproj
@@ -16,7 +16,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.39" />
+      <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.41" />
     </ItemGroup>
 
     <ItemGroup>

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Services/LearningHub.Nhs.OpenApi.Services.csproj
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Services/LearningHub.Nhs.OpenApi.Services.csproj
@@ -24,7 +24,7 @@
     <ItemGroup>
       <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.4" />
       <PackageReference Include="IdentityModel" Version="4.3.0" />
-      <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.39" />
+      <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.41" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Services/Services/SearchService.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Services/Services/SearchService.cs
@@ -83,6 +83,7 @@ namespace LearningHub.Nhs.OpenApi.Services.Services
             FindwiseResultModel findwiseResultModel, int? currentUserId)
         {
             List<ResourceActivityDTO> resourceActivities = new List<ResourceActivityDTO>() { };
+            List<ResourceMetadataViewModel> resourceMetadataViewModels = new List<ResourceMetadataViewModel>() { };
             var documentsFound = findwiseResultModel.SearchResults?.DocumentList.Documents?.ToList() ??
                                  new List<Document>();
             var findwiseResourceIds = documentsFound.Select(d => int.Parse(d.Id)).ToList();
@@ -102,7 +103,7 @@ namespace LearningHub.Nhs.OpenApi.Services.Services
                 resourceActivities = (await this.resourceRepository.GetResourceActivityPerResourceMajorVersion(resourceIds, userIds))?.ToList() ?? new List<ResourceActivityDTO>() { };
             }
 
-            List<ResourceMetadataViewModel> resourceMetadataViewModels = resourcesFound.Select(resource => this.MapToViewModel(resource, resourceActivities.Where(x => x.ResourceId == resource.Id).ToList()))
+            resourceMetadataViewModels = resourcesFound.Select(resource => this.MapToViewModel(resource, resourceActivities.Where(x => x.ResourceId == resource.Id).ToList()))
                 .OrderBySequence(findwiseResourceIds)
                 .ToList();
 

--- a/WebAPI/LearningHub.Nhs.API/LearningHub.Nhs.Api.csproj
+++ b/WebAPI/LearningHub.Nhs.API/LearningHub.Nhs.Api.csproj
@@ -27,7 +27,7 @@
 	<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.8" />
 	<PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
 	<PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
-	<PackageReference Include="LearningHub.Nhs.Models" Version="3.0.40" />
+	<PackageReference Include="LearningHub.Nhs.Models" Version="3.0.41" />
 	<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.19.0" />
 	<PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />

--- a/WebAPI/LearningHub.Nhs.Api.Shared/LearningHub.Nhs.Api.Shared.csproj
+++ b/WebAPI/LearningHub.Nhs.Api.Shared/LearningHub.Nhs.Api.Shared.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="elfhHub.Nhs.Models" Version="3.0.8" />
     <PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
-    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.40" />
+    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.41" />
 	<PackageReference Update="StyleCop.Analyzers" Version="1.1.118">
 		<PrivateAssets>all</PrivateAssets>
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/WebAPI/LearningHub.Nhs.Api.UnitTests/LearningHub.Nhs.Api.UnitTests.csproj
+++ b/WebAPI/LearningHub.Nhs.Api.UnitTests/LearningHub.Nhs.Api.UnitTests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="elfhHub.Nhs.Models" Version="3.0.8" />
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
     <PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
-    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.40" />
+    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.41" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />

--- a/WebAPI/LearningHub.Nhs.Repository.Interface/LearningHub.Nhs.Repository.Interface.csproj
+++ b/WebAPI/LearningHub.Nhs.Repository.Interface/LearningHub.Nhs.Repository.Interface.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
    <PackageReference Include="elfhHub.Nhs.Models" Version="3.0.8" />
    <PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
-   <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.40" />
+   <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.41" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
 	<PackageReference Update="StyleCop.Analyzers" Version="1.1.118">

--- a/WebAPI/LearningHub.Nhs.Repository/LearningHub.Nhs.Repository.csproj
+++ b/WebAPI/LearningHub.Nhs.Repository/LearningHub.Nhs.Repository.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="elfhHub.Nhs.Models" Version="3.0.8" />
     <PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
-    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.40" />
+    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.41" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
 	<PackageReference Update="StyleCop.Analyzers" Version="1.1.118">

--- a/WebAPI/LearningHub.Nhs.Services.Interface/LearningHub.Nhs.Services.Interface.csproj
+++ b/WebAPI/LearningHub.Nhs.Services.Interface/LearningHub.Nhs.Services.Interface.csproj
@@ -16,7 +16,7 @@
 	<PackageReference Include="Azure.Storage.Queues" Version="12.11.0" />
 	<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.8" />
     <PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
-    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.40" />
+    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.41" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
 	<PackageReference Update="StyleCop.Analyzers" Version="1.1.118">
 		<PrivateAssets>all</PrivateAssets>

--- a/WebAPI/LearningHub.Nhs.Services.UnitTests/LearningHub.Nhs.Services.UnitTests.csproj
+++ b/WebAPI/LearningHub.Nhs.Services.UnitTests/LearningHub.Nhs.Services.UnitTests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="EntityFrameworkCore.Testing.Moq" Version="4.0.0" />
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
     <PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
-    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.40" />
+    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.41" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />

--- a/WebAPI/LearningHub.Nhs.Services/LearningHub.Nhs.Services.csproj
+++ b/WebAPI/LearningHub.Nhs.Services/LearningHub.Nhs.Services.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="elfhHub.Nhs.Models" Version="3.0.8" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.4" />
     <PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
-    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.40" />
+    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.41" />
     <PackageReference Include="Microsoft.Azure.Management.DataFactory" Version="4.28.0" />
     <PackageReference Include="Microsoft.Azure.Management.Media" Version="5.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />

--- a/WebAPI/MigrationTool/LearningHub.Nhs.Migration.ConsoleApp/LearningHub.Nhs.Migration.ConsoleApp.csproj
+++ b/WebAPI/MigrationTool/LearningHub.Nhs.Migration.ConsoleApp/LearningHub.Nhs.Migration.ConsoleApp.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="elfhHub.Nhs.Models" Version="3.0.8" />
     <PackageReference Include="IdentityModel" Version="5.2.0" />
     <PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
-    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.40" />
+    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.41" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
 	<PackageReference Update="StyleCop.Analyzers" Version="1.1.118">
 		<PrivateAssets>all</PrivateAssets>

--- a/WebAPI/MigrationTool/LearningHub.Nhs.Migration.Interface/LearningHub.Nhs.Migration.Interface.csproj
+++ b/WebAPI/MigrationTool/LearningHub.Nhs.Migration.Interface/LearningHub.Nhs.Migration.Interface.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="elfhHub.Nhs.Models" Version="3.0.8" />
     <PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
-    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.40" />
+    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.41" />
 	<PackageReference Update="StyleCop.Analyzers" Version="1.1.118">
 		<PrivateAssets>all</PrivateAssets>
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/WebAPI/MigrationTool/LearningHub.Nhs.Migration.Models/LearningHub.Nhs.Migration.Models.csproj
+++ b/WebAPI/MigrationTool/LearningHub.Nhs.Migration.Models/LearningHub.Nhs.Migration.Models.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="elfhHub.Nhs.Models" Version="3.0.8" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.4" />
     <PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
-    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.40" />
+    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.41" />
 	<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	<PackageReference Update="StyleCop.Analyzers" Version="1.1.118">
 		<PrivateAssets>all</PrivateAssets>

--- a/WebAPI/MigrationTool/LearningHub.Nhs.Migration.Staging.Repository/LearningHub.Nhs.Migration.Staging.Repository.csproj
+++ b/WebAPI/MigrationTool/LearningHub.Nhs.Migration.Staging.Repository/LearningHub.Nhs.Migration.Staging.Repository.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="elfhHub.Nhs.Models" Version="3.0.8" />
     <PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
-    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.40" />
+    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.41" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
   </ItemGroup>

--- a/WebAPI/MigrationTool/LearningHub.Nhs.Migration.UnitTests/LearningHub.Nhs.Migration.UnitTests.csproj
+++ b/WebAPI/MigrationTool/LearningHub.Nhs.Migration.UnitTests/LearningHub.Nhs.Migration.UnitTests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="elfhHub.Nhs.Models" Version="3.0.8" />
     <PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
-    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.40" />
+    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.41" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
 	<PackageReference Update="StyleCop.Analyzers" Version="1.1.118">

--- a/WebAPI/MigrationTool/LearningHub.Nhs.Migration/LearningHub.Nhs.Migration.csproj
+++ b/WebAPI/MigrationTool/LearningHub.Nhs.Migration/LearningHub.Nhs.Migration.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="FluentValidation" Version="10.3.4" />
     <PackageReference Include="HtmlSanitizer" Version="6.0.453" />
     <PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
-    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.40" />
+    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.41" />
 	<PackageReference Update="StyleCop.Analyzers" Version="1.1.118">
 		<PrivateAssets>all</PrivateAssets>
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
…or learning resource (SIT fixes)

### JIRA link
https://hee-tis.atlassian.net/browse/TD-2895

### Description
Fixed the SIT comments related to the HTML file type and the search end points

### Screenshots

**Search End point - Learning status** 
![image](https://github.com/user-attachments/assets/99190c8d-f89f-4d62-8265-fe85507b57b4)

**HTML - eLearning status**

![image](https://github.com/user-attachments/assets/6ae85c78-d3a8-42fe-92a5-8a31aa45bd3c)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
