### PR TITLE
TD-3743: Concurrent Sessions Allowed

### DIFF
--- a/LearningHub.Nhs.WebUI/Helpers/InMemoryTicketStore.cs
+++ b/LearningHub.Nhs.WebUI/Helpers/InMemoryTicketStore.cs
@@ -1,0 +1,104 @@
+﻿namespace LearningHub.Nhs.WebUI.Helpers
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Authentication;
+    using Microsoft.AspNetCore.Authentication.Cookies;
+
+    /// <summary>
+    /// Defines the <see cref="InMemoryTicketStore" />.
+    /// </summary>
+    public class InMemoryTicketStore : ITicketStore
+    {
+        private readonly ConcurrentDictionary<string, AuthenticationTicket> cache;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InMemoryTicketStore"/> class.
+        /// The InMemoryTicketStore.
+        /// </summary>
+        /// <param name="cache">the cache.</param>
+        public InMemoryTicketStore(ConcurrentDictionary<string, AuthenticationTicket> cache)
+        {
+            this.cache = cache;
+        }
+
+        /// <summary>
+        /// The StoreAsync.
+        /// </summary>
+        /// <param name="ticket">The ticket.</param>
+        /// <returns>The key.</returns>
+        public async Task<string> StoreAsync(AuthenticationTicket ticket)
+        {
+            var ticketUserId = ticket.Principal.Claims.Where(c => c.Type == "sub")
+                .FirstOrDefault()
+                .Value;
+            var matchingAuthTicket = this.cache.Values.FirstOrDefault(
+                t => t.Principal.Claims.FirstOrDefault(
+                    c => c.Type == "sub"
+                    && c.Value == ticketUserId) != null);
+            if (matchingAuthTicket != null)
+            {
+                var cacheKey = this.cache.Where(
+                    entry => entry.Value == matchingAuthTicket)
+                    .Select(entry => entry.Key)
+                    .FirstOrDefault();
+                this.cache.TryRemove(
+                    cacheKey,
+                    out _);
+            }
+
+            var key = Guid
+                .NewGuid()
+                .ToString();
+            await this.RenewAsync(
+                key,
+                ticket);
+            return key;
+        }
+
+        /// <summary>
+        /// The RenewAsync.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <param name="ticket">The ticket.</param>
+        /// <returns>The Task.</returns>
+        public Task RenewAsync(
+            string key,
+            AuthenticationTicket ticket)
+        {
+            this.cache.AddOrUpdate(
+                key,
+                ticket,
+                (_, _) => ticket);
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// The RetrieveAsync.
+        /// </summary>
+        /// <param name="key">The Key.</param>
+        /// <returns>The Task.</returns>
+        public Task<AuthenticationTicket> RetrieveAsync(string key)
+        {
+            this.cache.TryGetValue(
+                key,
+                out var ticket);
+            return Task.FromResult(ticket);
+        }
+
+        /// <summary>
+        /// The RemoveAsync.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <returns>The Task.</returns>
+        public Task RemoveAsync(string key)
+        {
+            this.cache.TryRemove(
+                key,
+                out _);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/LearningHub.Nhs.WebUI/Startup/AuthenticationConfiguration.cs
+++ b/LearningHub.Nhs.WebUI/Startup/AuthenticationConfiguration.cs
@@ -1,12 +1,14 @@
 ﻿namespace LearningHub.Nhs.WebUI.Startup
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Linq;
     using System.Threading.Tasks;
     using IdentityModel;
     using LearningHub.Nhs.Caching;
     using LearningHub.Nhs.WebUI.Configuration;
     using LearningHub.Nhs.WebUI.Handlers;
+    using LearningHub.Nhs.WebUI.Helpers;
     using Microsoft.AspNetCore.Authentication;
     using Microsoft.AspNetCore.Authentication.Cookies;
     using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -41,6 +43,7 @@
                 options.SlidingExpiration = true;
                 options.EventsType = typeof(CookieEventHandler);
                 options.AccessDeniedPath = "/Home/AccessDenied";
+                options.SessionStore = new InMemoryTicketStore(new ConcurrentDictionary<string, AuthenticationTicket>());
             })
             .AddOpenIdConnect(AuthenticationScheme, options =>
             {


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3734

### Description
The application should detect the second authentication event and invalidate the initial session.

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation