### PR TITLE
TD-5348 LH resource download files error

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/Api/ResourceController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/Api/ResourceController.cs
@@ -69,9 +69,10 @@ namespace LearningHub.Nhs.WebUI.Controllers.Api
             }
 
             var file = await this.fileService.DownloadFileAsync(filePath, fileName);
+
             if (file != null)
             {
-                return this.File(file.Content, file.ContentType, fileName);
+                return !string.IsNullOrEmpty(file.DownloadUrl) ? this.Redirect(file.DownloadUrl) : this.File(file.Content, file.ContentType, fileName);
             }
             else
             {
@@ -106,7 +107,8 @@ namespace LearningHub.Nhs.WebUI.Controllers.Api
                     ActivityStatus = ActivityStatusEnum.Completed,
                 };
                 await this.activityService.CreateResourceActivityAsync(activity);
-                return this.File(file.Content, file.ContentType, fileName);
+
+                return !string.IsNullOrEmpty(file.DownloadUrl) ? this.Redirect(file.DownloadUrl) : this.File(file.Content, file.ContentType, fileName);
             }
             else
             {

--- a/LearningHub.Nhs.WebUI/Models/FileDownloadResponse.cs
+++ b/LearningHub.Nhs.WebUI/Models/FileDownloadResponse.cs
@@ -21,5 +21,10 @@
         /// Gets or sets the ContentType.
         /// </summary>
         public long ContentLength { get; set; }
+
+        /// <summary>
+        /// Gets or sets when downloading large files, a SAS URL is returned so the client can download directly from Azure Files.
+        /// </summary>
+        public string DownloadUrl { get; set; }
     }
 }


### PR DESCRIPTION
### JIRA link
[TD-5348](https://hee-tis.atlassian.net/browse/TD-5348)

### Description
Modified file service to generate azure storage link for files larger than 999mb

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-5348]: https://hee-tis.atlassian.net/browse/TD-5348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ