### PR TITLE
TD-5648-Catalogue forgotten password links goes to error page

### DIFF
--- a/LearningHub.Nhs.WebUI/Views/Shared/_LoginBanner.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Shared/_LoginBanner.cshtml
@@ -15,7 +15,7 @@
                     class="nhsuk-button nhsuk-button--secondary">OpenAthens Log in</a>
             </div>
             <p class="nhsuk-u-margin-bottom-2">
-                <a asp-controller="Account" asp-action="ForgotPassword" class="">Forgotten username or password</a>
+                <a asp-controller="Account" asp-action="ForgotUserPassword" class="">Forgotten username or password</a>
             </p>
             <p>
                 <a asp-controller="Account" asp-action="CreateAnAccount">Create new account</a>


### PR DESCRIPTION
### JIRA link
TD-5648

### Description
Catalogue forgotten password links goes to error page

### Screenshots
<img width="1247" alt="image" src="https://github.com/user-attachments/assets/2910d60d-4ed8-4e48-bb3b-05f133ab11f1" />
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [X] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [X] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [X] Confirmed that none of the work that I have undertaken requires any updates to documentation