### PR TITLE
TD-4794 -Browse Catalogue page only lists 10 catalogues

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/CatalogueController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/CatalogueController.cs
@@ -587,8 +587,7 @@
         [Route("/allcatalogue/{filterChar}")]
         public async Task<IActionResult> GetAllCatalogue(string filterChar = "a")
         {
-            var pageSize = this.settings.AllCataloguePageSize;
-            var catalogues = await this.catalogueService.GetAllCatalogueAsync(filterChar, pageSize);
+            var catalogues = await this.catalogueService.GetAllCatalogueAsync(filterChar);
             return this.View("allcatalogue", catalogues);
         }
 

--- a/LearningHub.Nhs.WebUI/Interfaces/ICatalogueService.cs
+++ b/LearningHub.Nhs.WebUI/Interfaces/ICatalogueService.cs
@@ -143,8 +143,7 @@
         /// The GetAllCatalogueAsync.
         /// </summary>
         /// <param name="filterChar">The letter.</param>
-        /// <param name="pageSize">The pageSize.</param>
         /// <returns>The allcatalogue result based on letters.</returns>
-        Task<AllCatalogueResponseViewModel> GetAllCatalogueAsync(string filterChar, int pageSize);
+        Task<AllCatalogueResponseViewModel> GetAllCatalogueAsync(string filterChar);
     }
 }

--- a/LearningHub.Nhs.WebUI/Services/CatalogueService.cs
+++ b/LearningHub.Nhs.WebUI/Services/CatalogueService.cs
@@ -607,14 +607,13 @@
         /// GetAllCatalogueAsync.
         /// </summary>
         /// <param name="filterChar">The filterChar.</param>
-        /// <param name="pageSize">the pageSize.</param>
-        /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        public async Task<AllCatalogueResponseViewModel> GetAllCatalogueAsync(string filterChar, int pageSize)
+        /// /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
+        public async Task<AllCatalogueResponseViewModel> GetAllCatalogueAsync(string filterChar)
         {
             AllCatalogueResponseViewModel viewmodel = new AllCatalogueResponseViewModel { };
             var client = await this.LearningHubHttpClient.GetClientAsync();
 
-            var request = $"catalogue/allcatalogues/{pageSize}/{filterChar}";
+            var request = $"catalogue/allcatalogues/{filterChar}";
             var response = await client.GetAsync(request).ConfigureAwait(false);
 
             if (response.IsSuccessStatusCode)

--- a/WebAPI/LearningHub.Nhs.API/Controllers/CatalogueController.cs
+++ b/WebAPI/LearningHub.Nhs.API/Controllers/CatalogueController.cs
@@ -375,14 +375,13 @@
         /// <summary>
         /// Gets AllCatalogues.
         /// </summary>
-        /// <param name="pageSize">The pageSize.</param>
         /// <param name="filterChar">The filterChar.</param>
         /// <returns>IActionResult.</returns>
         [HttpGet]
-        [Route("allcatalogues/{pageSize}/{filterChar}")]
-        public async Task<IActionResult> GetAllCataloguesAsync(int pageSize, string filterChar = null)
+        [Route("allcatalogues/{filterChar}")]
+        public async Task<IActionResult> GetAllCataloguesAsync(string filterChar = null)
         {
-            var response = await this.catalogueService.GetAllCataloguesAsync(pageSize, filterChar, this.CurrentUserId);
+            var response = await this.catalogueService.GetAllCataloguesAsync(filterChar, this.CurrentUserId);
             return this.Ok(response);
         }
     }

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/GetCatalogues.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/GetCatalogues.sql
@@ -1,9 +1,16 @@
-﻿CREATE PROCEDURE [hierarchy].[GetCatalogues] (
+﻿-------------------------------------------------------------------------------
+-- Author       Arunima George
+-- Created      15-08-2024
+-- Purpose      Get Cataloges for View all cataoge page
+--
+-- Modification History
+
+-- Anju   03-02-2025  TD-4794: Removed page size to disaplay all records
+-------------------------------------------------------------------------------
+
+CREATE PROCEDURE [hierarchy].[GetCatalogues] (
 	 @userId INT	
-	,@filterChar nvarchar(10)
-	,@OffsetRows int
-	,@fetchRows int
-	)
+	,@filterChar nvarchar(10))
 AS
 BEGIN
 
@@ -30,10 +37,7 @@ BEGIN
 			WHERE n.Id <> 1	AND n.Hidden = 0	AND n.Deleted = 0	AND cnv.Deleted = 0 AND nv.VersionStatusId = 2 
 			and cnv.Name like @filterChar+'%'
 			ORDER BY cnv.Name
-			OFFSET @OffsetRows ROWS
-			FETCH NEXT @FetchRows ROWS ONLY
-	
 
-	
+		
 		
 END

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/GetCataloguesCount.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Hierarchy/GetCataloguesCount.sql
@@ -1,4 +1,9 @@
-﻿CREATE PROCEDURE [hierarchy].[GetCataloguesCount] (
+﻿-------------------------------------------------------------------------------
+-- Author       Arunima George
+-- Created      15-08-2024
+-- Purpose      Get Cataloges for View all cataoge page
+
+CREATE PROCEDURE [hierarchy].[GetCataloguesCount] (
 	 @userId INT
 	)
 AS

--- a/WebAPI/LearningHub.Nhs.Repository.Interface/Hierarchy/ICatalogueNodeVersionRepository.cs
+++ b/WebAPI/LearningHub.Nhs.Repository.Interface/Hierarchy/ICatalogueNodeVersionRepository.cs
@@ -132,10 +132,9 @@
         /// <summary>
         /// Gets catalogues based on filter character.
         /// </summary>
-        /// <param name="pageSize">The pageSize.</param>
         /// <param name="filterChar">The filterChar.</param>
         /// <param name="userId">The userId.</param>
         /// <returns>The catalogues.</returns>
-        Task<List<AllCatalogueViewModel>> GetAllCataloguesAsync(int pageSize, string filterChar, int userId);
+        Task<List<AllCatalogueViewModel>> GetAllCataloguesAsync(string filterChar, int userId);
     }
 }

--- a/WebAPI/LearningHub.Nhs.Repository/Hierarchy/CatalogueNodeVersionRepository.cs
+++ b/WebAPI/LearningHub.Nhs.Repository/Hierarchy/CatalogueNodeVersionRepository.cs
@@ -373,18 +373,15 @@
         /// <summary>
         /// Gets catalogues based on filter character.
         /// </summary>
-        /// <param name="pageSize">The pageSize.</param>
         /// <param name="filterChar">The filterChar.</param>
         /// <param name="userId">The userId.</param>
         /// <returns>resources.</returns>
-        public async Task<List<AllCatalogueViewModel>> GetAllCataloguesAsync(int pageSize, string filterChar, int userId)
+        public async Task<List<AllCatalogueViewModel>> GetAllCataloguesAsync(string filterChar, int userId)
         {
             var param0 = new SqlParameter("@userId", SqlDbType.Int) { Value = userId };
             var param1 = new SqlParameter("@filterChar", SqlDbType.NVarChar, 10) { Value = filterChar.Trim() };
-            var param2 = new SqlParameter("@OffsetRows", SqlDbType.Int) { Value = 0 };
-            var param3 = new SqlParameter("@fetchRows", SqlDbType.Int) { Value = pageSize };
 
-            var result = await this.DbContext.AllCatalogueViewModel.FromSqlRaw("[hierarchy].[GetCatalogues] @userId, @filterChar, @OffsetRows, @fetchRows", param0, param1, param2, param3)
+            var result = await this.DbContext.AllCatalogueViewModel.FromSqlRaw("[hierarchy].[GetCatalogues] @userId, @filterChar", param0, param1)
               .AsNoTracking().ToListAsync();
             return result;
         }

--- a/WebAPI/LearningHub.Nhs.Services.Interface/ICatalogueService.cs
+++ b/WebAPI/LearningHub.Nhs.Services.Interface/ICatalogueService.cs
@@ -250,10 +250,9 @@
         /// <summary>
         /// GetAllCataloguesAsync.
         /// </summary>
-        /// <param name="pageSize">The pageSize.</param>
         /// <param name="filterChar">filterChar.</param>
         /// <param name="userId">userId.</param>
         /// <returns>The allcatalogue result based on letters.</returns>
-        Task<AllCatalogueResponseViewModel> GetAllCataloguesAsync(int pageSize, string filterChar, int userId);
+        Task<AllCatalogueResponseViewModel> GetAllCataloguesAsync(string filterChar, int userId);
     }
 }

--- a/WebAPI/LearningHub.Nhs.Services/CatalogueService.cs
+++ b/WebAPI/LearningHub.Nhs.Services/CatalogueService.cs
@@ -968,11 +968,10 @@
         /// <summary>
         /// GetAllCataloguesAsync.
         /// </summary>
-        /// <param name="pageSize">The pageSize.</param>
         /// <param name="filterChar">The filterChar.</param>
         /// <param name="userId">The userId.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        public async Task<AllCatalogueResponseViewModel> GetAllCataloguesAsync(int pageSize, string filterChar, int userId)
+        public async Task<AllCatalogueResponseViewModel> GetAllCataloguesAsync(string filterChar, int userId)
         {
             var catalogueAlphaCount = this.catalogueNodeVersionRepository.GetAllCataloguesAlphaCount(userId);
             var filterCharMod = filterChar.Trim() == "0-9" ? "[0-9]" : filterChar;
@@ -1010,7 +1009,7 @@
                 }
             }
 
-            var catalogues = await this.catalogueNodeVersionRepository.GetAllCataloguesAsync(pageSize, filterCharMod, userId);
+            var catalogues = await this.catalogueNodeVersionRepository.GetAllCataloguesAsync(filterCharMod, userId);
             foreach (var catalogue in catalogues)
             {
                 catalogue.Providers = await this.providerService.GetByCatalogueVersionIdAsync(catalogue.NodeVersionId);


### PR DESCRIPTION
### JIRA link
TD-4794

### Description
Browse Catalogue page only lists 10 catalogues. Removed page size to display all records

### Screenshots
![image](https://github.com/user-attachments/assets/43bacc23-c5dd-442a-bea1-cd1407c3d9b1)
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [X] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [X] Confirmed that none of the work that I have undertaken requires any updates to documentation