### PR TITLE
TD-5134: Fixed issue not showing the inputted text on the date fields when there is an error on the screen

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/AccountController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/AccountController.cs
@@ -897,7 +897,7 @@
             }
 
             await this.multiPageFormService.SetMultiPageFormData(accountCreation, MultiPageFormDataFeature.AddRegistrationPrompt, this.TempData);
-            var dateVM = accountCreation.StartDate.HasValue ? new AccountCreationDateViewModel() { Day = accountCreation.StartDate.Value.Day, Month = accountCreation.StartDate.GetValueOrDefault().Month, Year = accountCreation.StartDate.Value.Year, FilterText = accountCreationViewModel.FilterText, ReturnToConfirmation = accountCreationViewModel.ReturnToConfirmation } : new AccountCreationDateViewModel() { FilterText = accountCreationViewModel.FilterText, ReturnToConfirmation = accountCreationViewModel.ReturnToConfirmation };
+            var dateVM = accountCreation.StartDate.HasValue ? new AccountCreationDateViewModel() { Day = accountCreation.StartDate.HasValue ? accountCreation.StartDate.Value.Day.ToString() : string.Empty, Month = accountCreation.StartDate.HasValue ? accountCreation.StartDate.GetValueOrDefault().Month.ToString() : string.Empty, Year = accountCreation.StartDate.HasValue ? accountCreation.StartDate.Value.Year.ToString() : string.Empty, FilterText = accountCreationViewModel.FilterText, ReturnToConfirmation = accountCreationViewModel.ReturnToConfirmation } : new AccountCreationDateViewModel() { FilterText = accountCreationViewModel.FilterText, ReturnToConfirmation = accountCreationViewModel.ReturnToConfirmation };
             if (!string.IsNullOrWhiteSpace(accountCreationViewModel.PrimarySpecialtyId) && string.IsNullOrWhiteSpace(accountCreationViewModel.FilterText))
             {
                 var specialty = this.specialtyService.GetSpecialtiesAsync().Result.FirstOrDefault(x => x.Id == specialtyId);
@@ -959,7 +959,7 @@
                 }
             }
 
-            var dateVM = accountCreation.StartDate.HasValue ? new AccountCreationDateViewModel() { Day = accountCreation.StartDate.Value.Day, Month = accountCreation.StartDate.GetValueOrDefault().Month, Year = accountCreation.StartDate.Value.Year, ReturnToConfirmation = returnToConfirmation } : new AccountCreationDateViewModel() { ReturnToConfirmation = returnToConfirmation };
+            var dateVM = accountCreation.StartDate.HasValue ? new AccountCreationDateViewModel() { Day = accountCreation.StartDate.HasValue ? accountCreation.StartDate.Value.Day.ToString() : string.Empty, Month = accountCreation.StartDate.HasValue ? accountCreation.StartDate.GetValueOrDefault().Month.ToString() : string.Empty, Year = accountCreation.StartDate.HasValue ? accountCreation.StartDate.Value.Year.ToString() : string.Empty, ReturnToConfirmation = returnToConfirmation } : new AccountCreationDateViewModel() { ReturnToConfirmation = returnToConfirmation };
             return this.View("CreateAccountWorkStartDate", dateVM);
         }
 

--- a/LearningHub.Nhs.WebUI/Models/Account/AccountCreationDateViewModel.cs
+++ b/LearningHub.Nhs.WebUI/Models/Account/AccountCreationDateViewModel.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
-    using System.Linq;
     using LearningHub.Nhs.WebUI.Helpers;
 
     /// <summary>

--- a/LearningHub.Nhs.WebUI/Models/Account/AccountCreationDateViewModel.cs
+++ b/LearningHub.Nhs.WebUI/Models/Account/AccountCreationDateViewModel.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
+    using System.Linq;
     using LearningHub.Nhs.WebUI.Helpers;
 
     /// <summary>
@@ -13,17 +14,32 @@
         /// <summary>
         /// Gets or sets the Day.
         /// </summary>
-        public int? Day { get; set; }
+        public string Day { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Day Field.
+        /// </summary>
+        public int? DayInput { get; set; }
 
         /// <summary>
         /// Gets or sets the Country.
         /// </summary>
-        public int? Month { get; set; }
+        public string Month { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Month input.
+        /// </summary>
+        public int? MonthInput { get; set; }
 
         /// <summary>
         /// Gets or sets the Year.
         /// </summary>
-        public int? Year { get; set; }
+        public string Year { get; set; }
+
+        /// <summary>
+        /// Gets or sets YearInput.
+        /// </summary>
+        public int? YearInput { get; set; }
 
         /// <summary>
         /// Gets or sets the GetDate.
@@ -31,14 +47,46 @@
         /// <returns>DateTime.</returns>
         public DateTime? GetDate()
         {
-            return (this.Day.HasValue && this.Month.HasValue && this.Year.HasValue) ? new DateTime(this.Year!.Value, this.Month!.Value, this.Day!.Value) : (DateTime?)null;
+            return (this.DayInput.HasValue && this.MonthInput.HasValue && this.YearInput.HasValue) ? new DateTime(this.YearInput!.Value, this.MonthInput!.Value, this.DayInput!.Value) : (DateTime?)null;
         }
 
         /// <inheritdoc/>
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
-            return DateValidator.ValidateDate(this.Day, this.Month, this.Year, "valid start date")
-                .ToValidationResultList(nameof(this.Day), nameof(this.Month), nameof(this.Year));
+            var validationResults = new List<ValidationResult>();
+            int parsedDay = 0;
+            int parsedMonth = 0;
+            int parsedYear = 0;
+
+            if (!string.IsNullOrWhiteSpace(this.Day) && !int.TryParse(this.Day, out parsedDay))
+            {
+                validationResults.Add(new ValidationResult(
+                $"The value '{this.Day}' is not valid for Day.", new[] { nameof(this.Day) }));
+            }
+
+            if (!string.IsNullOrWhiteSpace(this.Month) && !int.TryParse(this.Month, out parsedMonth))
+            {
+                validationResults.Add(new ValidationResult(
+                $"The value '{this.Month}' is not valid for Month.", new[] { nameof(this.Month) }));
+            }
+
+            if (!string.IsNullOrWhiteSpace(this.Year) && !int.TryParse(this.Year, out parsedYear))
+            {
+                validationResults.Add(new ValidationResult(
+                $"The value '{this.Year}' is not valid for Year.", new[] { nameof(this.Year) }));
+            }
+
+            if (validationResults.Count > 0)
+            {
+                return validationResults;
+            }
+
+            this.DayInput = parsedDay;
+            this.MonthInput = parsedMonth;
+            this.YearInput = parsedYear;
+
+            return DateValidator.ValidateDate(this.DayInput, this.MonthInput, this.YearInput, "valid start date")
+                    .ToValidationResultList(nameof(this.Day), nameof(this.Month), nameof(this.Year));
         }
     }
 }


### PR DESCRIPTION
### JIRA link
[TD-5134](https://hee-tis.atlassian.net/browse/TD-5134)

### Description
Fixed the issue to retain the input text even if error occurs

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-5134]: https://hee-tis.atlassian.net/browse/TD-5134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ