### PR TITLE
TD-4070: Removed text from alt attribute for decorative images.

### DIFF
--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/roadmap/roadmap.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/roadmap/roadmap.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="roadmap-container mb-40">
         <div v-for="(item, index) in this.roadMapResult.roadMapItems" :class="getRoadMapClass(item)">
-            <img :src="downloadImage(item.imageName)" v-if="item.imageName" alt="Road map" />
+            <img :src="downloadImage(item.imageName)" v-if="item.imageName" alt="" />
             <h2>{{ item.title }}</h2>
             <p v-if="item.roadmapDate">{{ item.roadmapDate | formatDate('DD MMM YYYY') }}</p>
             <p v-html="item.description"></p>

--- a/LearningHub.Nhs.WebUI/Views/Home/_CmsPageRow.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Home/_CmsPageRow.cshtml
@@ -77,7 +77,7 @@
                                     <div class="information-page__asset-container">
                                         @if (@pageModel.PageSectionDetail?.ImageAsset != null)
                                         {
-                                            <img alt="@pageModel.PageSectionDetail.ImageAsset.AltTag" src="/file/download/@pageModel.PageSectionDetail.ImageAsset.ImageFile.FilePath/@pageModel.PageSectionDetail.ImageAsset.ImageFile.FileName" class="information-page__img">
+                                            <img alt="" src="/file/download/@pageModel.PageSectionDetail.ImageAsset.ImageFile.FilePath/@pageModel.PageSectionDetail.ImageAsset.ImageFile.FileName" class="information-page__img">
                                         }
                                     </div>
                                 </div>


### PR DESCRIPTION
### JIRA link
_[TD-4070](https://hee-tis.atlassian.net/browse/TD-4070)_

### Description
Removed text from alt attribute for decorative images in Landing page and Service updates and releases page.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4070]: https://hee-tis.atlassian.net/browse/TD-4070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ