### PR TITLE
programmatically associating error summary with  form field

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/AccountController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/AccountController.cs
@@ -429,6 +429,7 @@
         public async Task<IActionResult> CreateAccountCountrySelection(AccountCreationViewModel accountCreationViewModel)
         {
             var accountDetails = await this.multiPageFormService.GetMultiPageFormData<AccountCreationViewModel>(MultiPageFormDataFeature.AddRegistrationPrompt, this.TempData);
+            AccountCreationFormHelper.PopulateGroupedFormControlMetadata(this.ViewData);
             if (!string.IsNullOrWhiteSpace(accountCreationViewModel.FilterText))
             {
                 string filterText = Regex.Replace(accountCreationViewModel.FilterText, "[:!@#$%^&*()}{|\":?><\\[\\]\\;'/.,~\\\"\"\\'\\\\/]", " ");
@@ -469,6 +470,7 @@
         {
             var countryCheck = int.TryParse(accountCreationViewModel.CountryId, out int countryId);
             var accountCreation = await this.multiPageFormService.GetMultiPageFormData<AccountCreationViewModel>(MultiPageFormDataFeature.AddRegistrationPrompt, this.TempData);
+            AccountCreationFormHelper.PopulateGroupedFormControlMetadata(this.ViewData);
             if (accountCreationViewModel.CountryId != null)
             {
                 accountCreation.CountryId = accountCreationViewModel.CountryId;
@@ -535,7 +537,7 @@
         public async Task<IActionResult> CreateAccountSubmitRegionSelection(AccountCreationViewModel accountCreationViewModel)
         {
             var accountCreation = await this.multiPageFormService.GetMultiPageFormData<AccountCreationViewModel>(MultiPageFormDataFeature.AddRegistrationPrompt, this.TempData);
-
+            AccountCreationFormHelper.PopulateGroupedFormControlMetadata(this.ViewData);
             if (string.IsNullOrWhiteSpace(accountCreationViewModel.RegionId))
             {
                 if (accountCreation.CountryId == "1" || accountCreation.CountryId == null)
@@ -593,6 +595,7 @@
         public async Task<IActionResult> CreateAccountCurrentRole(AccountCreationViewModel accountCreationViewModel)
         {
             var accountCreation = await this.multiPageFormService.GetMultiPageFormData<AccountCreationViewModel>(MultiPageFormDataFeature.AddRegistrationPrompt, this.TempData);
+            AccountCreationFormHelper.PopulateGroupedFormControlMetadata(this.ViewData);
             if (!string.IsNullOrWhiteSpace(accountCreationViewModel.FilterText))
             {
                 string filterText = Regex.Replace(accountCreationViewModel.FilterText, "[:!@#$%^&*()}{|\":?><\\[\\]\\;'/.,~\\\"\"\\'\\\\/]", " ");
@@ -649,6 +652,7 @@
         public async Task<IActionResult> CreateAccountProfessionalRegNumber(AccountCreationViewModel accountCreationViewModel)
         {
             var roleCheck = int.TryParse(accountCreationViewModel.CurrentRole, out int roleId);
+            AccountCreationFormHelper.PopulateGroupedFormControlMetadata(this.ViewData);
             var accountCreation = await this.multiPageFormService.GetMultiPageFormData<AccountCreationViewModel>(MultiPageFormDataFeature.AddRegistrationPrompt, this.TempData);
 
             if (string.IsNullOrWhiteSpace(accountCreationViewModel.CurrentRole) || !roleCheck)
@@ -681,6 +685,7 @@
         public async Task<IActionResult> CreateAccountGradeSelection(AccountCreationViewModel accountCreationViewModel)
         {
             var accountCreation = await this.multiPageFormService.GetMultiPageFormData<AccountCreationViewModel>(MultiPageFormDataFeature.AddRegistrationPrompt, this.TempData);
+            AccountCreationFormHelper.PopulateGroupedFormControlMetadata(this.ViewData);
             int gradePageSize = UserRegistrationContentPageSize + 5;
             var roleCheck = int.TryParse(accountCreation.CurrentRole, out int roleId);
             if (!roleCheck || roleId == 0)
@@ -745,6 +750,7 @@
         public async Task<IActionResult> CreateAccountPrimarySpecialty(AccountCreationViewModel accountCreationViewModel)
         {
             var accountCreation = await this.multiPageFormService.GetMultiPageFormData<AccountCreationViewModel>(MultiPageFormDataFeature.AddRegistrationPrompt, this.TempData);
+            AccountCreationFormHelper.PopulateGroupedFormControlMetadata(this.ViewData);
             var gradeCheck = int.TryParse(accountCreationViewModel.GradeId, out int gradeId);
             if (string.IsNullOrWhiteSpace(accountCreationViewModel.GradeId) || !gradeCheck)
             {
@@ -777,6 +783,7 @@
         public async Task<IActionResult> CreateAccountPrimarySpecialtySelection(AccountCreationViewModel accountCreationViewModel)
         {
             var accountCreation = await this.multiPageFormService.GetMultiPageFormData<AccountCreationViewModel>(MultiPageFormDataFeature.AddRegistrationPrompt, this.TempData);
+            AccountCreationFormHelper.PopulateGroupedFormControlMetadata(this.ViewData);
             if (accountCreationViewModel.PrimarySpecialtyId?.ToLower() == "not applicable")
             {
                 var specialties = await this.specialtyService.GetSpecialtiesAsync();
@@ -953,6 +960,7 @@
         public async Task<IActionResult> CreateAccountWorkPlaceSearch()
         {
             var accountCreation = await this.multiPageFormService.GetMultiPageFormData<AccountCreationViewModel>(MultiPageFormDataFeature.AddRegistrationPrompt, this.TempData);
+            AccountCreationFormHelper.PopulateGroupedFormControlMetadata(this.ViewData);
             if (!string.IsNullOrWhiteSpace(accountCreation.LocationId) && !this.CheckConfirmationUpdate())
             {
                 return this.RedirectToAction("CreateAccountWorkPlace", new AccountCreationViewModel { LocationId = accountCreation.LocationId });
@@ -972,6 +980,7 @@
         public async Task<IActionResult> CreateAccountWorkPlace(AccountCreationViewModel accountCreationViewModel)
         {
             var accountCreation = await this.multiPageFormService.GetMultiPageFormData<AccountCreationViewModel>(MultiPageFormDataFeature.AddRegistrationPrompt, this.TempData);
+            AccountCreationFormHelper.PopulateGroupedFormControlMetadata(this.ViewData);
             if (string.IsNullOrWhiteSpace(accountCreationViewModel.FilterText))
             {
                 if (!string.IsNullOrWhiteSpace(accountCreation.LocationId))
@@ -1014,7 +1023,7 @@
         public async Task<IActionResult> CreateAccountConfirmation(AccountCreationViewModel accountCreationViewModel)
         {
             var accountCreation = await this.multiPageFormService.GetMultiPageFormData<AccountCreationViewModel>(MultiPageFormDataFeature.AddRegistrationPrompt, this.TempData);
-
+            AccountCreationFormHelper.PopulateGroupedFormControlMetadata(this.ViewData);
             if (accountCreation.AccountCreationType == AccountCreationTypeEnum.FullAccess)
             {
                 var placeOfWorkCheck = int.TryParse(accountCreationViewModel.LocationId, out int locationId);
@@ -1051,7 +1060,7 @@
         {
             var accountCreation = await this.multiPageFormService.GetMultiPageFormData<AccountCreationViewModel>(MultiPageFormDataFeature.AddRegistrationPrompt, this.TempData);
             this.ViewBag.AccountCreationType = accountCreation.AccountCreationType;
-
+            AccountCreationFormHelper.PopulateGroupedFormControlMetadata(this.ViewData);
             if (accountCreation.CountryId == "1" && (string.IsNullOrWhiteSpace(accountCreation.RegionId) || accountCreation.RegionId == "0"))
             {
                 this.ModelState.AddModelError(string.Empty, CommonValidationErrorMessages.RegionRequiredSummary);

--- a/LearningHub.Nhs.WebUI/Helpers/AccountCreationFormHelper.cs
+++ b/LearningHub.Nhs.WebUI/Helpers/AccountCreationFormHelper.cs
@@ -1,0 +1,28 @@
+﻿namespace LearningHub.Nhs.WebUI.Helpers
+{
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Mvc.ViewFeatures;
+
+    /// <summary>
+    /// Defines the <see cref="AccountCreationFormHelper" />.
+    /// </summary>
+    public static class AccountCreationFormHelper
+    {
+        /// <summary>
+        /// The PopulateGroupedFormControlMetadata.
+        /// </summary>
+        /// <param name="viewData">viewData.</param>
+        public static void PopulateGroupedFormControlMetadata(ViewDataDictionary viewData)
+        {
+            viewData["GroupedFormControlMetadata"] = new Dictionary<string, bool>
+            {
+                { "CountryId", true },
+                { "RegionId", true },
+                { "CurrentRole", true },
+                { "PrimarySpecialtyId", true },
+                { "GradeId", true },
+                { "LocationId", true },
+            };
+        }
+    }
+}

--- a/LearningHub.Nhs.WebUI/LearningHub.Nhs.WebUI.csproj
+++ b/LearningHub.Nhs.WebUI/LearningHub.Nhs.WebUI.csproj
@@ -128,7 +128,7 @@
 		<PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" Version="2.4.1" />
 		<PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.10" />
 		<PackageReference Include="MK.IO" Version="1.5.0" />
-		<PackageReference Include="NHSUKViewComponents.Web" Version="1.0.27" />
+		<PackageReference Include="NHSUKViewComponents.Web" Version="1.0.28" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/LearningHub.Nhs.WebUI/Views/Account/CreateAccountPrimarySpecialty.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Account/CreateAccountPrimarySpecialty.cshtml
@@ -62,7 +62,7 @@
                             <div class="nhsuk-radios">
 
                                 <div class="nhsuk-radios__item">
-                                    <input class="nhsuk-radios__input" id="PrimarySpecialtyId" name="PrimarySpecialtyId" type="radio" value="Not applicable">
+                                    <input class="nhsuk-radios__input" id="PrimarySpecialtyId-0" name="PrimarySpecialtyId" type="radio" value="Not applicable">
                                     <label class="nhsuk-label nhsuk-radios__label" for="PrimarySpecialtyId">
                                         Not applicable
                                     </label>

--- a/LearningHub.Nhs.WebUI/Views/Account/CreateAccountPrimarySpecialtySelection.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Account/CreateAccountPrimarySpecialtySelection.cshtml
@@ -144,7 +144,7 @@
                                 <div class="nhsuk-radios">
 
                                     <div class="nhsuk-radios__item">
-                                    <input class="nhsuk-radios__input" id="PrimarySpecialtyId" name="PrimarySpecialtyId" type="radio" value="Not applicable">
+                                    <input class="nhsuk-radios__input" id="PrimarySpecialtyId-0" name="PrimarySpecialtyId" type="radio" value="Not applicable">
                                         <label class="nhsuk-label nhsuk-radios__label" for="FilterText">
                                             Not applicable
                                         </label>

--- a/LearningHub.Nhs.WebUI/Views/Shared/Components/RadioList/Default.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Shared/Components/RadioList/Default.cshtml
@@ -52,7 +52,7 @@
             @foreach (var (radio, index) in Model.Radios.Select((r, i) => (r, i)))
             {
                 counter = index;
-                var radioId = $"{radio.Value}-{index}";
+                var radioId = $"{Model.AspFor}-{index}";
                 if (!string.IsNullOrWhiteSpace(Model.Class))
                 {
                     <div class="@Model.Class">
@@ -106,7 +106,7 @@
             @if (Model.OptionalRadio != null)
             {
                 <div class="nhsuk-radios__divider nhsuk-u-padding-left-2">or</div>
-                var radioId = $"{Model.OptionalRadio.Value}-{++counter}";
+                var radioId = $"{Model.AspFor}-{++counter}";
                 <div class="nhsuk-radios__item">
                     <input class="nhsuk-radios__input"
                            id="@radioId"


### PR DESCRIPTION
### JIRA link
[TD-4180](https://hee-tis.atlassian.net/browse/TD-4180)

### Description
Grouped form controls within the view component has now been updated to focus on the first item in a radio list when an error occurred. A viewdata was introduced to capture form fields that are grouped. This allows  the view component to assign the correct incremental ID which aligns with how IDs are generated in a radiogroup.

### Screenshots
![image](https://github.com/user-attachments/assets/54b563e3-3eed-4942-9cb7-c0645ed1d8bf)
![image](https://github.com/user-attachments/assets/0f4fba88-00d6-4d2d-b6fe-29aa8c806f7d)


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.


[TD-4180]: https://hee-tis.atlassian.net/browse/TD-4180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ