### PR TITLE
WMV file included in the admin UI Information page also

### DIFF
--- a/AdminUI/LearningHub.Nhs.AdminUI/Scripts/vuesrc/content/upload/fileValidation.ts
+++ b/AdminUI/LearningHub.Nhs.AdminUI/Scripts/vuesrc/content/upload/fileValidation.ts
@@ -8,7 +8,7 @@ export const file_size_validation = (value: any) => {
 export const file_extension_validation = (value: any) => {
     if (!value) { return true; }
     let fileExtension = value.name.split(".").pop();
-    let fileType = ['mp4', 'avi', 'm4v', 'mov', 'mkv', 'mpg', 'm2v', 'vob'].find(ext => ext == fileExtension);
+    let fileType = ['mp4', 'avi', 'm4v', 'mov', 'mkv', 'mpg', 'm2v', 'vob','wmv'].find(ext => ext == fileExtension);
     return fileType != undefined;
 };
 export const transcriptfile_extension_validation = (value: any) => {

--- a/WebAPI/LearningHub.Nhs.Database/Scripts/Post-Deploy/Scripts/UpdateFileTypes.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Scripts/Post-Deploy/Scripts/UpdateFileTypes.sql
@@ -1,1 +1,1 @@
-update resources.FileType set NotAllowed =1 where Extension='webm'
+update resources.FileType set NotAllowed =0 where Extension='WMV'


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4256

### Description
'WMV file allowed in the admin UI information page also.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
