### PR TITLE
TD-4782 image processing fix

### DIFF
--- a/WebAPI/LearningHub.Nhs.Repository/Resources/BlockCollectionRepository.cs
+++ b/WebAPI/LearningHub.Nhs.Repository/Resources/BlockCollectionRepository.cs
@@ -83,22 +83,7 @@ namespace LearningHub.Nhs.Repository.Resources
 
             foreach (var id in collectionIds)
             {
-                _ = Task.Run(async () =>
-                {
-                    var lhContext = new LearningHubDbContext(this.DbContext.Options);
-                    try
-                    {
-                        await lhContext.Database.ExecuteSqlRawAsync("resources.BlockCollectionDelete @p0", new SqlParameter("@p0", SqlDbType.Int) { Value = id });
-                    }
-                    catch (Exception ex)
-                    {
-                        throw new Exception(ex.Message);
-                    }
-                    finally
-                    {
-                        await lhContext.DisposeAsync();
-                    }
-                });
+               await this.DbContext.Database.ExecuteSqlRawAsync("resources.BlockCollectionDelete @p0", new SqlParameter("@p0", SqlDbType.Int) { Value = id });
             }
         }
 


### PR DESCRIPTION
### JIRA link
[TD-4782](https://hee-tis.atlassian.net/browse/TD-4782)

### Description
The image processing get stocked because the resource version associated with the whole slide image isn't found, This is cause by the delete block collection SP failing intermittently and thereby not removing obsolete block collections. 
The SP has now been updated to be awaited to fix this task anomaly. 

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4782]: https://hee-tis.atlassian.net/browse/TD-4782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ