### PR TITLE
TD-5130: Clearing country selection on new search

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/AccountController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/AccountController.cs
@@ -474,17 +474,17 @@
                 accountCreation.CountryId = accountCreationViewModel.CountryId;
             }
 
-            if (accountCreation.CountryId == "1")
-            {
-                await this.multiPageFormService.SetMultiPageFormData(accountCreation, MultiPageFormDataFeature.AddRegistrationPrompt, this.TempData);
-                var regionData = await this.regionService.GetAllPagedAsync(accountCreationViewModel.CurrentPageIndex, UserRegistrationContentPageSize);
-                return this.View(new AccountCreationListViewModel { Region = regionData.Item2, AccountCreationPaging = new AccountCreationPagingModel { TotalItems = regionData.Item1, PageSize = UserRegistrationContentPageSize, HasItems = regionData.Item1 > 0, CurrentPage = accountCreationViewModel.CurrentPageIndex }, RegionId = accountCreation.RegionId, ReturnToConfirmation = accountCreationViewModel.ReturnToConfirmation });
-            }
-            else if (string.IsNullOrWhiteSpace(accountCreationViewModel.CountryId) || !countryCheck)
+            if (string.IsNullOrWhiteSpace(accountCreationViewModel.CountryId) || !countryCheck)
             {
                 this.ModelState.AddModelError("CountryId", CommonValidationErrorMessages.CountryRequired);
                 var countries = await this.countryService.GetFilteredAsync(accountCreationViewModel.FilterText);
                 return this.View("CreateAccountCountrySelection", new AccountCreationListViewModel { FilterText = accountCreationViewModel.FilterText, CountryList = countries.ToList(), ReturnToConfirmation = accountCreationViewModel.ReturnToConfirmation });
+            }
+            else if (accountCreation.CountryId == "1")
+            {
+                await this.multiPageFormService.SetMultiPageFormData(accountCreation, MultiPageFormDataFeature.AddRegistrationPrompt, this.TempData);
+                var regionData = await this.regionService.GetAllPagedAsync(accountCreationViewModel.CurrentPageIndex, UserRegistrationContentPageSize);
+                return this.View(new AccountCreationListViewModel { Region = regionData.Item2, AccountCreationPaging = new AccountCreationPagingModel { TotalItems = regionData.Item1, PageSize = UserRegistrationContentPageSize, HasItems = regionData.Item1 > 0, CurrentPage = accountCreationViewModel.CurrentPageIndex }, RegionId = accountCreation.RegionId, ReturnToConfirmation = accountCreationViewModel.ReturnToConfirmation });
             }
             else
             {


### PR DESCRIPTION
### JIRA link
_[TD-5130](https://hee-tis.atlassian.net/browse/TD-5130)_

### Description
Clearing country selection on new search

### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [x] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-5130]: https://hee-tis.atlassian.net/browse/TD-5130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ