### PR TITLE
TD-5238-elearning resource page doesn't refresh properly upon completing elearning

### DIFF
--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/resource/ResourceContent.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/resource/ResourceContent.vue
@@ -722,14 +722,6 @@
             async launchScorm() {
                 var targetWin;
                 var targetWinName = "lhContent" + this.resourceItem.resourceId;
-                // Use a placeholder window to avoid popup blockers
-                targetWin = window.open("about:blank", targetWinName, "location=0,menubar=0,resizable=0,width=" + this.resourceItem.scormDetails.popupWidth + ",height=" + this.resourceItem.scormDetails.popupHeight);
-
-                // If the pop-up was blocked
-                if (!targetWin) {
-                    alert("Please allow pop-ups to view this content.");
-                    return;
-                }
                 var activeContent = await userData.getActiveContent();
 
                 if (activeContent.filter(ac => ac.resourceId === this.resourceItem.resourceId).length > 0) {


### PR DESCRIPTION
### JIRA link
_TD-5238

### Description
elearning resource page doesn't refresh properly upon completing elearning
### Screenshots
_Attach screenshots on mobile, tablet and desktop._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the formatter and made sure there are no IDE errors
- [ ] Written appropriate unit tests for the changes, including:
	- accessibility tests for new views
	- tests for new controller methods
	- tests for new or modified API endpoints
- [ ] Manually tested my work with and without JavaScript
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related) and addressed any valid accessibility issues
- [ ] Updated/added documentation in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3477930003/Learning+Hub) and/or [GitHub Readme](https://github.com/TechnologyEnhancedLearning/LearningHub.Nhs.UserApi/blob/master/README.md). List of documentation links added/changed:
  - [doc_1_here](link_1_here)
- [ ] Updated my Jira ticket with information about other parts of the system that were touched as part of the MR and have to be sanity tested to ensure nothing is broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks.
