### PR TITLE
TD-4196: Non-interactive content receives focus without good reason

### DIFF
--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/mycontributions/gridcardcomponent.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/mycontributions/gridcardcomponent.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="panel-card-container">
 
-        <div tabindex="0" class="my-contributions-panel-card h-100">
+        <div class="my-contributions-panel-card h-100">
 
             <div class="h-100 d-flex flex-column">
                 <div class="d-flex flex-row justify-content-start my-4">


### PR DESCRIPTION
### JIRA link
_[TD-4196](https://hee-tis.atlassian.net/browse/TD-4196)_

### Description
Removed tab index 0 from non interactive elements.

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [x] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4196]: https://hee-tis.atlassian.net/browse/TD-4196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ