### PR TITLE
TD-4183: Corrected the error messages for the start date.

### DIFF
--- a/LearningHub.Nhs.WebUI/Views/Shared/Components/DateInput/Default.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Shared/Components/DateInput/Default.cshtml
@@ -55,7 +55,6 @@
                            name="@Model.DayId"
                            value="@Model.DayValue"
                            type="text"
-                           pattern="[0-9]*"
                            min="1"
                            max="31"
                            step="1"
@@ -71,7 +70,6 @@
                            name="@Model.MonthId"
                            value="@Model.MonthValue"
                            type="text"
-                           pattern="[0-9]*"
                            min="1"
                            max="12"
                            step="1"
@@ -87,7 +85,6 @@
                            name="@Model.YearId"
                            value="@Model.YearValue"
                            type="text"
-                           pattern="[0-9]*"
                            min="1900"
                            max="9999"
                            step="1"
@@ -99,37 +96,4 @@
             </span>
         </div>
     </fieldset>
-    <script>
-        const fields = [@Model.DayId, @Model.MonthId, @Model.YearId];
-
-        const errorElement = document.getElementById('date-error');
-        for (let field of fields) {
-            const inputElement = document.getElementById(field.id);
-
-            inputElement.addEventListener('input', function (event) {
-
-                if (event.inputType === 'deleteContentBackward') {
-                    return;
-                }
-
-                const value = event.data;
-                const min = parseInt(inputElement.getAttribute('min'));
-                const max = parseInt(inputElement.getAttribute('max'));
-
-                inputElement.setAttribute('aria-invalid', 'false');
-                errorElement.textContent = '';
-                errorElement.style.visibility = 'hidden';
-
-                setTimeout(function () {
-                    if (value < 0 || value > max || !value.match(/^[0-9]*$/)) {
-                        inputElement.value = inputElement.value.slice(0, -1) + 1;
-                        inputElement.value = inputElement.value.slice(0, -1);
-                        inputElement.setAttribute('aria-invalid', 'true');
-                        errorElement.textContent = `Invalid input. Please enter a number between ${min} and ${max}.`;
-                        errorElement.style.visibility = 'visible';
-                    }
-                }, 0);
-            });
-        }
-    </script>
 </div>


### PR DESCRIPTION
### JIRA link
_[TD-4183](https://hee-tis.atlassian.net/browse/TD-4183)_

### Description
Corrected the error messages for the start date according to the NHS design standards.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4183]: https://hee-tis.atlassian.net/browse/TD-4183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ