### PR TITLE
TD-4180: Error message changed according to NHS design pattern

### DIFF
--- a/LearningHub.Nhs.WebUI/Views/Account/CreateAccountCountrySearch.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Account/CreateAccountCountrySearch.cshtml
@@ -21,25 +21,27 @@
                 }
                 <h1 class="nhsuk-heading-xl">Search for your country</h1>
                 <form asp-controller="Account" asp-action="CreateAccountCountrySelection" method="get">
-                    <input type="hidden" name="formSubmission" value="true">
+                    <input type="hidden" name="formSubmission" value="true">  
+                    <div class="@(errorHasOccurred ? "nhsuk-form-group input-validation-error" : "nhsuk-form-group")">
                     <label for="FilterText" class="nhsuk-body-l nhsuk-u-font-size-19 nhsuk-u-margin-bottom-3">Search for example, England</label>
-                    <div class="nhsuk-form-group search-box-container" style="white-space:nowrap">
+                    @if (errorHasOccurred)
+                    {
+                        <span class="nhsuk-error-message">
+                            <span class="nhsuk-u-visually-hidden">Error:</span> @CommonValidationErrorMessages.SearchTermRequired
+                        </span>
+                    }
+                     <div class="nhsuk-form-group search-box-container" style="white-space:nowrap">
                         <input class="nhsuk-input nhsuk-search__input" type="search" autocomplete="off" id="FilterText" name="FilterText" placeholder="" value="@Model.FilterText" @if (errorHasOccurred)
                         {
                             <text>aria-describedby="error-summary-title custom-validation-error"</text>
                         }>
-                        <button class="nhsuk-search__submit" type="submit">
-                            <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-                                <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
-                            </svg>
-                            <span class="nhsuk-u-visually-hidden">Search</span>
-                        </button>
-                    </div>
-                    <div>
-                    @if (errorHasOccurred)
-                    {
-                        <span id="custom-validation-error" class="custom-validation-error">@CommonValidationErrorMessages.SearchTermRequired</span>
-                    }
+                            <button class="nhsuk-search__submit" type="submit">
+                                <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                                    <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
+                                </svg>
+                                <span class="nhsuk-u-visually-hidden">Search</span>
+                            </button>
+                     </div>
                     </div>
                 </form>
 

--- a/LearningHub.Nhs.WebUI/Views/Account/CreateAccountSearchRole.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Account/CreateAccountSearchRole.cshtml
@@ -25,11 +25,20 @@
 
                 <form asp-controller="Account" asp-action="CreateAccountCurrentRole" method="get">
                     <input type="hidden" name="formSubmission" value="true">
-
+                    <div class="@(errorHasOccurred ? "nhsuk-form-group input-validation-error" : "nhsuk-form-group")">
                     <label for="FilterText" class="nhsuk-body-l nhsuk-u-font-size-19 nhsuk-u-margin-bottom-3">Use a generic term to best describe your role</label>
+                    @if (errorHasOccurred)
+                    {
+                        <span class="nhsuk-error-message">
+                            <span class="nhsuk-u-visually-hidden">Error:</span> @CommonValidationErrorMessages.SearchTermRequired
+                        </span>
+                    }
                     <div class="nhsuk-form-group search-box-container nhsuk-u-padding-bottom-5" style="white-space:nowrap">
                         <input type="hidden" name="RegionId" value="@Context.Request.Query["RegionId"]">
-                        <input class="nhsuk-input nhsuk-search__input" type="search" autocomplete="off" id="FilterText" name="FilterText" placeholder="" value="@Model.FilterText">
+                        <input class="nhsuk-input nhsuk-search__input" type="search" autocomplete="off" id="FilterText" name="FilterText" placeholder="" value="@Model.FilterText" @if (errorHasOccurred)
+                        {
+                            <text>aria-describedby="error-summary-title custom-validation-error"</text>
+                        }>
                         <button class="nhsuk-search__submit" type="submit">
                             <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                                 <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
@@ -38,8 +47,7 @@
                         </button>
 
                     </div>
-
-
+                    </div>
                 </form>
 
                 <details class="nhsuk-details nhsuk-expander">

--- a/LearningHub.Nhs.WebUI/Views/Account/CreateAccountWorkPlaceSearch.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Account/CreateAccountWorkPlaceSearch.cshtml
@@ -25,13 +25,22 @@
 
                 <form asp-controller="Account" asp-action="CreateAccountWorkPlace" method="get">
                     <input type="hidden" name="formSubmission" value="true">
-
+                    <div class="@(errorHasOccurred ? "nhsuk-form-group input-validation-error" : "nhsuk-form-group")">
                     <label for="FilterText" class="nhsuk-body-l nhsuk-u-font-size-19 nhsuk-u-margin-bottom-3">
                         Enter the name, postcode or Organisation Date Service (ODS) code of your place of work.
 
                     </label>
+                    @if (errorHasOccurred)
+                    {
+                        <span class="nhsuk-error-message">
+                            <span class="nhsuk-u-visually-hidden">Error:</span> @CommonValidationErrorMessages.SearchTermRequired
+                        </span>
+                    }
                     <div class="nhsuk-form-group search-box-container nhsuk-u-padding-bottom-5" style="white-space:nowrap">
-                        <input class="nhsuk-input nhsuk-search__input" type="search" autocomplete="off" id="FilterText" name="FilterText" placeholder="" value="@Model.FilterText">
+                        <input class="nhsuk-input nhsuk-search__input" type="search" autocomplete="off" id="FilterText" name="FilterText" placeholder="" value="@Model.FilterText" @if (errorHasOccurred)
+                        {
+                            <text>aria-describedby="error-summary-title custom-validation-error"</text>
+                        }>
                         <button class="nhsuk-search__submit" type="submit">
                             <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                                 <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
@@ -40,7 +49,7 @@
                         </button>
 
                     </div>
-
+                    </div>
                 </form>
 
                 <details class="nhsuk-details nhsuk-expander">


### PR DESCRIPTION
### JIRA link
_[TD-4180](https://hee-tis.atlassian.net/browse/TD-4180)_

### Description
Error message changed according to NHS design pattern in pages selecting country, role and place of work.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4180]: https://hee-tis.atlassian.net/browse/TD-4180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ