### PR TITLE
Td-5048: Issue showing multiple entries for service updates/releases …

### DIFF
--- a/AdminUI/LearningHub.Nhs.AdminUI/Views/Roadmap/Update.cshtml
+++ b/AdminUI/LearningHub.Nhs.AdminUI/Views/Roadmap/Update.cshtml
@@ -15,7 +15,7 @@
 <div class="go-back-header">
     <a href="@Url.Action("Updates", "Roadmap")">&lt; Go back</a>
 </div>
-<form style="margin-left: 24px; margin-right: 24px; max-width: 800px;" action="/Roadmap/@formAction" method="POST" enctype="multipart/form-data">
+<form style="margin-left: 24px; margin-right: 24px; max-width: 800px;" action="/Roadmap/@formAction" method="POST" onsubmit="btnSave.disabled = true; return true;" enctype="multipart/form-data">
     <input type="hidden" name="RoadmapTypeId" value="@Model.RoadmapTypeId"/>
     <input type="hidden" name="Id" value="@Model.Id"/>
     <div class="row mt-5">
@@ -99,7 +99,7 @@
     </div>
     <div class="row mt-5">
         <div class="col-12 d-flex justify-content-between">
-            <button class="btn btn-custom-green">Save</button>
+            <button class="btn btn-custom-green" id="btnSave">Save</button>
             @if (isNew)
             {
                 <a class="btn-link-red btn btn-link" asp-action="Updates" asp-controller="Roadmap">Cancel</a>


### PR DESCRIPTION
…on 'Admin' section when clicked 'save' button multiple times

### JIRA link
https://hee-tis.atlassian.net/browse/TD-5048

### Description
Fixed the issue with the multiple click
### Screenshots
![image](https://github.com/user-attachments/assets/db353abd-de19-401d-aa3b-ea6cef4ede08)

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation