### PR TITLE
TD-5001: Word "Support" placement

### DIFF
--- a/WebAPI/LearningHub.Nhs.Database/Scripts/ELFH Database Scripts/Update LH email content.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Scripts/ELFH Database Scripts/Update LH email content.sql
@@ -28,7 +28,7 @@ Note that this link has a time limit of [TimeLimit]. If you select the link afte
 To log in at any other time go to <a href="[TenantUrl]">[TenantUrl]</a>, enter your username and password and select the Sign in button.<br/><br/>  
 When you first log in you will be guided through a series of steps to complete your registration. Providing correct information means that we can offer you a better learning experience.<br/><br/>  
 Please <b>do not reply</b> to this email.<br/><br/>  
-Support  <ol>  <li>For more information on how to log in, access learning resources and contribute resources, visit the Learning Hub <a href="https://support.learningub.nhs.uk/">Support pages</a>.</li>  <li>If you have any problems or further questions, contact us using the following <a href="[SupportFormUrl]">Support Form</a>.</li>  <li>You can also use our <b>Live Chat</b> service which will connect you to the Support team. Look for the Live Chat icon in the bottom right of your browser when you visit the Learning Hub.</li>  </ol>  Thanks again for creating an account and we hope you enjoy your learning experience.<br/><br/>  
+<ol>  <li>For more information on how to log in, access learning resources and contribute resources, visit the Learning Hub <a href="[SupportFormUrl]">Support pages</a>.</li>  <li>If you have any problems or further questions, contact us using the following <a href="[SupportFormUrl]">Support Form</a>.</li>  <li>You can also use our <b>Live Chat</b> service which will connect you to the Support team. Look for the Live Chat icon in the bottom right of your browser when you visit the Learning Hub.</li>  </ol>  Thanks again for creating an account and we hope you enjoy your learning experience.<br/><br/>  
 The Learning Hub Support Team<br/>  
 NHS England<br/><br/>  
 <small>This e-mail and any files transmitted with it are confidential. If you are not the intended recipient, any reading, printing, storage, disclosure, copying or any other action taken in respect of this e-mail is prohibited and may be unlawful. If you are not the intended recipient, please notify the sender immediately by using the reply function and then permanently delete what you have received.<br/></small><br/>
@@ -46,8 +46,7 @@ If this was not you, contact us using the following <a href="[SupportFormUrl]">S
 In the unlikely event that selecting the above link does not work, please copy and paste this directly into the address bar of your browser: [PasswordValidateUrl]<br/><br/>  
 Note that this link has a time limit of [TimeLimit]. If you select the link after this time you will receive instructions on how to generate a new one.<br/><br/>  
 Once you have reset your password you will be given a link to log in with your new password.<br/><br/>  
-Please <b>do not reply</b> to this email.<br/><br/>  
-Support  
+Please <b>do not reply</b> to this email.<br/><br/>    
 <ol>  <li>For more information on how to log in, access learning resources and contribute resources, visit the Learning Hub <a href="https://support.learningub.nhs.uk/">Support pages</a>.</li>  
 <li>If you have any problems or further questions, contact us using the following <a href="[SupportFormUrl]">Support Form</a>.</li>  
 <li>You can also use our <b>Live Chat</b> service which will connect you to the Support team. Look for the Live Chat icon in the bottom right of your browser when you visit the Learning Hub.</li>  </ol> 
@@ -67,7 +66,7 @@ We received a request to retrieve your username for the Learning Hub.<br/><br/>
 If this was not you, contact us using the following <a href="[SupportFormUrl]">Support Form</a>.<br/><br/>  
 The username registered to this email address is: [UserName]<br/><br/>  
 If you know your password, you can log in straight away or do you need a <b><a href="[TenantUrl]/forgotten-password">password reminder</a></b> password reminder?<br/><br/>  
-Please <b>do not reply</b> to this email.<br/><br/>  Support  <ol>  
+Please <b>do not reply</b> to this email.<br/><br/>   <ol>  
 <li>For more information on how to log in, access learning resources and contribute resources, visit the Learning Hub <a href="https://support.learninghub.nhs.uk/">Support pages</a>.</li>  
 <li>If you have any problems or further questions, contact us using the following <a href="[SupportFormUrl]">Support Form</a>.</li>  
 <li>You can also use our <b>Live Chat</b> service which will connect you to the Support team. Look for the Live Chat icon in the bottom right of your browser when you visit the Learning Hub.</li>  </ol>  


### PR DESCRIPTION
### JIRA link
_[TD-5001](https://hee-tis.atlassian.net/browse/TD-5001)_

### Description
Word "Support" is removed from the automated mails during account creation.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-5001]: https://hee-tis.atlassian.net/browse/TD-5001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ