### PR TITLE
TD-5080: Issue on 'Enter your start date' screen not allowing to add '0' to date field

### DIFF
--- a/LearningHub.Nhs.WebUI/Views/Shared/Components/DateInput/Default.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Shared/Components/DateInput/Default.cshtml
@@ -121,7 +121,7 @@
                 errorElement.style.visibility = 'hidden';
 
                 setTimeout(function () {
-                    if (value < 1 || value > max || !value.match(/^[0-9]*$/)) {
+                    if (value < 0 || value > max || !value.match(/^[0-9]*$/)) {
                         inputElement.value = inputElement.value.slice(0, -1) + 1;
                         inputElement.value = inputElement.value.slice(0, -1);
                         inputElement.setAttribute('aria-invalid', 'true');


### PR DESCRIPTION

### JIRA link
_[TD-5080](https://hee-tis.atlassian.net/browse/TD-5080)_

### Description
Issue fixed on zero not allowing to enter on date field.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-5080]: https://hee-tis.atlassian.net/browse/TD-5080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ