### PR TITLE
TD-4251: Fixed title bold issue on admin UI compared to web UI on safari browser

### DIFF
--- a/AdminUI/LearningHub.Nhs.AdminUI/Styles/Pages/page_detail.scss
+++ b/AdminUI/LearningHub.Nhs.AdminUI/Styles/Pages/page_detail.scss
@@ -252,6 +252,10 @@ h4 {
     font-size: 16px;
 }
 
+.information-page__row h1,h2,h3,h4 {
+    font-family: "Frutiger W01", Arial, sans-serif !important;
+}
+
 /* desktop */
 @media (min-width: 990px) {
 }


### PR DESCRIPTION
### JIRA link
_[TD-4251](https://hee-tis.atlassian.net/browse/TD-4251)_

### Description
Fixed the title bold issue on AdminUI when compared with WebUI on safari browser.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4251]: https://hee-tis.atlassian.net/browse/TD-4251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ