### PR TITLE
TD-4870: Timeout page not showing properly in search page.

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/SearchController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/SearchController.cs
@@ -306,6 +306,11 @@ namespace LearningHub.Nhs.WebUI.Controllers
         public async Task<IActionResult> GetAutoSuggestion(string term)
         {
             var autoSuggestions = await this.searchService.GetAutoSuggestionList(term);
+            if (!this.User.Identity.IsAuthenticated)
+            {
+                return this.RedirectToAction("AccessDenied", "Home");
+            }
+
             return this.PartialView("_AutoComplete", autoSuggestions);
         }
     }


### PR DESCRIPTION
### JIRA link
_[TD-4870](https://hee-tis.atlassian.net/browse/TD-4870)_

### Description
Fixed the issue related to showing login page in auto suggestion dropdown when timed out.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4870]: https://hee-tis.atlassian.net/browse/TD-4870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ