### PR TITLE
TD-3727- Unrestricted file upload- SIT comments

### DIFF
--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/Content.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/Content.vue
@@ -401,7 +401,8 @@
                                                                    v-model.trim="currentPassword"
                                                                    placeholder="Current password"
                                                                    @blur="$v.currentPassword.$touch()"
-                                                                   v-bind:class="{ 'input-validation-error': $v.currentPassword.$error}">
+                                                                   v-bind:class="{ 'input-validation-error': $v.currentPassword.$error}"
+                                                                   @keydown.enter="submitPassword">
                                                         </div>
 
                                                         <div class="row" v-if="showError">

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/fileUpload.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/fileUpload.vue
@@ -253,7 +253,7 @@
                             }
                         }
                         else {
-                            this.$emit('childfileuploaderror', FileErrorTypeEnum.Custom, 'There was a problem uploading this file to the Learning Hub. The .zip file you tried to upload was empty.');
+                            this.$emit('childfileuploaderror', FileErrorTypeEnum.InvalidType, 'We do not support this file type on the Learning Hub.');
                         }
                     }
                     this.uploading = false;
@@ -263,7 +263,7 @@
                             this.$emit('childfileuploaderror', FileErrorTypeEnum.Custom, 'There was a problem uploading this file to the Learning Hub. Please try again and if it still does not upload, contact the support team.');
                         }
                         else {
-                            this.$emit('childfileuploaderror', FileErrorTypeEnum.Custom, 'There was a problem uploading this file to the Learning Hub. The .zip file you tried to upload was empty.');
+                            this.$emit('childfileuploaderror', FileErrorTypeEnum.InvalidType, 'We do not support this file type on the Learning Hub.');
                         }                        
                         self.processing = false;
                         self.uploading = false;


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-3727

### Description
Fixed the SIT comments
1. In all cases of uploading a file that is not in the resource.filetype table, you are presented with the same error (problem uploading zip), even if it’s not a zip file. Should there not be some sort of catch-all in the filetype table that captures everything that is not accepted and gives the same error for consistency?
 
e.g. We do not support this file type on the Learning Hub.
 
Please see our support article which describes the file types that can be uploaded to the Learning Hub. - **Corrected the error messages**
 
 
bonus fix - after entering your password when uploading a file, pressing enter should submit it. Currently you have to move your mouse and hit “continue” - **Fixed**

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation