### PR TITLE
TD-4944: UI Overlap on Mobile Devices

### DIFF
--- a/AdminUI/LearningHub.Nhs.AdminUI/wwwroot/css/mkplayer-ui.css
+++ b/AdminUI/LearningHub.Nhs.AdminUI/wwwroot/css/mkplayer-ui.css
@@ -89,7 +89,7 @@
         display: -webkit-box;
         display: -ms-flexbox;
         display: flex;
-        margin: .5em 0
+        margin: 1em 0
     }
 
     .bmpui-ui-controlbar .bmpui-controlbar-top .bmpui-ui-label {
@@ -563,7 +563,7 @@
 
 .bmpui-ui-seekbar, .bmpui-ui-volumeslider {
     cursor: pointer;
-    font-size: 1em;
+    font-size: 0.2em;
     height: 1em;
     position: relative;
     width: 100%
@@ -684,7 +684,7 @@
 
 .bmpui-ui-uicontainer .bmpui-ui-subtitle-overlay {
     bottom: 0;
-    font-size: 1.2em;
+    font-size: 1em;
     left: 0;
     pointer-events: none;
     position: absolute;

--- a/LearningHub.Nhs.WebUI/wwwroot/css/mkplayer-ui.css
+++ b/LearningHub.Nhs.WebUI/wwwroot/css/mkplayer-ui.css
@@ -89,7 +89,7 @@
         display: -webkit-box;
         display: -ms-flexbox;
         display: flex;
-        margin: .5em 0
+        margin: 1em 0
     }
 
     .bmpui-ui-controlbar .bmpui-controlbar-top .bmpui-ui-label {
@@ -563,7 +563,7 @@
 
 .bmpui-ui-seekbar, .bmpui-ui-volumeslider {
     cursor: pointer;
-    font-size: 1em;
+    font-size: 0.2em;
     height: 1em;
     position: relative;
     width: 100%
@@ -684,7 +684,7 @@
 
 .bmpui-ui-uicontainer .bmpui-ui-subtitle-overlay {
     bottom: 0;
-    font-size: 1.2em;
+    font-size: 1em;
     left: 0;
     pointer-events: none;
     position: absolute;


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4944

### Description
Fixed the issue with UI Overlap on Mobile Devices  

### Screenshots

**After Fix**

**Mobile Views**
![image](https://github.com/user-attachments/assets/9ffd1850-5e82-4344-9dba-78a8e44904a3)

![image](https://github.com/user-attachments/assets/ac789330-0470-4006-8dae-1a3484859064)

**System View**

![image](https://github.com/user-attachments/assets/00d79140-b71d-4af4-ad97-a950f0dce4c8)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
