### PR TITLE
TD-4190:DIG702: Content becomes lost or obscured at low resolution or…

### DIFF
--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/SelectResourceTypeContainer.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/SelectResourceTypeContainer.vue
@@ -1,5 +1,5 @@
 ﻿<template>
-    <div class="lh-padding-fluid">
+    <div class="lh-padding-fluid select-resource-type">
         <div class="lh-container-xl">
             <h2 id="title-label" class="nhsuk-heading-l">Select a resource type</h2>
             <div v-if="!contributeResourceAVFlag" class="align-self-center">
@@ -53,3 +53,10 @@
         }
     });
 </script>
+<style lang="scss" scoped>
+    @use '../../../Styles/abstracts/all' as *;
+
+    .select-resource-type {
+       padding-left: 0.1rem !important;
+    }
+</style>

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/mycontributions/mycontributions.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/mycontributions/mycontributions.vue
@@ -392,6 +392,7 @@
     @media (max-width: 768px) {
         .dropdown-toggle {
             display: block !important;
+            white-space: wrap !important;
         }
     }
 

--- a/LearningHub.Nhs.WebUI/Styles/sections/_all.scss
+++ b/LearningHub.Nhs.WebUI/Styles/sections/_all.scss
@@ -420,6 +420,10 @@ div.contribute {
       }
     }
   }
+  .contriburecontainer
+  {
+      margin-left : -100px;
+  }
 }
 
 /* end contribute*/

--- a/LearningHub.Nhs.WebUI/Views/ContributeResource/ContributeResource.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/ContributeResource/ContributeResource.cshtml
@@ -5,7 +5,7 @@
     @* <link href="https://amp.azure.net/libs/amp/2.3.8/skins/amp-default/azuremediaplayer.min.css" type="text/css" rel="stylesheet" asp-append-version="true" /> *@
 }
 
-    <div id="contributecontainer">
+<div id="contributecontainer" class="contriburecontainer">
         @* This empty <router-view> is populated by the Vue.js code *@
         <router-view :keep-user-session-alive-interval-seconds="@ViewBag.KeepUserSessionAliveIntervalSeconds"></router-view>
     </div>


### PR DESCRIPTION
… scrolling in 2 dimensions is required (reflow 320 x 256)

### JIRA link
https://hee-tis.atlassian.net/browse/TD-4190

### Description
Fixed the resolution issues with the contribute screen.

### Screenshots
![image](https://github.com/user-attachments/assets/2ecaf3a9-e0e6-469f-9970-06dcf997c6fb)
![image](https://github.com/user-attachments/assets/a65be87f-a147-4f50-9070-2ab70ba1d873)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
