### PR TITLE
TD-4081:DIG306: Labels for form fields are missing

### DIFF
--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/bookmark/togglebookmark.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/bookmark/togglebookmark.vue
@@ -24,7 +24,8 @@
                             <div class="modal-body-container p-3 mt-2 mb-2">
                                 <form>
                                     <div class="d-flex">
-                                        <input class="form-control input titleInput" type="text" v-model="title" v-bind:maxlength="maxAllowedTitleLength" />
+                                        <label class="nhsuk-u-visually-hidden" for="titleInput"></label>
+                                        <input class="form-control input titleInput" id="titleInput" type="text" v-model="title" v-bind:maxlength="maxAllowedTitleLength" />
                                     </div>
                                 </form>
                             </div>

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/catalogue/catalogueaccessrequest.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/catalogue/catalogueaccessrequest.vue
@@ -98,7 +98,8 @@
                             </div>
                             <div class="row mt-5">
                                 <div class="col">
-                                    <textarea v-model="rejectionMessage" class="form-control rejection-message-input" rows="6"></textarea>
+                                    <label class="nhsuk-u-visually-hidden" for="rejectionMessage"></label>
+                                    <textarea v-model="rejectionMessage" id="rejectionMessage" class="form-control rejection-message-input" rows="6"></textarea>
                                 </div>
                             </div>
                         </div>

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/ContributeAssessmentSettings.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/ContributeAssessmentSettings.vue
@@ -41,8 +41,8 @@
 
                         <div class="d-flex">
                             <div class="selection pr-50">
-                                <div class="mb-4">Add a pass mark for this assessment. This is the percentage that the learner must achieve in order to pass.</div>
-                                <input class="text-input" type="text" v-model="assessmentDetails.passMark"/>
+                                <div class="mb-4"><label for="passmark">Add a pass mark for this assessment. This is the percentage that the learner must achieve in order to pass.</label></div>
+                                <input class="text-input" id="passmark" name="passmark" type="text" v-model="assessmentDetails.passMark"/>
                             </div>
                             <div class="tip" v-if="assessmentDetails.assessmentType === AssessmentTypeEnum.Informal">
                                 <h3>Tip</h3>

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/ContributeTitle.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/ContributeTitle.vue
@@ -5,7 +5,8 @@
             <div class="d-flex flex-wrap justify-content-between align-items-center mx-n12 my-n2">
                 <h1 class="nhsuk-heading-xl">
                     <span v-if="!editing" class="contribute-title-component-title">{{ title || 'Untitled' }}</span>
-                    <input type="text" v-if="editing" v-model="title" placeholder="Untitled" ref="contributeTitleInput" />
+                    <label class="nhsuk-u-visually-hidden" for="contributeTitleInput"></label>
+                    <input type="text" id="contributeTitleInput" name="contributeTitleInput" v-if="editing" v-model="title" placeholder="Untitled" ref="contributeTitleInput" />
                 </h1>
                 <LinkTextAndIcon v-if="!editing"
                                  v-on:click="editing = true"

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/SelectResourceTitle.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/SelectResourceTitle.vue
@@ -4,9 +4,10 @@
             <div class="lh-container-xl">
                 <CharacterCount v-model="resourceDetails.title"
                                 v-bind:characterLimit="255"
-                                v-bind:hasOtherError="isTitleRequiredAndMissing">
+                                v-bind:hasOtherError="isTitleRequiredAndMissing"
+                                v-bind:inputId ="resourceTitle">
                     <template v-slot:title class="nhsuk-heading-l">Add a title</template>
-                    <template v-slot:description>Give your resource a concise, useful title that will make sense to learners.</template>
+                    <template v-slot:description><label :for="resourceTitle">Give your resource a concise, useful title that will make sense to learners.</label></template>
                     <template v-slot:otherErrorMessage v-if="isTitleRequiredAndMissing">You must enter a title</template>
                 </CharacterCount>
             </div>
@@ -22,7 +23,8 @@
     export default Vue.extend({
         props: {
             resourceDetails: { type: Object } as PropOptions<ContributeResourceDetailModel>,
-            isTypeSelected: Boolean
+            isTypeSelected: Boolean,
+            resourceTitle: { type: String, default: 'resourceTitle' } 
         },
         components: {
             CharacterCount
@@ -30,7 +32,7 @@
         computed: {
             isTitleRequiredAndMissing(): boolean {
                 return this.isTypeSelected && this.resourceDetails.title.trim().length === 0;
-            },
+            },          
         }
     });
 </script>

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/components/questions/MatchGameAnswerOption.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/components/questions/MatchGameAnswerOption.vue
@@ -15,8 +15,9 @@
             </div>
         </div>
         <div v-if="blockType === BlockTypeEnum.Text">
-            <input type="text" class="form-control text-input" maxlength="40" v-model="answerOption"/>
-            <div class="footer-text">
+            <label for="answerOption" class="nhsuk-u-visually-hidden"></label>
+            <input type="text" form="answerOption" id="answerOption" name="answerOption" aria-describedby="answerOptionError" class="form-control text-input" maxlength="40" v-model="answerOption"/>
+            <div class="footer-text" id="answerOptionError">
                 You have {{ charactersRemaining }} characters remaining.
             </div>
         </div>

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/components/questions/SingleChoiceAnswer.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/components/questions/SingleChoiceAnswer.vue
@@ -27,10 +27,11 @@
             <hr class="cutoff-line">
         </div>
         <div>
-          <input type="text" class="form-control text-input" maxlength="120" v-model="message"/>
-          <div class="footer-text">
-            You have {{ charactersRemaining }} characters remaining.
-          </div>
+            <label class="nhsuk-u-visually-hidden" for="message"></label>
+            <input type="text" id="message" name="message" aria-describedby="messageError" class="form-control text-input" maxlength="120" v-model="message" />
+            <div class="footer-text" id="messageError">
+                You have {{ charactersRemaining }} characters remaining.
+            </div>
         </div>
     </div>
 </template>

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/Content.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/Content.vue
@@ -20,8 +20,8 @@
                         <div class="row">
                             <div class="form-group col-12 mt-5">
                                 <h2 id="title-label" class="nhsuk-heading-l">Title<i v-if="$v.resourceDetailTitle.$invalid" class="warningTriangle fa-solid fa-triangle-exclamation"></i></h2>
-                                <div class="mb-3">Give your resource a concise, useful title that will make sense to learners.</div>
-                                <input type="text" class="form-control" aria-labelledby="title-label" maxlength="255" id="resourceDetail_title" v-model="resourceDetailTitle" @change="setTitle($event.target.value)" autocomplete="off" v-bind:disabled="resourceLoading">
+                                <div class="mb-3"><label for="resourceDetail_title">Give your resource a concise, useful title that will make sense to learners.</label></div>
+                                <input type="text" class="form-control" aria-labelledby="title-label" maxlength="255" id="resourceDetail_title" name="resourceDetail_title" v-model="resourceDetailTitle" @change="setTitle($event.target.value)" autocomplete="off" v-bind:disabled="resourceLoading">
                             </div>
                         </div>
                         <div class="row mt-4">
@@ -357,9 +357,9 @@
                                                         </p>
                                                     </div>
                                                     <div>
-                                                        <div class="modal-section-header">Notes</div>
+                                                        <div class="modal-section-header"><label for="notes">Notes</label></div>
                                                         <p class="mt-1">Provide information to help learners understand why this new version has been created.</p>
-                                                        <textarea class="form-control" v-bind:class="{ 'input-validation-error': $v.publishNotes.$invalid && $v.publishNotes.$dirty }" rows="4" maxlength="4000" v-model="publishNotes"></textarea>
+                                                        <textarea class="form-control"id="notes" v-bind:class="{ 'input-validation-error': $v.publishNotes.$invalid && $v.publishNotes.$dirty }" rows="4" maxlength="4000" v-model="publishNotes"></textarea>
                                                         <div class="error-text pt-3" v-if="$v.publishNotes.$invalid && $v.publishNotes.$dirty">
                                                             <span class="text-danger">Enter notes.</span>
                                                         </div>

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/ContentAudio.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/ContentAudio.vue
@@ -34,7 +34,7 @@
 
         <div class="row mt-5">
             <div class="form-group col-12">
-                <h3 id="additionalinfo-label">Additional information <span class="optional">(optional)</span></h3>
+                <h3 id="additionalinfo-label"><label for="additionalinfo">Additional information <span class="optional">(optional)</span></label></h3>
             </div>
         </div>
         <div class="row">
@@ -43,7 +43,7 @@
                 for example, how it was developed or what is required for it to be used.
             </div>
             <div class="col-12 mt-3">
-                <textarea class="form-control" aria-labelledby="additionalinfo-label" rows="4" maxlength="250" v-model="additionalInformation" @change="setAdditionalInformation($event.target.value)"></textarea>
+                <textarea class="form-control" id="additionalinfo" aria-labelledby="additionalinfo-label" rows="4" maxlength="250" v-model="additionalInformation" @change="setAdditionalInformation($event.target.value)"></textarea>
             </div>
             <div class="col-12 footer-text">
                 You can enter a maximum of 250 characters

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/ContentCommon.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/ContentCommon.vue
@@ -78,7 +78,7 @@
 
         <div class="row mt-5">
             <div class="form-group col-12">
-                <h2 id="keyword-label" class="nhsuk-heading-l">Keywords <i v-if="keywords.length==0" class="warningTriangle fa-solid fa-triangle-exclamation"></i></h2>
+                <h2 id="keyword-label" class="nhsuk-heading-l"><label for="newKeyword">Keywords</label> <i v-if="keywords.length==0" class="warningTriangle fa-solid fa-triangle-exclamation"></i></h2>
             </div>
         </div>
         <div class="row">
@@ -92,11 +92,11 @@
                     </span>
                 </div>
 
-                <div class="col-12">
+                <div class="col-12" id="keyworddesc">
                     To help learners find this resource, type one or more relevant keywords separated by commas and click 'Add'.
                 </div>
                 <div class="col-12 mt-4 input-with-button">
-                    <input id="newKeyword" aria-labelledby="keyword-label" type="text" class="form-control" maxlength="260" v-model="newKeyword" v-bind:class="{ 'input-validation-error': keywordError }" @input="keywordError=false" @change="keywordChange" />
+                    <input id="newKeyword" aria-labelledby="keyword-label" aria-describedby="keyworddesc" type="text" class="form-control" maxlength="260" v-model="newKeyword" v-bind:class="{ 'input-validation-error': keywordError }" @input="keywordError=false" @change="keywordChange" />
                     <button type="button" class="nhsuk-button nhsuk-button--secondary ml-3 nhsuk-u-margin-bottom-0" @click="addKeyword">&nbsp;Add</button>
                 </div>
                 <div class="col-12 footer-text">
@@ -165,24 +165,24 @@
                 <div class="resource-area-body" v-if="authors.length < maxAllowedAuthors">
                     <div class="form-group" v-bind:class="{ 'input-validation-error': authorError }">
                         <div class="col-12 mb-0 error-text" v-if="authorError">
-                            <span class="text-danger">Enter the author name or organisation.</span>
+                            <span class="text-danger" data-valmsg-for="authorName">Enter the author name or organisation.</span>
                         </div>
                         <div class="col-12">
                             <label class="mb-0" for="authorName">Author name</label>
                         </div>
                         <div class="col-12">
-                            <input type="text" id="authorName" class="form-control" v-bind:class="{ 'input-validation-error': authorError }" maxlength="100" v-model="authorName" v-bind:disabled="currentUserAuthor" @input="authorError=false" />
+                            <input type="text" id="authorName" name="authorName" class="form-control" aria-describedby="authorNamehint" v-bind:class="{ 'input-validation-error': authorError }" maxlength="100" v-model="authorName" v-bind:disabled="currentUserAuthor" @input="authorError=false" />
                         </div>
-                        <div class="col-12 footer-text">
+                        <div class="col-12 footer-text" id="authorNamehint">
                             You can enter a maximum of 100 characters
                         </div>
                         <div class="col-12">
                             <label class="mb-0" for="authorOganisation">Organisation</label>
                         </div>
                         <div class="col-12">
-                            <input type="text" id="authorOganisation" class="form-control" v-bind:class="{ 'input-validation-error': authorError }" maxlength="100" v-model="authorOganisation" @input="authorError=false" />
+                            <input type="text" id="authorOganisation" name="authorOganisation" aria-describedby="authorOganisationhint" class="form-control" v-bind:class="{ 'input-validation-error': authorError }" maxlength="100" v-model="authorOganisation" @input="authorError=false" />
                         </div>
-                        <div class="col-12 footer-text">
+                        <div class="col-12 footer-text" id="authorOganisationhint">
                             You can enter a maximum of 100 characters
                         </div>
                     </div>
@@ -190,9 +190,9 @@
                         <label class="mb-0" for="authorRole">Role <span class="optional">(optional)</span></label>
                     </div>
                     <div class="col-12">
-                        <input type="text" id="authorRole" class="form-control" maxlength="100" v-model="authorRole" />
+                        <input type="text" id="authorRole" name="authorRole" class="form-control" maxlength="100" v-model="authorRole" aria-describedby="authorRolehint" />
                     </div>
-                    <div class="col-12 footer-text">
+                    <div class="col-12 footer-text" id="authorRolehint">
                         You can enter a maximum of 100 characters
                     </div>
                     <div class="col-12 mt-4 input-with-button">

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/ContentGenericFile.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/ContentGenericFile.vue
@@ -30,39 +30,39 @@
         <div class="row authored-date">
             <div class="col-4 col-sm-3 col-md-2">
                 <label for="year" class="mb-0">Year</label><br />
-                <input type="text" id="year" maxlength="4" v-bind:class="{ 'input-validation-error': $v.authoredYear.$invalid && $v.authoredYear.$dirty }" class="form-control" :placeholder="currentYear" v-model="authoredYear" @blur="setProperty('authoredYear', $event.target.value)" />
+                <input type="text" id="year" name="year" aria-describedby="yearError" maxlength="4" v-bind:class="{ 'input-validation-error': $v.authoredYear.$invalid && $v.authoredYear.$dirty }" class="form-control" :placeholder="currentYear" v-model="authoredYear" @blur="setProperty('authoredYear', $event.target.value)" />
             </div>
             <div class="col-4 col-sm-3 col-md-2">
                 <label for="month" v-bind:class="{ disabled: $v.authoredYear.$invalid || !authoredYear }" class="mb-0">Month</label><br />
-                <input type="text" id="month" maxlength="2" v-bind:class="{ 'input-validation-error': $v.authoredMonth.$invalid && $v.authoredMonth.$dirty }" class="form-control" :placeholder="currentMonth" v-model="authoredMonth" v-bind:disabled="$v.authoredYear.$invalid || !authoredYear" @blur="setProperty('authoredMonth', $event.target.value)" />
+                <input type="text" id="month" name="month" aria-describedby="monthError" maxlength="2" v-bind:class="{ 'input-validation-error': $v.authoredMonth.$invalid && $v.authoredMonth.$dirty }" class="form-control" :placeholder="currentMonth" v-model="authoredMonth" v-bind:disabled="$v.authoredYear.$invalid || !authoredYear" @blur="setProperty('authoredMonth', $event.target.value)" />
             </div>
             <div class="col-4 col-sm-3 col-md-2">
                 <label for="day-of-month" v-bind:class="{ disabled: $v.authoredYear.$invalid || !authoredYear || $v.authoredMonth.$invalid || !authoredMonth }" class="mb-0">Day</label><br />
-                <input type="text" id="day-of-month" maxlength="2" v-bind:class="{ 'input-validation-error': $v.authoredDayOfMonth.$invalid && $v.authoredDayOfMonth.$dirty }" class="form-control" :placeholder="currentDayOfMonth" v-model="authoredDayOfMonth" v-bind:disabled="$v.authoredYear.$invalid || authoredYear == '' || $v.authoredMonth.$invalid || !authoredMonth" @blur="setProperty('authoredDayOfMonth', $event.target.value)" />
+                <input type="text" id="day-of-month" aria-describedby="day-of-monthError" name="day-of-month" maxlength="2" v-bind:class="{ 'input-validation-error': $v.authoredDayOfMonth.$invalid && $v.authoredDayOfMonth.$dirty }" class="form-control" :placeholder="currentDayOfMonth" v-model="authoredDayOfMonth" v-bind:disabled="$v.authoredYear.$invalid || authoredYear == '' || $v.authoredMonth.$invalid || !authoredMonth" @blur="setProperty('authoredDayOfMonth', $event.target.value)" />
             </div>
         </div>
         <div class="error-text pt-3" v-if="!$v.authoredYear.between && $v.authoredYear.$dirty">
-            <span class="text-danger">Use four numbers to enter the year.</span>
+            <span class="text-danger" id="yearError" aria-live="polite">Use four numbers to enter the year.</span>
         </div>
         <div class="error-text pt-3" v-if="$v.authoredYear.between && !$v.authoredYear.maxValue && $v.authoredYear.$dirty">
-            <span class="text-danger">The year this file was authored cannot be in the future.</span>
+            <span class="text-danger" id="yearError" aria-live="polite">The year this file was authored cannot be in the future.</span>
         </div>
         <div class="error-text pt-3" v-if="!$v.authoredYear.$invalid && (!$v.authoredMonth.between || !$v.authoredMonth.minLength) && $v.authoredMonth.$dirty">
-            <span class="text-danger">Use two numbers to enter a valid month.</span>
+            <span class="text-danger" id="monthError" aria-live="polite">Use two numbers to enter a valid month.</span>
         </div>
         <div class="error-text pt-3" v-if="!$v.authoredYear.$invalid && !$v.authoredMonth.month_in_past && $v.authoredMonth.$dirty">
-            <span class="text-danger">The month this file was authored cannot be in the future.</span>
+            <span class="text-danger" id="monthError" aria-live="polite">The month this file was authored cannot be in the future.</span>
         </div>
         <div class="error-text pt-3" v-if="!$v.authoredMonth.$invalid && (!$v.authoredDayOfMonth.between || !$v.authoredDayOfMonth.minLength) && $v.authoredDayOfMonth.$dirty">
-            <span class="text-danger">Use two numbers to enter a valid day.</span>
+            <span class="text-danger" id="day-of-monthError" aria-live="polite">Use two numbers to enter a valid day.</span>
         </div>
         <div class="error-text pt-3" v-if="!$v.authoredMonth.$invalid && !$v.authoredDayOfMonth.dayOfMonth_in_past && $v.authoredDayOfMonth.$dirty">
-            <span class="text-danger">The day this file was authored cannot be in the future.</span>
+            <span class="text-danger" id="day-of-monthError" aria-live="polite">The day this file was authored cannot be in the future.</span>
         </div>
 
         <div class="row mt-5">
             <div class="form-group col-12 my-2">
-                <h3 id="additionalinfo-label">Additional information <span class="optional">(optional)</span></h3>
+                <h3 id="additionalinfo-label"><label for="additionalinfo">Additional information <span class="optional">(optional)</span></label></h3>
             </div>
         </div>
         <div class="row">
@@ -71,7 +71,7 @@
                 for example, how it was developed or what is required for it to be used.
             </div>
             <div class="col-12 mt-3">
-                <textarea class="form-control" aria-labelledby="additionalinfo-label" rows="4" maxlength="250" v-model="additionalInformation" @change="setAdditionalInformation($event.target.value)"></textarea>
+                <textarea class="form-control" id="additionalinfo" aria-labelledby="additionalinfo-label" rows="4" maxlength="250" v-model="additionalInformation" @change="setAdditionalInformation($event.target.value)"></textarea>
             </div>
             <div class="col-12 footer-text">
                 You can enter a maximum of 250 characters

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/ContentImage.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/ContentImage.vue
@@ -13,7 +13,7 @@
 
         <div class="row mt-5">
             <div class="form-group col-12">
-                <h3 id="alttag-label">Alt tag <i v-if="$v.localImageDetail.altTag.$invalid" class="warningTriangle fa-solid fa-triangle-exclamation"></i></h3>
+                <h3 id="alttag-label"><label for="alttag">Alt tag</label> <i v-if="$v.localImageDetail.altTag.$invalid" class="warningTriangle fa-solid fa-triangle-exclamation"></i></h3>
             </div>
         </div>
         <div class="row">
@@ -22,7 +22,7 @@
                 This will not be shown on screen but it will help those using screen readers.
             </div>
             <div class="col-12 mt-3">
-                <textarea class="form-control" aria-labelledby="alttag-label" rows="4" maxlength="125" v-model="localImageDetail.altTag" @change="setProperty('altTag', $event.target.value)" @input="altTextKeyup"></textarea>
+                <textarea class="form-control" id="alttag" name="alttag" aria-labelledby="alttag-label" rows="4" maxlength="125" v-model="localImageDetail.altTag" @change="setProperty('altTag', $event.target.value)" @input="altTextKeyup"></textarea>
             </div>
             <div class="col-12 footer-text">
                 You can enter a maximum of 125 characters
@@ -31,7 +31,7 @@
 
         <div class="row mt-5">
             <div class="form-group col-12">
-                <h3 id="additionalinfo-label">Additional information <span class="optional">(optional)</span></h3>
+                <h3 id="additionalinfo-label"><label for="additionalinfo">Additional information <span class="optional">(optional)</span></label></h3>
             </div>
         </div>
         <div class="row">
@@ -40,7 +40,7 @@
                 for example, how it was developed or what is required for it to be used.
             </div>
             <div class="col-12 mt-3">
-                <textarea class="form-control" aria-labelledby="additionalinfo-label" rows="4" maxlength="250" v-model="additionalInformation" @change="setAdditionalInformation($event.target.value)"></textarea>
+                <textarea class="form-control" id="additionalinfo" aria-labelledby="additionalinfo-label" rows="4" maxlength="250" v-model="additionalInformation" @change="setAdditionalInformation($event.target.value)"></textarea>
             </div>
             <div class="col-12 footer-text">
                 You can enter a maximum of 250 characters

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/ContentWeblink.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/ContentWeblink.vue
@@ -2,15 +2,15 @@
     <div>
         <div class="row mt-2">
             <div class="form-group col-12 mb-1">
-                <h3 id="web-link-label">Add the address (URL) of the web link<i v-if="$v.localWeblinkDetail.url.$invalid || !urlIsAccessible" class="warningTriangle fa-solid fa-triangle-exclamation"></i></h3>
+                <h3 id="web-link-label"><label for="=web-link-text">Add the address (URL) of the web link</label><i v-if="$v.localWeblinkDetail.url.$invalid || !urlIsAccessible" class="warningTriangle fa-solid fa-triangle-exclamation"></i></h3>
             </div>
         </div>
         <div class="row">
-            <div class="col-12">
+            <div class="col-12" id="web-link-labelhint">
                 This can be found in the address bar of your browser, for example, https://www.england.nhs.uk
             </div>
             <div class="col-12 mt-3">
-                <input type="text" aria-labelledby="web-link-label" placeholder="https://" class="form-control" v-bind:class="{ 'input-validation-error': (!urlIsAccessible || $v.localWeblinkDetail.url.$invalid) && $v.localWeblinkDetail.url.$dirty }" v-model="localWeblinkDetail.url" @change="setProperty('url', $event.target.value)" @input="urlKeyup" />
+                <input type="text" id="web-link-text" name="web-link-text" aria-labelledby="web-link-label" aria-describedby="web-link-labelhint" placeholder="https://" class="form-control" v-bind:class="{ 'input-validation-error': (!urlIsAccessible || $v.localWeblinkDetail.url.$invalid) && $v.localWeblinkDetail.url.$dirty }" v-model="localWeblinkDetail.url" @change="setProperty('url', $event.target.value)" @input="urlKeyup" />
             </div>
         </div>
         <div class="error-text pt-3" v-if="!$v.localWeblinkDetail.url.url && $v.localWeblinkDetail.url.$dirty">
@@ -22,7 +22,7 @@
 
         <div class="row mt-5">
             <div class="form-group col-12 mb-1">
-                <h3 id="text-to-display-label">Text to display <span class="optional">(optional)</span></h3>
+                <h3 id="text-to-display-label"><label for="localWeblinkDetaildisplayText">Text to display <span class="optional">(optional)</span></label></h3>
             </div>
         </div>
         <div class="row">
@@ -31,16 +31,16 @@
                 you can change the way it is shown to learners so that they understand what it is for, for example, NHS England.
             </div>
             <div class="col-12 mt-3">
-                <input type="text" aria-labelledby="text-to-display-label" class="form-control" maxlength="50" v-model="localWeblinkDetail.displayText" @change="setProperty('displayText', $event.target.value)" />
+                <input type="text" id="localWeblinkDetaildisplayText" name= "localWeblinkDetaildisplayText" aria-labelledby="text-to-display-label" describedby="localWeblinkDetaildisplayTexthint" class="form-control" maxlength="50" v-model="localWeblinkDetail.displayText" @change="setProperty('displayText', $event.target.value)" />
             </div>
-            <div class="col-12 footer-text">
+            <div class="col-12 footer-text" id="localWeblinkDetaildisplayTexthint">
                 You can enter a maximum of 50 characters
             </div>
         </div>
 
         <div class="row mt-5">
             <div class="form-group col-12">
-                <h3 id="additionalinfo-label">Additional information <span class="optional">(optional)</span></h3>
+                <h3 id="additionalinfo-label"><label for="additionalinfo-label">Additional information <span class="optional">(optional)</span></label></h3>
             </div>
         </div>
         <div class="row">
@@ -49,9 +49,9 @@
                 for example, how it was developed or what is required for it to be used.
             </div>
             <div class="col-12 mt-3">
-                <textarea class="form-control" aria-labelledby="additionalinfo-label" rows="4" maxlength="250" v-model="additionalInformation" @change="setAdditionalInformation($event.target.value)"></textarea>
+                <textarea class="form-control" id="additionalinfo-label" name="additionalinfo-label" aria-labelledby="additionalinfo-label" aria-describedby="additionalinfo-label-hint" rows="4" maxlength="250" v-model="additionalInformation" @change="setAdditionalInformation($event.target.value)"></textarea>
             </div>
-            <div class="col-12 footer-text">
+            <div class="col-12 footer-text" id="additionalinfo-label-hint">
                 You can enter a maximum of 250 characters
             </div>
         </div>

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/resource/ExtraAssessmentAttemptRequestModal.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/resource/ExtraAssessmentAttemptRequestModal.vue
@@ -12,7 +12,8 @@
         <template v-slot:form>
             <h2 class="font-weight-bold mb-5">Reason for retaking assessment</h2>
             <div class="text-box p-0">
-                <textarea class="form-control" placeholder="Add your reason..." rows="4" :maxlength="maxLength" v-model="reason"></textarea>
+                <label class="nhsuk-u-visually-hidden" for="reason"></label>
+                <textarea class="form-control" id="reason" placeholder="Add your reason..." rows="4" :maxlength="maxLength" v-model="reason"></textarea>
                 <div class="characters-count">
                     You have {{ charactersRemaining }} characters remaining
                 </div>


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4081

### Description
DIG306: Labels for form fields are missing

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
