### PR TITLE
TD-5179: Fixed focus issue on My bookmarks screen

### DIFF
--- a/LearningHub.Nhs.WebUI/Styles/nhsuk/pages/bookmark.scss
+++ b/LearningHub.Nhs.WebUI/Styles/nhsuk/pages/bookmark.scss
@@ -112,6 +112,23 @@ td.col-type {
 tr.bookmark-item:hover td {
     background-color: $nhsuk-white;
 }
+.my-bookmark-btn:focus {
+    outline: none;
+    text-decoration: none !important;
+    color: $nhsuk-black !important;
+    background-color: $nhsuk-yellow !important;
+    box-shadow: 0 -2px $govuk-focus-highlight-yellow, 0 4px $nhsuk-black;
+}
+
+.my-bookmark-btn:hover {
+    outline: none;
+    text-decoration: none !important;
+}
+
+.my-bookmark-btn {
+    transition: none !important;
+    border-radius: 0 !important;
+}
 
 @media (min-width: 768px) {
 

--- a/LearningHub.Nhs.WebUI/Views/Bookmark/_BookmarkAction.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Bookmark/_BookmarkAction.cshtml
@@ -6,7 +6,7 @@
         <span class="action-link-chevron @(Model.IsFirst? "empty" : "")">
             @if (Model.IsFirst == false)
             {
-                <button name="action" value="moveup" class="btn btn-link action-link" title="Move up" aria-label="Move up">
+                <button name="action" value="moveup" class="btn btn-link action-link my-bookmark-btn" title="Move up" aria-label="Move up">
                     <i class="fa-solid fa-chevron-up fa-sm"></i>
                 </button>
             }
@@ -15,25 +15,25 @@
         <span class="action-link-chevron @(Model.IsLast? "empty" : "")">
             @if (Model.IsLast == false)
             {
-                <button name="action" value="movedown" class="btn btn-link action-link" title="Move down" aria-label="Move down">
+                <button name="action" value="movedown" class="btn btn-link action-link my-bookmark-btn" title="Move down" aria-label="Move down">
                     <i class="fa-solid fa-chevron-down fa-sm"></i>
                 </button>
             }
         </span>
 
         <span class="action-link-rename">
-            <button name="action" value="rename" class="btn btn-link action-link" title="Rename">Rename</button>
+            <button name="action" value="rename" class="btn btn-link action-link my-bookmark-btn" title="Rename">Rename</button>
         </span>
 
         <span class="action-link-move">
             @if (Model.IsFolder == false)
             {
-                <button name="action" value="move" class="btn btn-link action-link" title="Move">Move</button>
+                <button name="action" value="move" class="btn btn-link action-link my-bookmark-btn" title="Move">Move</button>
             }
         </span>
 
         <span class="action-link-delete">
-            <button name="action" value="delete" class="btn btn-link action-link" title="Delete">Delete</button>
+            <button name="action" value="delete" class="btn btn-link action-link my-bookmark-btn" title="Delete">Delete</button>
         </span>
     </form>
 </div>


### PR DESCRIPTION
### JIRA link
[TD-5179](https://hee-tis.atlassian.net/browse/TD-5179)

### Description
Fixed focus issue on My bookmarks screen following NHS design focus styles.

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-5179]: https://hee-tis.atlassian.net/browse/TD-5179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ