### PR TITLE
TD-5302-Fix for Contact Us Page - Two headings have the same heading level

### DIFF
--- a/LearningHub.Nhs.WebUI/Views/Home/Contactus.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Home/Contactus.cshtml
@@ -31,9 +31,9 @@
       <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
         <div class="nhsuk-card nhsuk-card--clickable">
           <div class="nhsuk-card__content">
-            <h2 class="nhsuk-card__heading nhsuk-heading-m">
+            <h3 class="nhsuk-card__heading nhsuk-heading-m">
               <a class="nhsuk-card__link" target="_blank" href="@options.Value.SupportUrls.SupportSite">Support site</a>
-            </h2>
+            </h3>
             <p class="nhsuk-card__description">
               Visit our support site for help on using the Learning Hub.
             </p>
@@ -44,9 +44,9 @@
       <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
         <div class="nhsuk-card nhsuk-card--clickable">
           <div class="nhsuk-card__content">
-            <h2 class="nhsuk-card__heading nhsuk-heading-m">
+            <h3 class="nhsuk-card__heading nhsuk-heading-m">
               <a class="nhsuk-card__link" target="_blank" href="@options.Value.SupportUrls.SupportForm">Support team</a>
-            </h2>
+            </h3>
             <p  class="nhsuk-card__description">
               Complete our form to ask the support team for help.
             </p>
@@ -58,9 +58,9 @@
       <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
         <div class="nhsuk-card nhsuk-card--clickable">
           <div class="nhsuk-card__content">
-            <h2 class="nhsuk-card__heading nhsuk-heading-m">
+            <h3 class="nhsuk-card__heading nhsuk-heading-m">
               <a href="@options.Value.SupportUrls.SupportFeedbackForm" target="_blank">Share feedback</a>
-            </h2>
+            </h3>
             <p class="nhsuk-card__description">
                 Share your feedback to help us improve the platform.
             </p>
@@ -71,9 +71,9 @@
       <li class="nhsuk-grid-column-one-half nhsuk-card-group__item">
         <div class="nhsuk-card nhsuk-card--clickable">
           <div class="nhsuk-card__content">
-            <h2 class="nhsuk-card__heading nhsuk-heading-m">
+            <h3 class="nhsuk-card__heading nhsuk-heading-m">
               <a class="nhsuk-card__link" href="@options.Value.SupportUrls.ContributeUR">Contribute to user research</a>
-            </h2>
+            </h3>
             <p class="nhsuk-card__description">
               Influence the future development of the Learning Hub.
             </p>


### PR DESCRIPTION
### JIRA link
TD-5302

### Description
fix for Contact Us Page - Two headings have the same heading level

### Screenshots
![image](https://github.com/user-attachments/assets/04237dec-ec0a-45d2-adf9-a2d606a767a6)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [X] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [X] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [X] Confirmed that none of the work that I have undertaken requires any updates to documentation