### PR TITLE
TD-4382: Video progress recorded but not changing status to complete

### DIFF
--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/CalculatePlayedMediaSegments.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/CalculatePlayedMediaSegments.sql
@@ -9,6 +9,7 @@
 -- 09-11-2020  RobS	Initial Revision
 -- 30-10-2023  RobS Updates for changes to activity status. Ending ResourceActivity status is now 'Incomplete' if
 --             user hasn't played whole media file. Used to be 'Completed'.
+-- 23-04-2025  SA   TD-4382 - added the condition to exclude the deleted resource versions 
 -------------------------------------------------------------------------------
 
 CREATE PROCEDURE [activity].[CalculatePlayedMediaSegments]
@@ -41,7 +42,7 @@ from [resources].[ResourceVersion] (nolock) rv
 	left join [resources].[AudioResourceVersion] (nolock) arv on arv.ResourceVersionId = rv.Id
 where rv.ResourceId = @ResourceId
 	and rv.MajorVersion = @MajorVersion
-	and rv.VersionStatusId > 1
+	and rv.VersionStatusId > 1 and rv.Deleted = 0
 --select @DurationInSeconds
 
 -- Start the analysis.


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-4382

### Description
Video progress recorded but not changing status to complete  -  The resource has multiple versions, and its total duration was returning null because deleted records were not excluded from the resource version table. So, the stored procedure was modified to exclude the deleted records.

<img width="719" alt="image" src="https://github.com/user-attachments/assets/18ead9af-cf11-41e0-9be8-b430081e2284" />


### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation