### PR TITLE
Develop/fixes/lh td 5538 update web.config file

### DIFF
--- a/AdminUI/LearningHub.Nhs.AdminUI/web.config
+++ b/AdminUI/LearningHub.Nhs.AdminUI/web.config
@@ -1,18 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <system.webServer>
-    <modules runAllManagedModulesForAllRequests="false">
-      <remove name="WebDAVModule" />
-    </modules>
-    <handlers>
-      <remove name="aspNetCore" />
-      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
-    </handlers>
-    <aspNetCore processPath="bin\x64\Debug\net8.0\LearningHub.Nhs.AdminUI.exe" arguments="" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" hostingModel="InProcess">
-      <environmentVariables>
-        <environmentVariable name="ASPNETCORE_ENVIRONMENT" value="Development" />
-        <environmentVariable name="ASPNETCORE_HTTPS_PORT" value="443" />
-      </environmentVariables>
-    </aspNetCore>
-  </system.webServer>
+  <location path="." inheritInChildApplications="false">
+    <system.webServer>
+      <httpProtocol>
+        <customHeaders>
+          <remove name="X-Powered-By" />
+          <remove name="Server" />
+        </customHeaders>
+      </httpProtocol>
+      <security>
+        <requestFiltering removeServerHeader="true" />
+      </security>
+		<handlers>
+			<add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
+		</handlers>
+		<aspNetCore processPath="dotnet" arguments=".\LearningHub.Nhs.AdminUI.dll" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" hostingModel="inprocess" />
+    </system.webServer>
+  </location>
 </configuration>
+<!--ProjectGuid: 1C97A3C2-73E8-4AFF-92EF-F65B4899FADB-->

--- a/AdminUI/LearningHub.Nhs.AdminUI/web.config
+++ b/AdminUI/LearningHub.Nhs.AdminUI/web.config
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <system.webServer>
+    <modules runAllManagedModulesForAllRequests="false">
+      <remove name="WebDAVModule" />
+    </modules>
+    <handlers>
+      <remove name="aspNetCore" />
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
+    </handlers>
+    <aspNetCore processPath="bin\x64\Debug\net8.0\LearningHub.Nhs.AdminUI.exe" arguments="" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" hostingModel="InProcess">
+      <environmentVariables>
+        <environmentVariable name="ASPNETCORE_ENVIRONMENT" value="Development" />
+        <environmentVariable name="ASPNETCORE_HTTPS_PORT" value="443" />
+      </environmentVariables>
+    </aspNetCore>
+  </system.webServer>
+</configuration>

--- a/LearningHub.Nhs.WebUI/Controllers/AccountController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/AccountController.cs
@@ -1168,6 +1168,16 @@
         }
 
         /// <summary>
+        /// The user already has an already active session. Then prevent concurrent access to the Learning Hub.
+        /// </summary>
+        /// <returns>The <see cref="IActionResult"/>.</returns>
+        [HttpGet]
+        public IActionResult AlreadyAnActiveSession()
+        {
+            return this.View();
+        }
+
+        /// <summary>
         /// The ForgotPassword.
         /// </summary>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>

--- a/LearningHub.Nhs.WebUI/Services/UserService.cs
+++ b/LearningHub.Nhs.WebUI/Services/UserService.cs
@@ -1886,8 +1886,6 @@
             return userHistoryViewModel;
         }
 
-
-
         /// <summary>
         /// The base 64 m d 5 hash digest.
         /// </summary>

--- a/LearningHub.Nhs.WebUI/Views/Account/AlreadyAnActiveSession.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Account/AlreadyAnActiveSession.cshtml
@@ -1,5 +1,5 @@
 ﻿@{
-    ViewData["Title"] = "Already active session";
+    ViewData["Title"] = "Session already active";
 }
 <div class="bg-white">
     <div class="nhsuk-width-container app-width-container">

--- a/LearningHub.Nhs.WebUI/web.config
+++ b/LearningHub.Nhs.WebUI/web.config
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+	<location path="." inheritInChildApplications="false">
+		<system.webServer>
+			<httpProtocol>
+				<customHeaders>
+					<remove name="X-Powered-By" />
+					<remove name="Server" />
+				</customHeaders>
+			</httpProtocol>
+			<security>
+				<requestFiltering removeServerHeader="true" />
+			</security>
+			<handlers>
+				<add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
+			</handlers>
+			<aspNetCore processPath="dotnet" arguments=".\LearningHub.Nhs.WebUI.dll" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" hostingModel="InProcess" />
+		</system.webServer>
+	</location>
+</configuration>
+<!--ProjectGuid: 044CCD77-8B9E-4888-BC20-9FD6E2AFE904-->

--- a/WebAPI/LearningHub.Nhs.API/web.config
+++ b/WebAPI/LearningHub.Nhs.API/web.config
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+	<location path="." inheritInChildApplications="false">
+		<system.webServer>
+			<httpProtocol>
+				<customHeaders>
+					<remove name="X-Powered-By" />
+					<remove name="Server" />
+				</customHeaders>
+			</httpProtocol>
+			<security>
+				<requestFiltering removeServerHeader="true" />
+			</security>
+			<handlers>
+				<add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
+			</handlers>
+			<aspNetCore processPath="dotnet" arguments=".\LearningHub.Nhs.Api.dll" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" hostingModel="InProcess" />
+		</system.webServer>
+	</location>
+</configuration>
+<!--ProjectGuid: 21F15E96-314F-4F39-822F-C2568CDC4A5A-->

--- a/WebAPI/LearningHub.Nhs.API/web.config
+++ b/WebAPI/LearningHub.Nhs.API/web.config
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-	<location path="." inheritInChildApplications="false">
-		<system.webServer>
-			<httpProtocol>
-				<customHeaders>
-					<remove name="X-Powered-By" />
-					<remove name="Server" />
-				</customHeaders>
-			</httpProtocol>
-			<security>
-				<requestFiltering removeServerHeader="true" />
-			</security>
-			<handlers>
-				<add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
-			</handlers>
-			<aspNetCore processPath="dotnet" arguments=".\LearningHub.Nhs.Api.dll" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" hostingModel="InProcess" />
-		</system.webServer>
-	</location>
+  <location path="." inheritInChildApplications="false">
+    <system.webServer>
+      <httpProtocol>
+        <customHeaders>
+          <remove name="X-Powered-By" />
+          <remove name="Server" />
+        </customHeaders>
+      </httpProtocol>
+      <security>
+        <requestFiltering removeServerHeader="true" />
+      </security>
+		<handlers>
+			<add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
+		</handlers>
+		<aspNetCore processPath="dotnet" arguments=".\LearningHub.Nhs.Api.dll" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" hostingModel="InProcess" />
+    </system.webServer>
+  </location>
 </configuration>
 <!--ProjectGuid: 21F15E96-314F-4F39-822F-C2568CDC4A5A-->


### PR DESCRIPTION
### JIRA link
[TD-5538](https://hee-tis.atlassian.net/browse/TD-5538)

### Description
Included web.config in the solution to add security headers

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-5538]: https://hee-tis.atlassian.net/browse/TD-5538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ