### PR TITLE
TD-5176 Large file download fix.

### DIFF
--- a/LearningHub.Nhs.WebUI/Interfaces/IFileService.cs
+++ b/LearningHub.Nhs.WebUI/Interfaces/IFileService.cs
@@ -5,6 +5,7 @@
     using System.Threading.Tasks;
     using Azure.Storage.Files.Shares.Models;
     using LearningHub.Nhs.Models.Resource;
+    using LearningHub.Nhs.WebUI.Models;
 
     /// <summary>
     /// Defines the <see cref="IFileService" />.
@@ -25,7 +26,8 @@
         /// <param name="filePath">File path.</param>
         /// <param name="fileName">File name.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        Task<ShareFileDownloadInfo> DownloadFileAsync(string filePath, string fileName);
+        // Task<ShareFileDownloadInfo> DownloadFileAsync(string filePath, string fileName);
+        Task<FileDownloadResponse> DownloadFileAsync(string filePath, string fileName);
 
         /// <summary>
         /// The StreamFileAsync.

--- a/LearningHub.Nhs.WebUI/Models/FileDownloadResponse.cs
+++ b/LearningHub.Nhs.WebUI/Models/FileDownloadResponse.cs
@@ -1,0 +1,25 @@
+﻿namespace LearningHub.Nhs.WebUI.Models
+{
+    using System.IO;
+
+    /// <summary>
+    /// Defines the <see cref="FileDownloadResponse" />.
+    /// </summary>
+    public class FileDownloadResponse
+    {
+        /// <summary>
+        /// Gets or sets the Content.
+        /// </summary>
+        public Stream Content { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ContentType.
+        /// </summary>
+        public string ContentType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ContentType.
+        /// </summary>
+        public long ContentLength { get; set; }
+    }
+}


### PR DESCRIPTION
### JIRA link
[TD-5176](https://hee-tis.atlassian.net/browse/TD-5176)

### Description
I've added a logic to download files less than or equal to 500mb using our default download method directly to the browser, otherwise download the files in chunks of 100mb , with up to 8 simultaneous download at the webserver and output the entire file to the browser at once

### Screenshots
![image](https://github.com/user-attachments/assets/ec6d205f-4779-4629-9937-a88e92117809)
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-5176]: https://hee-tis.atlassian.net/browse/TD-5176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ