### PR TITLE
Infastructure test for TD-5348

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/Api/ResourceController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/Api/ResourceController.cs
@@ -65,6 +65,7 @@ namespace LearningHub.Nhs.WebUI.Controllers.Api
         /// <param name="fileName">File name.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
         [HttpGet("DownloadResource")]
+        [AllowAnonymous]
         public async Task<IActionResult> DownloadResource(string filePath, string fileName)
         {
             if (string.IsNullOrEmpty(fileName))

--- a/LearningHub.Nhs.WebUI/Controllers/Api/ResourceController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/Api/ResourceController.cs
@@ -2,6 +2,10 @@ namespace LearningHub.Nhs.WebUI.Controllers.Api
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Net.Http.Headers;
+    using System.Threading;
     using System.Threading.Tasks;
     using LearningHub.Nhs.Models.Enums;
     using LearningHub.Nhs.Models.Resource;
@@ -9,6 +13,7 @@ namespace LearningHub.Nhs.WebUI.Controllers.Api
     using LearningHub.Nhs.Models.Resource.Contribute;
     using LearningHub.Nhs.WebUI.Interfaces;
     using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Configuration;
 
@@ -70,7 +75,15 @@ namespace LearningHub.Nhs.WebUI.Controllers.Api
             var file = await this.fileService.DownloadFileAsync(filePath, fileName);
             if (file != null)
             {
-                return this.File(file.Content, file.ContentType, fileName);
+                // Set response headers.
+                this.Response.ContentType = file.ContentType;
+                this.Response.ContentLength = file.ContentLength;
+                var contentDisposition = new ContentDispositionHeaderValue("attachment") { FileNameStar = fileName };
+                this.Response.Headers["Content-Disposition"] = contentDisposition.ToString();
+
+                // Stream the file in chunks with periodic flushes to keep the connection active.
+                await this.StreamFileWithKeepAliveAsync(file.Content, this.Response.Body, this.HttpContext.RequestAborted);
+                return this.Ok();
             }
             else
             {
@@ -105,7 +118,16 @@ namespace LearningHub.Nhs.WebUI.Controllers.Api
                     ActivityStatus = ActivityStatusEnum.Completed,
                 };
                 await this.activityService.CreateResourceActivityAsync(activity);
-                return this.File(file.Content, file.ContentType, fileName);
+
+                // Set response headers.
+                this.Response.ContentType = file.ContentType;
+                this.Response.ContentLength = file.ContentLength;
+                var contentDisposition = new ContentDispositionHeaderValue("attachment") { FileNameStar = fileName };
+                this.Response.Headers["Content-Disposition"] = contentDisposition.ToString();
+
+                // Stream the file in chunks with periodic flushes to keep the connection active.
+                await this.StreamFileWithKeepAliveAsync(file.Content, this.Response.Body, this.HttpContext.RequestAborted);
+                return this.Ok();
             }
             else
             {
@@ -583,6 +605,21 @@ namespace LearningHub.Nhs.WebUI.Controllers.Api
         {
             var result = await this.resourceService.GetObsoleteResourceFile(resourceVersionId, deletedResource);
             return result;
+        }
+
+        /// <summary>
+        /// Reads from the source stream in chunks and writes to the destination stream,
+        /// flushing after each chunk to help keep the connection active.
+        /// </summary>
+        private async Task StreamFileWithKeepAliveAsync(Stream source, Stream destination, CancellationToken cancellationToken)
+        {
+            byte[] buffer = new byte[8192];
+            int bytesRead;
+            while ((bytesRead = await source.ReadAsync(buffer, 0, buffer.Length, cancellationToken)) > 0)
+            {
+                await destination.WriteAsync(buffer, 0, bytesRead, cancellationToken);
+                await destination.FlushAsync(cancellationToken);
+            }
         }
     }
 }


### PR DESCRIPTION
### JIRA link
[TD-5348](https://hee-tis.atlassian.net/browse/TD-5348)

### Description
There is need to investigate where the connection is being interrupted during download

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation