### PR TITLE
TD-4948-Update Semantic version Number for LH repo

### DIFF
--- a/AdminUI/LearningHub.Nhs.AdminUI/LearningHub.Nhs.AdminUI.csproj
+++ b/AdminUI/LearningHub.Nhs.AdminUI/LearningHub.Nhs.AdminUI.csproj
@@ -1,642 +1,649 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <UserSecretsId>31abd8b9-4223-4ff3-896b-a46530c9e15c</UserSecretsId>
-    <ApplicationInsightsResourceId>/subscriptions/57c55d5f-78c1-4373-a021-ff8357548f51/resourceGroups/LearningHubNhsUk-AdminUI-Prod-RG/providers/microsoft.insights/components/LearningHubNhsUk-AdminUI-Prod</ApplicationInsightsResourceId>
-    <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-	<Platforms>x64</Platforms>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<AssemblyVersion>1.0.0.0</AssemblyVersion>
+		<FileVersion>1.0.0.0</FileVersion>
+		<Version>1.0.0</Version>
+		<UserSecretsId>31abd8b9-4223-4ff3-896b-a46530c9e15c</UserSecretsId>
+		<ApplicationInsightsResourceId>/subscriptions/57c55d5f-78c1-4373-a021-ff8357548f51/resourceGroups/LearningHubNhsUk-AdminUI-Prod-RG/providers/microsoft.insights/components/LearningHubNhsUk-AdminUI-Prod</ApplicationInsightsResourceId>
+		<TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<Platforms>x64</Platforms>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Compile Remove="Views\Notification\**" />
-    <Content Remove="Views\Notification\**" />
-    <EmbeddedResource Remove="Views\Notification\**" />
-    <None Remove="Views\Notification\**" />
-  </ItemGroup>
+	<ItemGroup>
+		<Compile Remove="Views\Notification\**" />
+		<Content Remove="Views\Notification\**" />
+		<EmbeddedResource Remove="Views\Notification\**" />
+		<None Remove="Views\Notification\**" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Content Remove="bundleconfig.json" />
-    <Content Remove="compilerconfig.json" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <TypeScriptCompile Remove="Scripts\vuesrc\content-structure\contentStructureContainer.ts" />
-    <TypeScriptCompile Remove="Scripts\vuesrc\content-structure\contentStructureRouter.ts" />
-    <TypeScriptCompile Remove="Scripts\vuesrc\content\contentContainer.ts" />
-    <TypeScriptCompile Remove="Scripts\vuesrc\content\contentPageListContainer.ts" />
-    <TypeScriptCompile Remove="Scripts\vuesrc\content\contentRouter.ts" />
-    <TypeScriptCompile Remove="Scripts\vuesrc\home\home.ts" />
-  </ItemGroup>
+	<ItemGroup>
+		<Content Remove="bundleconfig.json" />
+		<Content Remove="compilerconfig.json" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <_ContentIncludedByDefault Remove="bundleconfig.json" />
-  </ItemGroup>
+	<ItemGroup>
+		<TypeScriptCompile Remove="Scripts\vuesrc\content-structure\contentStructureContainer.ts" />
+		<TypeScriptCompile Remove="Scripts\vuesrc\content-structure\contentStructureRouter.ts" />
+		<TypeScriptCompile Remove="Scripts\vuesrc\content\contentContainer.ts" />
+		<TypeScriptCompile Remove="Scripts\vuesrc\content\contentPageListContainer.ts" />
+		<TypeScriptCompile Remove="Scripts\vuesrc\content\contentRouter.ts" />
+		<TypeScriptCompile Remove="Scripts\vuesrc\home\home.ts" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Content Include="node_modules\%40ckeditor\ckeditor5-build-classic\package.json" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-core\lang\contexts.json" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-core\package.json" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-engine\package.json" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-engine\theme\placeholder.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-heading\lang\contexts.json" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-heading\package.json" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-heading\theme\heading.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-paragraph\package.json" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\lang\contexts.json" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\package.json" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\button\button.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\button\switchbutton.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\colorgrid\colorgrid.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\dropdown\dropdown.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\dropdown\listdropdown.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\dropdown\splitbutton.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\dropdown\toolbardropdown.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\editorui\editorui.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\icon\icon.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\inputtext\inputtext.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\labeledinput\labeledinput.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\label\label.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\list\list.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\panel\balloonpanel.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\panel\balloonrotator.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\panel\fakepanel.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\panel\stickypanel.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\toolbar\blocktoolbar.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\toolbar\toolbar.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\tooltip\mixins\_tooltip.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\tooltip\tooltip.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\globals\globals.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\globals\_hidden.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\globals\_reset.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\globals\_zindex.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\mixins\_dir.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\mixins\_rwd.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\mixins\_unselectable.css" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-utils\package.json" />
-    <Content Include="node_modules\%40ckeditor\ckeditor5-vue\package.json" />
-  </ItemGroup>
+	<ItemGroup>
+		<_ContentIncludedByDefault Remove="bundleconfig.json" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
-    <PackageReference Include="Azure.Storage.Files.Shares" Version="12.8.0" />
-    <PackageReference Include="BuildWebCompiler" Version="1.12.405" />
-    <PackageReference Include="elfhHub.Nhs.Models" Version="3.0.8" />
-    <PackageReference Include="FluentValidation" Version="10.3.4" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.4" />
-    <PackageReference Include="HtmlSanitizer" Version="6.0.453" />
-	<PackageReference Include="IdentityModel" Version="4.4.0" />
-    <PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.2" />
-    <PackageReference Include="LearningHub.Nhs.Models" Version="3.0.42" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.19.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Azure.Management.Media" Version="5.0.0" />
-    <PackageReference Include="Microsoft.FeatureManagement" Version="3.2.0" />
-    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.2.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.14.1" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.14.1" />
-    <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" Version="2.4.1" />
-    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="4.5.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.0" />
-    <PackageReference Include="MK.IO" Version="1.6.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NLog.Web.AspNetCore" Version="4.14.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.14.1" />
-  </ItemGroup>
+	<ItemGroup>
+		<Content Include="node_modules\%40ckeditor\ckeditor5-build-classic\package.json" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-core\lang\contexts.json" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-core\package.json" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-engine\package.json" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-engine\theme\placeholder.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-heading\lang\contexts.json" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-heading\package.json" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-heading\theme\heading.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-paragraph\package.json" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\lang\contexts.json" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\package.json" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\button\button.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\button\switchbutton.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\colorgrid\colorgrid.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\dropdown\dropdown.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\dropdown\listdropdown.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\dropdown\splitbutton.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\dropdown\toolbardropdown.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\editorui\editorui.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\icon\icon.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\inputtext\inputtext.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\labeledinput\labeledinput.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\label\label.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\list\list.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\panel\balloonpanel.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\panel\balloonrotator.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\panel\fakepanel.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\panel\stickypanel.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\toolbar\blocktoolbar.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\toolbar\toolbar.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\tooltip\mixins\_tooltip.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\components\tooltip\tooltip.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\globals\globals.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\globals\_hidden.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\globals\_reset.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\globals\_zindex.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\mixins\_dir.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\mixins\_rwd.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-ui\theme\mixins\_unselectable.css" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-utils\package.json" />
+		<Content Include="node_modules\%40ckeditor\ckeditor5-vue\package.json" />
+	</ItemGroup>
 
-
-  <ItemGroup>
-    <Folder Include="Properties\" />
-    <Folder Include="Scripts\vuesrc\content\upload\" />
-    <Folder Include="Scripts\vuesrc\helpers\" />
-	 <Folder Include="wwwroot\lib\fontawesome-free-6.4.2-web\" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
+		<PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
+		<PackageReference Include="Azure.Storage.Files.Shares" Version="12.8.0" />
+		<PackageReference Include="BuildWebCompiler" Version="1.12.405" />
+		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.8" />
+		<PackageReference Include="FluentValidation" Version="10.3.4" />
+		<PackageReference Include="FluentValidation.AspNetCore" Version="10.3.4" />
+		<PackageReference Include="HtmlSanitizer" Version="6.0.453" />
+		<PackageReference Include="IdentityModel" Version="4.4.0" />
+		<PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.2" />
+		<PackageReference Include="LearningHub.Nhs.Models" Version="3.0.42" />
+		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.19.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Azure.Management.Media" Version="5.0.0" />
+		<PackageReference Include="Microsoft.FeatureManagement" Version="3.2.0" />
+		<PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.2.0" />
+		<PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
+		<PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.14.1" />
+		<PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.14.1" />
+		<PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" Version="2.4.1" />
+		<PackageReference Include="Microsoft.TypeScript.MSBuild" Version="4.5.2">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.0" />
+		<PackageReference Include="MK.IO" Version="1.6.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="NLog.Web.AspNetCore" Version="4.14.0" />
+		<PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.14.1" />
+	</ItemGroup>
 
 
-  <ItemGroup>
-    <None Include="bundleconfig.json" />
-    <None Include="compilerconfig.json" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\ckeditor.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\ckeditor.js.map" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\af.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\ar.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\ast.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\az.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\bg.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\ca.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\cs.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\da.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\de-ch.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\de.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\el.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\en-au.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\en-gb.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\eo.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\es.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\et.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\eu.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\fa.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\fi.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\fr.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\gl.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\gu.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\he.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\hr.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\hu.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\id.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\it.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\ja.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\km.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\kn.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\ko.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\ku.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\lt.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\lv.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\ms.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\nb.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\ne.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\nl.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\no.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\oc.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\pl.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\pt-br.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\pt.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\ro.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\ru.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\si.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\sk.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\sl.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\sq.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\sr-latn.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\sr.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\sv.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\tr.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\tt.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\ug.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\uk.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\vi.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\zh-cn.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\zh.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\CHANGELOG.md" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\LICENSE.md" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-build-classic\README.md" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\CHANGELOG.md" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\af.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\ar.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\ast.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\az.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\bg.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\ca.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\cs.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\da.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\de.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\el.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\en-au.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\en-gb.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\en.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\eo.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\es.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\et.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\eu.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\fa.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\fi.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\fr.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\gl.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\he.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\hr.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\hu.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\id.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\it.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\ja.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\km.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\kn.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\ko.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\ku.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\lt.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\lv.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\nb.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\ne.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\nl.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\no.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\oc.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\pl.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\pt-br.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\pt.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\ro.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\ru.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\sk.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\sl.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\sq.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\sr-latn.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\sr.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\sv.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\tr.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\tt.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\ug.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\uk.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\vi.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\zh-cn.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\zh.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\LICENSE.md" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\README.md" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\src\command.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\src\commandcollection.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\src\editingkeystrokehandler.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\src\editor\editor.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\src\editor\editorconfig.jsdoc" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\src\editor\editorui.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\src\editor\editorwithui.jsdoc" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\src\editor\utils\attachtoform.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\src\editor\utils\dataapimixin.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\src\editor\utils\elementapimixin.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\src\editor\utils\securesourceelement.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\src\multicommand.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\src\pendingactions.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\src\plugin.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\src\plugincollection.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\cancel.svg" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\check.svg" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\eraser.svg" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\image.svg" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\low-vision.svg" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\object-center.svg" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\object-full-width.svg" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\object-left.svg" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\object-right.svg" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\pencil.svg" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\pilcrow.svg" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\quote.svg" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\three-vertical-dots.svg" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\CHANGELOG.md" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\LICENSE.md" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\README.md" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\controller\datacontroller.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\controller\editingcontroller.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\conversion\conversion.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\conversion\conversionhelpers.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\conversion\downcastdispatcher.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\conversion\downcasthelpers.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\conversion\mapper.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\conversion\modelconsumable.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\conversion\upcastdispatcher.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\conversion\upcasthelpers.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\conversion\viewconsumable.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\dataprocessor\basichtmlwriter.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\dataprocessor\dataprocessor.jsdoc" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\dataprocessor\htmldataprocessor.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\dataprocessor\htmlwriter.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\dataprocessor\xmldataprocessor.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\dev-utils\model.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\dev-utils\operationreplayer.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\dev-utils\utils.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\dev-utils\view.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\batch.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\differ.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\document.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\documentfragment.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\documentselection.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\element.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\history.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\item.jsdoc" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\liveposition.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\liverange.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\markercollection.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\model.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\node.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\nodelist.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\attributeoperation.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\detachoperation.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\insertoperation.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\markeroperation.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\mergeoperation.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\moveoperation.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\nooperation.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\operation.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\operationfactory.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\renameoperation.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\rootattributeoperation.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\splitoperation.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\transform.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\utils.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\position.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\range.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\rootelement.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\schema.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\selection.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\text.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\textproxy.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\treewalker.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\utils\deletecontent.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\utils\getselectedcontent.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\utils\insertcontent.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\utils\modifyselection.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\utils\selection-post-fixer.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\writer.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\utils\bindtwostepcarettoattribute.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\attributeelement.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\containerelement.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\document.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\documentfragment.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\documentselection.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\domconverter.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\downcastwriter.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\editableelement.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\element.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\elementdefinition.jsdoc" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\emptyelement.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\filler.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\item.jsdoc" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\matcher.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\node.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\observer\clickobserver.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\observer\compositionobserver.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\observer\domeventdata.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\observer\domeventobserver.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\observer\fakeselectionobserver.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\observer\focusobserver.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\observer\inputobserver.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\observer\keyobserver.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\observer\mouseobserver.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\observer\mutationobserver.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\observer\observer.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\observer\selectionobserver.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\placeholder.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\position.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\range.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\renderer.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\rooteditableelement.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\selection.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\text.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\textproxy.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\treewalker.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\uielement.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\upcastwriter.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\view.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\CHANGELOG.md" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\ar.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\az.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\bg.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\ca.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\cs.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\da.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\de.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\el.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\en-au.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\en-gb.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\en.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\eo.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\es.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\et.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\eu.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\fa.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\fi.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\fr.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\gl.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\he.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\hr.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\hu.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\id.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\it.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\ja.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\km.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\kn.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\ko.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\ku.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\lt.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\lv.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\nb.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\ne.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\nl.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\no.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\pl.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\pt-br.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\pt.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\ro.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\ru.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\sk.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\sl.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\sq.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\sr-latn.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\sr.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\sv.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\tr.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\ug.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\uk.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\vi.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\zh-cn.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\zh.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\LICENSE.md" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\README.md" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\src\heading.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\src\headingbuttonsui.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\src\headingcommand.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\src\headingediting.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\src\headingui.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\src\title.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\src\utils.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\theme\icons\heading1.svg" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\theme\icons\heading2.svg" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\theme\icons\heading3.svg" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\theme\icons\heading4.svg" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\theme\icons\heading5.svg" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-heading\theme\icons\heading6.svg" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-paragraph\CHANGELOG.md" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-paragraph\LICENSE.md" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-paragraph\README.md" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-paragraph\src\paragraph.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-paragraph\src\paragraphbuttonui.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-paragraph\src\paragraphcommand.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-paragraph\theme\icons\paragraph.svg" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\CHANGELOG.md" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\ar.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\ast.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\az.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\cs.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\da.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\de-ch.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\de.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\el.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\en-au.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\en-gb.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\en.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\eo.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\es.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\et.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\eu.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\fa.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\fi.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\fr.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\gl.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\he.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\hr.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\hu.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\id.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\it.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\ja.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\km.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\kn.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\ku.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\lt.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\lv.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\nb.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\ne.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\nl.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\no.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\pl.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\pt-br.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\pt.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\ro.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\ru.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\sk.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\sq.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\sr-latn.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\sr.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\sv.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\tr.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\ug.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\uk.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\vi.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\zh-cn.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\zh.po" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\LICENSE.md" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\README.md" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\bindings\clickoutsidehandler.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\bindings\preventdefault.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\bindings\submithandler.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\button\button.jsdoc" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\button\buttonview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\button\switchbuttonview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\colorgrid\colorgridview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\colorgrid\colortileview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\componentfactory.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\dropdown\button\dropdownbutton.jsdoc" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\dropdown\button\dropdownbuttonview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\dropdown\button\splitbuttonview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\dropdown\dropdownpanelfocusable.jsdoc" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\dropdown\dropdownpanelview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\dropdown\dropdownview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\dropdown\utils.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\editableui\editableuiview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\editableui\inline\inlineeditableuiview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\editorui\boxed\boxededitoruiview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\editorui\editoruiview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\focuscycler.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\icon\iconview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\iframe\iframeview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\inputtext\inputtextview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\labeledinput\labeledinputview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\label\labelview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\list\listitemview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\list\listseparatorview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\list\listview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\model.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\notification\notification.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\panel\balloon\balloonpanelview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\panel\balloon\contextualballoon.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\panel\sticky\stickypanelview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\template.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\toolbar\balloon\balloontoolbar.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\toolbar\block\blockbuttonview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\toolbar\block\blocktoolbar.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\toolbar\enabletoolbarkeyboardfocus.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\toolbar\normalizetoolbarconfig.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\toolbar\toolbarseparatorview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\toolbar\toolbarview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\tooltip\tooltipview.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\view.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\src\viewcollection.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\theme\icons\color-tile-check.svg" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\theme\icons\dropdown-arrow.svg" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\theme\icons\next-arrow.svg" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-ui\theme\icons\previous-arrow.svg" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\CHANGELOG.md" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\LICENSE.md" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\README.md" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\areconnectedthroughproperties.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\ckeditorerror.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\collection.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\comparearrays.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\config.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\count.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\diff.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\difftochanges.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\createelement.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\emittermixin.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\getancestors.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\getborderwidths.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\getcommonancestor.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\getdatafromelement.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\getpositionedancestor.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\getresizeobserver.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\global.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\indexof.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\insertat.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\isnode.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\isrange.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\istext.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\iswindow.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\position.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\rect.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\remove.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\scroll.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\setdatainelement.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\tounit.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\elementreplacer.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\emittermixin.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\env.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\eventinfo.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\fastdiff.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\first.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\focustracker.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\isiterable.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\keyboard.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\keystrokehandler.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\locale.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\mapsequal.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\mix.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\nth.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\objecttomap.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\observablemixin.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\priorities.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\spy.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\tomap.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\translation-service.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\uid.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\unicode.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-utils\src\version.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-vue\CHANGELOG.md" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-vue\dist\ckeditor.js" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-vue\dist\ckeditor.js.map" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-vue\LICENSE.md" />
-    <None Include="node_modules\%40ckeditor\ckeditor5-vue\README.md" />
-    <None Include="Scripts\vuesrc\content-structure\contentStructureContainer.ts" />
-    <None Include="Scripts\vuesrc\content-structure\contentStructureRouter.ts" />
-    <None Include="Scripts\vuesrc\content\contentRouter.ts" />
-    <None Include="Scripts\vuesrc\content\contentContainer.ts" />
-    <None Include="Scripts\vuesrc\content\contentPageListContainer.ts" />
-    <None Include="Scripts\vuesrc\home\home.ts" />
-    <None Include="Views\ExternalSystem\Index.cshtml" />
-  </ItemGroup>
+	<ItemGroup>
+		<Folder Include="Properties\" />
+		<Folder Include="Scripts\vuesrc\content\upload\" />
+		<Folder Include="Scripts\vuesrc\helpers\" />
+		<Folder Include="wwwroot\lib\fontawesome-free-6.4.2-web\" />
+	</ItemGroup>
 
 
-  <ItemGroup>
-    <Content Update="NLog.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="bundleconfig.json" />
+		<None Include="compilerconfig.json" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\ckeditor.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\ckeditor.js.map" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\af.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\ar.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\ast.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\az.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\bg.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\ca.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\cs.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\da.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\de-ch.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\de.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\el.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\en-au.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\en-gb.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\eo.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\es.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\et.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\eu.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\fa.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\fi.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\fr.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\gl.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\gu.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\he.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\hr.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\hu.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\id.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\it.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\ja.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\km.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\kn.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\ko.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\ku.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\lt.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\lv.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\ms.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\nb.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\ne.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\nl.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\no.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\oc.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\pl.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\pt-br.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\pt.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\ro.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\ru.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\si.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\sk.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\sl.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\sq.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\sr-latn.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\sr.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\sv.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\tr.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\tt.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\ug.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\uk.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\vi.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\zh-cn.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\build\translations\zh.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\CHANGELOG.md" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\LICENSE.md" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-build-classic\README.md" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\CHANGELOG.md" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\af.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\ar.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\ast.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\az.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\bg.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\ca.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\cs.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\da.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\de.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\el.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\en-au.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\en-gb.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\en.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\eo.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\es.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\et.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\eu.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\fa.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\fi.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\fr.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\gl.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\he.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\hr.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\hu.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\id.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\it.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\ja.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\km.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\kn.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\ko.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\ku.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\lt.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\lv.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\nb.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\ne.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\nl.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\no.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\oc.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\pl.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\pt-br.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\pt.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\ro.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\ru.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\sk.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\sl.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\sq.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\sr-latn.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\sr.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\sv.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\tr.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\tt.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\ug.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\uk.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\vi.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\zh-cn.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\lang\translations\zh.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\LICENSE.md" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\README.md" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\src\command.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\src\commandcollection.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\src\editingkeystrokehandler.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\src\editor\editor.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\src\editor\editorconfig.jsdoc" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\src\editor\editorui.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\src\editor\editorwithui.jsdoc" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\src\editor\utils\attachtoform.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\src\editor\utils\dataapimixin.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\src\editor\utils\elementapimixin.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\src\editor\utils\securesourceelement.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\src\multicommand.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\src\pendingactions.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\src\plugin.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\src\plugincollection.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\cancel.svg" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\check.svg" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\eraser.svg" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\image.svg" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\low-vision.svg" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\object-center.svg" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\object-full-width.svg" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\object-left.svg" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\object-right.svg" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\pencil.svg" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\pilcrow.svg" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\quote.svg" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-core\theme\icons\three-vertical-dots.svg" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\CHANGELOG.md" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\LICENSE.md" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\README.md" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\controller\datacontroller.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\controller\editingcontroller.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\conversion\conversion.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\conversion\conversionhelpers.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\conversion\downcastdispatcher.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\conversion\downcasthelpers.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\conversion\mapper.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\conversion\modelconsumable.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\conversion\upcastdispatcher.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\conversion\upcasthelpers.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\conversion\viewconsumable.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\dataprocessor\basichtmlwriter.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\dataprocessor\dataprocessor.jsdoc" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\dataprocessor\htmldataprocessor.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\dataprocessor\htmlwriter.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\dataprocessor\xmldataprocessor.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\dev-utils\model.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\dev-utils\operationreplayer.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\dev-utils\utils.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\dev-utils\view.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\batch.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\differ.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\document.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\documentfragment.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\documentselection.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\element.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\history.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\item.jsdoc" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\liveposition.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\liverange.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\markercollection.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\model.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\node.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\nodelist.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\attributeoperation.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\detachoperation.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\insertoperation.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\markeroperation.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\mergeoperation.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\moveoperation.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\nooperation.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\operation.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\operationfactory.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\renameoperation.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\rootattributeoperation.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\splitoperation.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\transform.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\operation\utils.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\position.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\range.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\rootelement.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\schema.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\selection.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\text.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\textproxy.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\treewalker.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\utils\deletecontent.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\utils\getselectedcontent.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\utils\insertcontent.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\utils\modifyselection.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\utils\selection-post-fixer.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\model\writer.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\utils\bindtwostepcarettoattribute.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\attributeelement.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\containerelement.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\document.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\documentfragment.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\documentselection.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\domconverter.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\downcastwriter.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\editableelement.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\element.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\elementdefinition.jsdoc" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\emptyelement.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\filler.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\item.jsdoc" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\matcher.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\node.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\observer\clickobserver.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\observer\compositionobserver.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\observer\domeventdata.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\observer\domeventobserver.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\observer\fakeselectionobserver.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\observer\focusobserver.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\observer\inputobserver.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\observer\keyobserver.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\observer\mouseobserver.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\observer\mutationobserver.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\observer\observer.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\observer\selectionobserver.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\placeholder.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\position.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\range.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\renderer.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\rooteditableelement.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\selection.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\text.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\textproxy.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\treewalker.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\uielement.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\upcastwriter.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-engine\src\view\view.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\CHANGELOG.md" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\ar.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\az.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\bg.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\ca.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\cs.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\da.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\de.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\el.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\en-au.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\en-gb.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\en.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\eo.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\es.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\et.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\eu.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\fa.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\fi.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\fr.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\gl.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\he.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\hr.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\hu.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\id.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\it.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\ja.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\km.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\kn.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\ko.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\ku.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\lt.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\lv.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\nb.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\ne.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\nl.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\no.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\pl.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\pt-br.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\pt.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\ro.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\ru.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\sk.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\sl.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\sq.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\sr-latn.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\sr.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\sv.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\tr.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\ug.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\uk.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\vi.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\zh-cn.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\lang\translations\zh.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\LICENSE.md" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\README.md" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\src\heading.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\src\headingbuttonsui.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\src\headingcommand.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\src\headingediting.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\src\headingui.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\src\title.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\src\utils.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\theme\icons\heading1.svg" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\theme\icons\heading2.svg" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\theme\icons\heading3.svg" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\theme\icons\heading4.svg" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\theme\icons\heading5.svg" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-heading\theme\icons\heading6.svg" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-paragraph\CHANGELOG.md" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-paragraph\LICENSE.md" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-paragraph\README.md" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-paragraph\src\paragraph.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-paragraph\src\paragraphbuttonui.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-paragraph\src\paragraphcommand.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-paragraph\theme\icons\paragraph.svg" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\CHANGELOG.md" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\ar.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\ast.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\az.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\cs.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\da.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\de-ch.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\de.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\el.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\en-au.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\en-gb.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\en.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\eo.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\es.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\et.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\eu.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\fa.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\fi.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\fr.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\gl.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\he.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\hr.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\hu.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\id.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\it.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\ja.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\km.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\kn.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\ku.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\lt.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\lv.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\nb.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\ne.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\nl.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\no.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\pl.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\pt-br.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\pt.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\ro.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\ru.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\sk.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\sq.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\sr-latn.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\sr.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\sv.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\tr.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\ug.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\uk.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\vi.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\zh-cn.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\lang\translations\zh.po" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\LICENSE.md" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\README.md" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\bindings\clickoutsidehandler.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\bindings\preventdefault.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\bindings\submithandler.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\button\button.jsdoc" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\button\buttonview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\button\switchbuttonview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\colorgrid\colorgridview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\colorgrid\colortileview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\componentfactory.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\dropdown\button\dropdownbutton.jsdoc" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\dropdown\button\dropdownbuttonview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\dropdown\button\splitbuttonview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\dropdown\dropdownpanelfocusable.jsdoc" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\dropdown\dropdownpanelview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\dropdown\dropdownview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\dropdown\utils.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\editableui\editableuiview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\editableui\inline\inlineeditableuiview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\editorui\boxed\boxededitoruiview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\editorui\editoruiview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\focuscycler.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\icon\iconview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\iframe\iframeview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\inputtext\inputtextview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\labeledinput\labeledinputview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\label\labelview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\list\listitemview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\list\listseparatorview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\list\listview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\model.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\notification\notification.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\panel\balloon\balloonpanelview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\panel\balloon\contextualballoon.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\panel\sticky\stickypanelview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\template.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\toolbar\balloon\balloontoolbar.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\toolbar\block\blockbuttonview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\toolbar\block\blocktoolbar.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\toolbar\enabletoolbarkeyboardfocus.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\toolbar\normalizetoolbarconfig.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\toolbar\toolbarseparatorview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\toolbar\toolbarview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\tooltip\tooltipview.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\view.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\src\viewcollection.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\theme\icons\color-tile-check.svg" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\theme\icons\dropdown-arrow.svg" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\theme\icons\next-arrow.svg" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-ui\theme\icons\previous-arrow.svg" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\CHANGELOG.md" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\LICENSE.md" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\README.md" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\areconnectedthroughproperties.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\ckeditorerror.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\collection.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\comparearrays.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\config.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\count.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\diff.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\difftochanges.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\createelement.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\emittermixin.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\getancestors.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\getborderwidths.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\getcommonancestor.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\getdatafromelement.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\getpositionedancestor.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\getresizeobserver.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\global.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\indexof.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\insertat.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\isnode.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\isrange.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\istext.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\iswindow.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\position.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\rect.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\remove.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\scroll.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\setdatainelement.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\dom\tounit.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\elementreplacer.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\emittermixin.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\env.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\eventinfo.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\fastdiff.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\first.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\focustracker.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\isiterable.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\keyboard.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\keystrokehandler.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\locale.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\mapsequal.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\mix.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\nth.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\objecttomap.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\observablemixin.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\priorities.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\spy.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\tomap.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\translation-service.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\uid.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\unicode.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-utils\src\version.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-vue\CHANGELOG.md" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-vue\dist\ckeditor.js" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-vue\dist\ckeditor.js.map" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-vue\LICENSE.md" />
+		<None Include="node_modules\%40ckeditor\ckeditor5-vue\README.md" />
+		<None Include="Scripts\vuesrc\content-structure\contentStructureContainer.ts" />
+		<None Include="Scripts\vuesrc\content-structure\contentStructureRouter.ts" />
+		<None Include="Scripts\vuesrc\content\contentRouter.ts" />
+		<None Include="Scripts\vuesrc\content\contentContainer.ts" />
+		<None Include="Scripts\vuesrc\content\contentPageListContainer.ts" />
+		<None Include="Scripts\vuesrc\home\home.ts" />
+		<None Include="Views\ExternalSystem\Index.cshtml" />
+	</ItemGroup>
 
 
-  <ProjectExtensions><VisualStudio><UserProperties appsettings_1json__JsonSchema="" /></VisualStudio></ProjectExtensions>
+	<ItemGroup>
+		<Content Update="NLog.config">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
 
 
-  
+	<ProjectExtensions>
+		<VisualStudio>
+			<UserProperties appsettings_1json__JsonSchema="" />
+		</VisualStudio>
+	</ProjectExtensions>
+
+
+
 
 </Project>

--- a/AdminUI/LearningHub.Nhs.AdminUI/ServiceCollectionExtension.cs
+++ b/AdminUI/LearningHub.Nhs.AdminUI/ServiceCollectionExtension.cs
@@ -141,6 +141,7 @@
 
             services.AddTransient<CookieEventHandler>();
             services.AddSingleton<LogoutUserManager>();
+            services.AddSingleton<VersionService>();
 
             services.AddAuthentication(options =>
             {

--- a/AdminUI/LearningHub.Nhs.AdminUI/Services/VersionService.cs
+++ b/AdminUI/LearningHub.Nhs.AdminUI/Services/VersionService.cs
@@ -1,0 +1,18 @@
+﻿namespace LearningHub.Nhs.AdminUI.Services
+{
+    /// <summary>
+    /// Defines the <see cref="VersionService" />.
+    /// </summary>
+    public class VersionService
+    {
+        /// <summary>
+        /// The GetVersion.
+        /// </summary>
+        /// <returns>The <see cref="string"/>.</returns>
+        public string GetVersion()
+        {
+            var version = typeof(Program).Assembly.GetName().Version;
+            return $"{version?.Major}.{version?.Minor}.{version?.Build}";
+        }
+    }
+}

--- a/AdminUI/LearningHub.Nhs.AdminUI/ViewComponents/VersionViewComponent.cs
+++ b/AdminUI/LearningHub.Nhs.AdminUI/ViewComponents/VersionViewComponent.cs
@@ -1,0 +1,34 @@
+﻿namespace LearningHub.Nhs.AdminUI.ViewComponents
+{
+    using LearningHub.Nhs.AdminUI.Services;
+    using Microsoft.AspNetCore.Html;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.ViewComponents;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VersionViewComponent"/> class.
+    /// </summary>
+    public class VersionViewComponent : ViewComponent
+    {
+        private readonly VersionService versionService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VersionViewComponent"/> class.
+        /// </summary>
+        /// <param name="versionService">.</param>
+        public VersionViewComponent(VersionService versionService)
+        {
+            this.versionService = versionService;
+        }
+
+        /// <summary>
+        /// The Invoke.
+        /// </summary>
+        /// <returns>A representing the result of the synchronous operation.</returns>
+        public IViewComponentResult Invoke()
+        {
+            var version = this.versionService.GetVersion();
+            return new HtmlContentViewComponentResult(new HtmlString($"<!-- Version: {version} -->"));
+        }
+    }
+}

--- a/AdminUI/LearningHub.Nhs.AdminUI/Views/Shared/_Layout.cshtml
+++ b/AdminUI/LearningHub.Nhs.AdminUI/Views/Shared/_Layout.cshtml
@@ -2,83 +2,84 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>@ViewData["Title"] - Learning Hub Administration</title>
-  <link rel="apple-touch-icon" sizes="180x180" href="~/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="~/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="~/favicon-16x16.png">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"] - Learning Hub Administration</title>
+    <link rel="apple-touch-icon" sizes="180x180" href="~/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="~/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="~/favicon-16x16.png">
 
-  <environment include="Development">
+    <environment include="Development">
 
-    <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css" />
-    <link rel="stylesheet" type="text/css" href="~/lib/fontawesome-free-6.4.2-web/css/all.css"/>
-  </environment>
-  <environment exclude="Development">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/css/bootstrap.min.css"
-          asp-fallback-href="~/lib/bootstrap/dist/css/bootstrap.min.css"
-          asp-fallback-test-class="sr-only" asp-fallback-test-property="position" asp-fallback-test-value="absolute"
-          crossorigin="anonymous"
-          integrity="sha256-eSi1q2PG6J7g7ib17yAaWMcrr5GrtohYChqibrV7PBE=" />
-    <link rel="stylesheet" type="text/css" href="~/lib/fontawesome-free-6.4.2-web/css/all.min.css" />
-  </environment>
-  <link rel="stylesheet" type="text/css" href="~/css/site.css" asp-append-version="true"/>
-  <link rel="stylesheet" type="text/css" href="~/css/nhsuk/common.css"/>
-  @RenderSection("Styles", required: false)
-  @await Html.PartialAsync("_GoogleAnalytics")
-  <partial name="~/Views/Shared/_TimezoneInfoScriptPartial.cshtml" />
+        <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.css" />
+        <link rel="stylesheet" type="text/css" href="~/lib/fontawesome-free-6.4.2-web/css/all.css" />
+    </environment>
+    <environment exclude="Development">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/css/bootstrap.min.css"
+              asp-fallback-href="~/lib/bootstrap/dist/css/bootstrap.min.css"
+              asp-fallback-test-class="sr-only" asp-fallback-test-property="position" asp-fallback-test-value="absolute"
+              crossorigin="anonymous"
+              integrity="sha256-eSi1q2PG6J7g7ib17yAaWMcrr5GrtohYChqibrV7PBE=" />
+        <link rel="stylesheet" type="text/css" href="~/lib/fontawesome-free-6.4.2-web/css/all.min.css" />
+    </environment>
+    <link rel="stylesheet" type="text/css" href="~/css/site.css" asp-append-version="true" />
+    <link rel="stylesheet" type="text/css" href="~/css/nhsuk/common.css" />
+    @RenderSection("Styles", required: false)
+    @await Html.PartialAsync("_GoogleAnalytics")
+    <partial name="~/Views/Shared/_TimezoneInfoScriptPartial.cshtml" />
 </head>
 <body>
-  <header role="banner" id="header">
-    <partial name="~/Views/Shared/_NavPartial.cshtml" />
-  </header>
-  <div class="container-fluid">
-    <!--<partial name="_CookieConsentPartial" />-->
-    <main role="main" id="maincontent" tabindex="-1">
-      @{
-        var mainWidth = IsSectionDefined("SideMenu") ? "col-sm-9 col-lg-9 col-xl-10 pageWithMenu" : "col-sm-12";
-      }
-      <div class="row">
-        @if (IsSectionDefined("SideMenu"))
-        {
-          <div class="col-sm-3 col-lg-3 col-xl-2 side-menu">
-            @RenderSection("SideMenu", required: false)
-          </div>
-        }
-        <div class="@mainWidth">
-          @RenderBody()
-        </div>
-      </div>
-    </main>
-  </div>
-  <footer class="border-top footer text-muted">
-    <partial name="~/Views/Shared/_FooterPartial.cshtml" />
-  </footer>
+    <header role="banner" id="header">
+        <partial name="~/Views/Shared/_NavPartial.cshtml" />
+    </header>
+    <div class="container-fluid">
+        <!--<partial name="_CookieConsentPartial" />-->
+        <main role="main" id="maincontent" tabindex="-1">
+            @{
+                var mainWidth = IsSectionDefined("SideMenu") ? "col-sm-9 col-lg-9 col-xl-10 pageWithMenu" : "col-sm-12";
+            }
+            <div class="row">
+                @if (IsSectionDefined("SideMenu"))
+                {
+                    <div class="col-sm-3 col-lg-3 col-xl-2 side-menu">
+                        @RenderSection("SideMenu", required: false)
+                    </div>
+                }
+                <div class="@mainWidth">
+                    @RenderBody()
+                </div>
+            </div>
+        </main>
+    </div>
+    <footer class="border-top footer text-muted">
+        <partial name="~/Views/Shared/_FooterPartial.cshtml" />
+    </footer>
 
-  <environment include="Development">
-    <script src="~/lib/jquery/dist/jquery.js"></script>
-    <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.js"></script>
-    <script src="~/lib/ckeditor/ckeditor.js"></script>
-  </environment>
-  <environment exclude="Development">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"
-            asp-fallback-src="~/lib/jquery/dist/jquery.min.js"
-            asp-fallback-test="window.jQuery"
-            crossorigin="anonymous"
-            integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=">
-    </script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/js/bootstrap.bundle.min.js"
-            asp-fallback-src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"
-            asp-fallback-test="window.jQuery && window.jQuery.fn && window.jQuery.fn.modal"
-            crossorigin="anonymous"
-            integrity="sha256-E/V4cWE4qvAeO5MOhjtGtqDzPndRO1LBk8lJ/PR7CA4=">
-    </script>
-    <script src="~/lib/ckeditor/ckeditor.js"></script>
-    @*<script type="text/javascript" src="~/js/site.min.js"></script>*@
-  </environment>
-  @*<script type="text/javascript" src="~/js/bundle/header.js"></script>*@
-  <partial name="~/Views/Shared/_ValidationScriptsPartial.cshtml" />
-  @RenderSection("Scripts", required: false)
+    <environment include="Development">
+        <script src="~/lib/jquery/dist/jquery.js"></script>
+        <script src="~/lib/bootstrap/dist/js/bootstrap.bundle.js"></script>
+        <script src="~/lib/ckeditor/ckeditor.js"></script>
+    </environment>
+    <environment exclude="Development">
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"
+                asp-fallback-src="~/lib/jquery/dist/jquery.min.js"
+                asp-fallback-test="window.jQuery"
+                crossorigin="anonymous"
+                integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=">
+        </script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/js/bootstrap.bundle.min.js"
+                asp-fallback-src="~/lib/bootstrap/dist/js/bootstrap.bundle.min.js"
+                asp-fallback-test="window.jQuery && window.jQuery.fn && window.jQuery.fn.modal"
+                crossorigin="anonymous"
+                integrity="sha256-E/V4cWE4qvAeO5MOhjtGtqDzPndRO1LBk8lJ/PR7CA4=">
+        </script>
+        <script src="~/lib/ckeditor/ckeditor.js"></script>
+        @*<script type="text/javascript" src="~/js/site.min.js"></script>*@
+    </environment>
+    @*<script type="text/javascript" src="~/js/bundle/header.js"></script>*@
+    <partial name="~/Views/Shared/_ValidationScriptsPartial.cshtml" />
+    @RenderSection("Scripts", required: false)
 </body>
 </html>
+@await Component.InvokeAsync("Version")
 <!-- Build number: @settings.Value.BuildNumber -->

--- a/LearningHub.Nhs.WebUI/LearningHub.Nhs.WebUI.csproj
+++ b/LearningHub.Nhs.WebUI/LearningHub.Nhs.WebUI.csproj
@@ -2,11 +2,14 @@
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>  
+		<AssemblyVersion>1.0.0.0</AssemblyVersion>
+		<FileVersion>1.0.0.0</FileVersion>
+		<Version>1.0.0</Version>
+		<AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
 		<UserSecretsId>a2ecb5d2-cf13-4551-9cb6-3d86dfbcf8ef</UserSecretsId>
 		<TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Platforms>x64</Platforms>
+		<Platforms>x64</Platforms>
 		<GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>
 	</PropertyGroup>
 
@@ -104,7 +107,7 @@
 		<PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
 		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.8" />
 		<PackageReference Include="FluentValidation.AspNetCore" Version="10.3.4" />
-        <PackageReference Include="GDS.MultiPageFormData" Version="1.0.5" />
+		<PackageReference Include="GDS.MultiPageFormData" Version="1.0.5" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.11.38" />
 		<PackageReference Include="IdentityModel" Version="4.3.0" />
 		<PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
@@ -175,72 +178,76 @@
 		<TypeScriptCompile Include="Scripts\vuesrc\resource\helpers\resourceHelper.ts" />
 	</ItemGroup>
 
-<ItemGroup>
-  <TypeScriptCompile Update="Scripts\vuesrc\models\activeContentModel.ts">
-	<SubType>Code</SubType>
-  </TypeScriptCompile>
-  <TypeScriptCompile Update="Scripts\vuesrc\models\articleModel.ts">
-    <SubType>Code</SubType>
-  </TypeScriptCompile>
-  <TypeScriptCompile Update="Scripts\vuesrc\models\audioModel.ts">
-    <SubType>Code</SubType>
-  </TypeScriptCompile>
-  <TypeScriptCompile Update="Scripts\vuesrc\models\content-structure\editModeEnum.ts">
-    <SubType>Code</SubType>
-  </TypeScriptCompile>
-  <TypeScriptCompile Update="Scripts\vuesrc\models\content-structure\nodeContentAdminModel.ts">
-    <SubType>Code</SubType>
-  </TypeScriptCompile>
-  <TypeScriptCompile Update="Scripts\vuesrc\models\content-structure\nodeContentBrowseModel.ts">
-    <SubType>Code</SubType>
-  </TypeScriptCompile>
-  <TypeScriptCompile Update="Scripts\vuesrc\models\content-structure\nodeContentEditorModel.ts">
-    <SubType>Code</SubType>
-  </TypeScriptCompile>
-  <TypeScriptCompile Update="Scripts\vuesrc\models\fileModel.ts">
-    <SubType>Code</SubType>
-  </TypeScriptCompile>
-  <TypeScriptCompile Update="Scripts\vuesrc\models\genericFileModel.ts">
-    <SubType>Code</SubType>
-  </TypeScriptCompile>
-  <TypeScriptCompile Update="Scripts\vuesrc\models\imageModel.ts">
-    <SubType>Code</SubType>
-  </TypeScriptCompile>
-  <TypeScriptCompile Update="Scripts\vuesrc\models\interactionQueueModel.ts">
-    <SubType>Code</SubType>
-  </TypeScriptCompile>
-  <TypeScriptCompile Update="Scripts\vuesrc\models\mylearning\activityDetailedItemModel.ts">
-    <SubType>Code</SubType>
-  </TypeScriptCompile>
-  <TypeScriptCompile Update="Scripts\vuesrc\models\mylearning\activityDetailedModel.ts">
-    <SubType>Code</SubType>
-  </TypeScriptCompile>
-  <TypeScriptCompile Update="Scripts\vuesrc\models\mylearning\myLearningRequestModel.ts">
-    <SubType>Code</SubType>
-  </TypeScriptCompile>
-  <TypeScriptCompile Update="Scripts\vuesrc\models\mylearning\playedSegmentModel.ts">
-    <SubType>Code</SubType>
-  </TypeScriptCompile>
-  <TypeScriptCompile Update="Scripts\vuesrc\models\ratingModel.ts">
-    <SubType>Code</SubType>
-  </TypeScriptCompile>
-  <TypeScriptCompile Update="Scripts\vuesrc\models\ratingSummaryBasicModel.ts">
-    <SubType>Code</SubType>
-  </TypeScriptCompile>
-  <TypeScriptCompile Update="Scripts\vuesrc\models\ratingSummaryModel.ts">
-    <SubType>Code</SubType>
-  </TypeScriptCompile>
-  <TypeScriptCompile Update="Scripts\vuesrc\models\userBasicModel.ts">
-    <SubType>Code</SubType>
-  </TypeScriptCompile>
-  <TypeScriptCompile Update="Scripts\vuesrc\models\videoModel.ts">
-    <SubType>Code</SubType>
-  </TypeScriptCompile>
-  <TypeScriptCompile Update="Scripts\vuesrc\models\webLinkModel.ts">
-    <SubType>Code</SubType>
-  </TypeScriptCompile>
-</ItemGroup>
+	<ItemGroup>
+		<TypeScriptCompile Update="Scripts\vuesrc\models\activeContentModel.ts">
+			<SubType>Code</SubType>
+		</TypeScriptCompile>
+		<TypeScriptCompile Update="Scripts\vuesrc\models\articleModel.ts">
+			<SubType>Code</SubType>
+		</TypeScriptCompile>
+		<TypeScriptCompile Update="Scripts\vuesrc\models\audioModel.ts">
+			<SubType>Code</SubType>
+		</TypeScriptCompile>
+		<TypeScriptCompile Update="Scripts\vuesrc\models\content-structure\editModeEnum.ts">
+			<SubType>Code</SubType>
+		</TypeScriptCompile>
+		<TypeScriptCompile Update="Scripts\vuesrc\models\content-structure\nodeContentAdminModel.ts">
+			<SubType>Code</SubType>
+		</TypeScriptCompile>
+		<TypeScriptCompile Update="Scripts\vuesrc\models\content-structure\nodeContentBrowseModel.ts">
+			<SubType>Code</SubType>
+		</TypeScriptCompile>
+		<TypeScriptCompile Update="Scripts\vuesrc\models\content-structure\nodeContentEditorModel.ts">
+			<SubType>Code</SubType>
+		</TypeScriptCompile>
+		<TypeScriptCompile Update="Scripts\vuesrc\models\fileModel.ts">
+			<SubType>Code</SubType>
+		</TypeScriptCompile>
+		<TypeScriptCompile Update="Scripts\vuesrc\models\genericFileModel.ts">
+			<SubType>Code</SubType>
+		</TypeScriptCompile>
+		<TypeScriptCompile Update="Scripts\vuesrc\models\imageModel.ts">
+			<SubType>Code</SubType>
+		</TypeScriptCompile>
+		<TypeScriptCompile Update="Scripts\vuesrc\models\interactionQueueModel.ts">
+			<SubType>Code</SubType>
+		</TypeScriptCompile>
+		<TypeScriptCompile Update="Scripts\vuesrc\models\mylearning\activityDetailedItemModel.ts">
+			<SubType>Code</SubType>
+		</TypeScriptCompile>
+		<TypeScriptCompile Update="Scripts\vuesrc\models\mylearning\activityDetailedModel.ts">
+			<SubType>Code</SubType>
+		</TypeScriptCompile>
+		<TypeScriptCompile Update="Scripts\vuesrc\models\mylearning\myLearningRequestModel.ts">
+			<SubType>Code</SubType>
+		</TypeScriptCompile>
+		<TypeScriptCompile Update="Scripts\vuesrc\models\mylearning\playedSegmentModel.ts">
+			<SubType>Code</SubType>
+		</TypeScriptCompile>
+		<TypeScriptCompile Update="Scripts\vuesrc\models\ratingModel.ts">
+			<SubType>Code</SubType>
+		</TypeScriptCompile>
+		<TypeScriptCompile Update="Scripts\vuesrc\models\ratingSummaryBasicModel.ts">
+			<SubType>Code</SubType>
+		</TypeScriptCompile>
+		<TypeScriptCompile Update="Scripts\vuesrc\models\ratingSummaryModel.ts">
+			<SubType>Code</SubType>
+		</TypeScriptCompile>
+		<TypeScriptCompile Update="Scripts\vuesrc\models\userBasicModel.ts">
+			<SubType>Code</SubType>
+		</TypeScriptCompile>
+		<TypeScriptCompile Update="Scripts\vuesrc\models\videoModel.ts">
+			<SubType>Code</SubType>
+		</TypeScriptCompile>
+		<TypeScriptCompile Update="Scripts\vuesrc\models\webLinkModel.ts">
+			<SubType>Code</SubType>
+		</TypeScriptCompile>
+	</ItemGroup>
 
-<ProjectExtensions><VisualStudio><UserProperties appsettings_1json__JsonSchema="" /></VisualStudio></ProjectExtensions>
+	<ProjectExtensions>
+		<VisualStudio>
+			<UserProperties appsettings_1json__JsonSchema="" />
+		</VisualStudio>
+	</ProjectExtensions>
 
 </Project>

--- a/LearningHub.Nhs.WebUI/ServiceCollectionExtension.cs
+++ b/LearningHub.Nhs.WebUI/ServiceCollectionExtension.cs
@@ -10,6 +10,7 @@
     using LearningHub.Nhs.WebUI.Configuration;
     using LearningHub.Nhs.WebUI.EventSource;
     using LearningHub.Nhs.WebUI.Handlers;
+    using LearningHub.Nhs.WebUI.Services;
     using LearningHub.Nhs.WebUI.Startup;
     using Microsoft.ApplicationInsights.Extensibility.EventCounterCollector;
     using Microsoft.AspNetCore.Builder;
@@ -88,6 +89,7 @@
                 .Get<LearningHubAuthServiceConfig>();
             services.AddTransient<CookieEventHandler>();
             services.AddSingleton<LogoutUserManager>();
+            services.AddSingleton<VersionService>();
 
             services.ConfigureAuthentication(learningHubAuthSvcConf);
 

--- a/LearningHub.Nhs.WebUI/Services/VersionService.cs
+++ b/LearningHub.Nhs.WebUI/Services/VersionService.cs
@@ -1,0 +1,18 @@
+﻿namespace LearningHub.Nhs.WebUI.Services
+{
+    /// <summary>
+    /// Defines the <see cref="VersionService" />.
+    /// </summary>
+    public class VersionService
+    {
+        /// <summary>
+        /// The GetVersion.
+        /// </summary>
+        /// <returns>The <see cref="string"/>.</returns>
+        public string GetVersion()
+        {
+            var version = typeof(Program).Assembly.GetName().Version;
+            return $"{version?.Major}.{version?.Minor}.{version?.Build}";
+        }
+    }
+}

--- a/LearningHub.Nhs.WebUI/ViewComponents/VersionViewComponent.cs
+++ b/LearningHub.Nhs.WebUI/ViewComponents/VersionViewComponent.cs
@@ -1,0 +1,34 @@
+﻿namespace LearningHub.Nhs.WebUI.ViewComponents
+{
+    using LearningHub.Nhs.WebUI.Services;
+    using Microsoft.AspNetCore.Html;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.ViewComponents;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VersionViewComponent"/> class.
+    /// </summary>
+    public class VersionViewComponent : ViewComponent
+    {
+        private readonly VersionService versionService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VersionViewComponent"/> class.
+        /// </summary>
+        /// <param name="versionService">.</param>
+        public VersionViewComponent(VersionService versionService)
+        {
+            this.versionService = versionService;
+        }
+
+        /// <summary>
+        /// The Invoke.
+        /// </summary>
+        /// <returns>A representing the result of the synchronous operation.</returns>
+        public IViewComponentResult Invoke()
+        {
+            var version = this.versionService.GetVersion();
+            return new HtmlContentViewComponentResult(new HtmlString($"<!-- Version: {version} -->"));
+        }
+    }
+}

--- a/LearningHub.Nhs.WebUI/Views/Shared/Tenant/LearningHub/_Layout.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Shared/Tenant/LearningHub/_Layout.cshtml
@@ -148,10 +148,12 @@
     <partial name="~/Views/Shared/_JavascriptDetectorPartial.cshtml" />
     <partial name="~/Views/Shared/_SupportUrlsScriptPartial.cshtml" />
     @RenderSection("Scripts", required: false)
+
     <script type="text/javascript" src="~/js/mkplayer-ui-custom.js" asp-append-version="true"></script>
 
 </body>
 </html>
+@await Component.InvokeAsync("Version")
 <!-- Build number: @settings.Value.BuildNumber -->
 @functions {
     public async Task<bool> DisplayOffline()

--- a/ReportAPI/LearningHub.Nhs.ReportApi/LearningHub.Nhs.ReportApi.csproj
+++ b/ReportAPI/LearningHub.Nhs.ReportApi/LearningHub.Nhs.ReportApi.csproj
@@ -1,47 +1,50 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <GenerateDocumentationFile>False</GenerateDocumentationFile>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<AssemblyVersion>1.0.0.0</AssemblyVersion>
+		<FileVersion>1.0.0.0</FileVersion>
+		<Version>1.0.0</Version>
+		<Nullable>enable</Nullable>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<GenerateDocumentationFile>False</GenerateDocumentationFile>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <CodeAnalysisRuleSet />
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<CodeAnalysisRuleSet />
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <CodeAnalysisRuleSet />
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<CodeAnalysisRuleSet />
+	</PropertyGroup>
 
-  <ItemGroup>
-   
-    <PackageReference Include="LearningHub.Nhs.Models" Version="2.1.12" />
-   
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
-   
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.10" />
-   
-    <PackageReference Include="NLog.Web.AspNetCore" Version="5.1.4" />
-   
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
-  </ItemGroup>
+	<ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\LearningHub.Nhs.ReportApi.Services.Interface\LearningHub.Nhs.ReportApi.Services.Interface.csproj" />
-    <ProjectReference Include="..\LearningHub.Nhs.ReportApi.Services\LearningHub.Nhs.ReportApi.Services.csproj" />
-    <ProjectReference Include="..\LearningHub.Nhs.ReportApi.Shared\LearningHub.Nhs.ReportApi.Shared.csproj" />
-  </ItemGroup>
+		<PackageReference Include="LearningHub.Nhs.Models" Version="2.1.12" />
 
-  <ItemGroup>
-    <None Update="LearningHub.Nhs.ReportApi.xml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
 
-  <ItemGroup>
-    <PackageReference Update="StyleCop.Analyzers" Version="1.1.118" />
-  </ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.10" />
+
+		<PackageReference Include="NLog.Web.AspNetCore" Version="5.1.4" />
+
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\LearningHub.Nhs.ReportApi.Services.Interface\LearningHub.Nhs.ReportApi.Services.Interface.csproj" />
+		<ProjectReference Include="..\LearningHub.Nhs.ReportApi.Services\LearningHub.Nhs.ReportApi.Services.csproj" />
+		<ProjectReference Include="..\LearningHub.Nhs.ReportApi.Shared\LearningHub.Nhs.ReportApi.Shared.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Update="LearningHub.Nhs.ReportApi.xml">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Update="StyleCop.Analyzers" Version="1.1.118" />
+	</ItemGroup>
 
 </Project>

--- a/ReportAPI/LearningHub.Nhs.ReportApi/ServiceCollectionExtension.cs
+++ b/ReportAPI/LearningHub.Nhs.ReportApi/ServiceCollectionExtension.cs
@@ -39,11 +39,13 @@
 
             var swaggerTitle = configuration["Swagger:Title"];
             var swaggerVersion = configuration["Swagger:Version"];
-            var swaggerDescription = $"Build Number: {configuration["Swagger:BuildNumber"]}";
+            var swaggerDescription = "This is the API documentation for version ";
 
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc(swaggerTitle, new OpenApiInfo { Title = swaggerTitle, Version = swaggerVersion, Description = swaggerDescription });
+                var version = typeof(Program).Assembly.GetName().Version;
+                var versionString = $"{version?.Major}.{version?.Minor}.{version?.Build}";
+                c.SwaggerDoc(swaggerTitle, new OpenApiInfo { Title = swaggerTitle, Version = swaggerVersion, Description = $"{swaggerDescription}{versionString}" });
                 c.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, $"{Assembly.GetExecutingAssembly().GetName().Name}.XML"));
                 c.CustomSchemaIds(type => type.ToString());
             });

--- a/WebAPI/LearningHub.Nhs.API/LearningHub.Nhs.Api.csproj
+++ b/WebAPI/LearningHub.Nhs.API/LearningHub.Nhs.Api.csproj
@@ -1,63 +1,70 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
-    <UserSecretsId>234b55ad-984b-47ae-9d7a-71e372e6ded7</UserSecretsId>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-	<Platforms>x64</Platforms>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<AssemblyVersion>1.0.0.0</AssemblyVersion>
+		<FileVersion>1.0.0.0</FileVersion>
+		<Version>1.0.0</Version>
+		<AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
+		<UserSecretsId>234b55ad-984b-47ae-9d7a-71e372e6ded7</UserSecretsId>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<Platforms>x64</Platforms>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DocumentationFile>LearningHub.Nhs.Api.xml</DocumentationFile>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<DocumentationFile>LearningHub.Nhs.Api.xml</DocumentationFile>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Content Remove="nlog.config" />
-  </ItemGroup>
+	<ItemGroup>
+		<Content Remove="nlog.config" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Include="nlog.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="nlog.config">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
-  <ItemGroup>
-	<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
-	<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.8" />
-	<PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
-	<PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
-	<PackageReference Include="LearningHub.Nhs.Models" Version="3.0.42" />
-	<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.19.0" />
-	<PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Redis" Version="2.2.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.0" />
-    <PackageReference Include="NLog.Web.AspNetCore" Version="4.14.0" />
-	<PackageReference Update="StyleCop.Analyzers" Version="1.1.118">
-		<PrivateAssets>all</PrivateAssets>
-		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	</PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.14.1" />
-	<PackageReference Update="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
+		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.8" />
+		<PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
+		<PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
+		<PackageReference Include="LearningHub.Nhs.Models" Version="3.0.42" />
+		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.19.0" />
+		<PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Redis" Version="2.2.0" />
+		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.0" />
+		<PackageReference Include="NLog.Web.AspNetCore" Version="4.14.0" />
+		<PackageReference Update="StyleCop.Analyzers" Version="1.1.118">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+		<PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
+		<PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.14.1" />
+		<PackageReference Update="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\LearningHub.Nhs.Api.Shared\LearningHub.Nhs.Api.Shared.csproj" />
-    <ProjectReference Include="..\MigrationTool\LearningHub.Nhs.Migration.Staging.Repository\LearningHub.Nhs.Migration.Staging.Repository.csproj" />
-    <ProjectReference Include="..\MigrationTool\LearningHub.Nhs.Migration\LearningHub.Nhs.Migration.csproj" />
-    <ProjectReference Include="..\LearningHub.Nhs.Repository.Interface\LearningHub.Nhs.Repository.Interface.csproj" />
-    <ProjectReference Include="..\LearningHub.Nhs.Repository\LearningHub.Nhs.Repository.csproj" />
-    <ProjectReference Include="..\LearningHub.Nhs.Services.Interface\LearningHub.Nhs.Services.Interface.csproj" />
-    <ProjectReference Include="..\LearningHub.Nhs.Services\LearningHub.Nhs.Services.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\LearningHub.Nhs.Api.Shared\LearningHub.Nhs.Api.Shared.csproj" />
+		<ProjectReference Include="..\MigrationTool\LearningHub.Nhs.Migration.Staging.Repository\LearningHub.Nhs.Migration.Staging.Repository.csproj" />
+		<ProjectReference Include="..\MigrationTool\LearningHub.Nhs.Migration\LearningHub.Nhs.Migration.csproj" />
+		<ProjectReference Include="..\LearningHub.Nhs.Repository.Interface\LearningHub.Nhs.Repository.Interface.csproj" />
+		<ProjectReference Include="..\LearningHub.Nhs.Repository\LearningHub.Nhs.Repository.csproj" />
+		<ProjectReference Include="..\LearningHub.Nhs.Services.Interface\LearningHub.Nhs.Services.Interface.csproj" />
+		<ProjectReference Include="..\LearningHub.Nhs.Services\LearningHub.Nhs.Services.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <WCFMetadata Include="Connected Services" />
-  </ItemGroup>
+	<ItemGroup>
+		<WCFMetadata Include="Connected Services" />
+	</ItemGroup>
 
-  <ProjectExtensions><VisualStudio><UserProperties appsettings_1development_1json__JsonSchema="https://datahubproject.io/schemas/datahub_ingestion_schema.json" appsettings_1json__JsonSchema="" /></VisualStudio></ProjectExtensions>
+	<ProjectExtensions>
+		<VisualStudio>
+			<UserProperties appsettings_1development_1json__JsonSchema="https://datahubproject.io/schemas/datahub_ingestion_schema.json" appsettings_1json__JsonSchema="" />
+		</VisualStudio>
+	</ProjectExtensions>
 
 </Project>

--- a/WebAPI/LearningHub.Nhs.API/ServiceCollectionExtension.cs
+++ b/WebAPI/LearningHub.Nhs.API/ServiceCollectionExtension.cs
@@ -64,11 +64,12 @@
 
             var swaggerTitle = configuration["Swagger:Title"];
             var swaggerVersion = configuration["Swagger:Version"];
-            var swaggerDescription = $"Build Number: {configuration["Swagger:BuildNumber"]}";
-
+            var swaggerDescription = "This is the API documentation for version ";
             services.AddSwaggerGen(c =>
             {
-                c.SwaggerDoc(swaggerTitle, new OpenApiInfo { Title = swaggerTitle, Version = swaggerVersion, Description = swaggerDescription });
+                var version = typeof(Program).Assembly.GetName().Version;
+                var versionString = $"{version?.Major}.{version?.Minor}.{version?.Build}";
+                c.SwaggerDoc(swaggerTitle, new OpenApiInfo { Title = swaggerTitle, Version = swaggerVersion, Description = $"{swaggerDescription}{versionString}" });
                 c.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, $"{Assembly.GetExecutingAssembly().GetName().Name}.XML"));
                 c.CustomSchemaIds(type => type.ToString());
             });


### PR DESCRIPTION
### JIRA link
TD-4948

### Description
Update Semantic version Number for LH repo

### Screenshots
![API](https://github.com/user-attachments/assets/81e42334-d7d0-4d92-9db3-ef7c022a6ab7)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
