### PR TITLE
TD-5143: issue reading twice with screen reader on contribute resourc…

### DIFF
--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/ckeditorwithhint.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/ckeditorwithhint.vue
@@ -1,15 +1,26 @@
 <template>
     <div>
-        <ckeditor v-model="description" :config="editorConfig" @ready="onEditorReady" @blur="onBlur"></ckeditor>
-        <div :class="[`pt-2 footer-text${this.valid ? '' : ' text-danger'}`]">{{ hint }}</div>
+        <ckeditor v-model="description"
+                  :config="editorConfig"
+                  @ready="onEditorReady"
+                  @blur="onBlur"
+                  tabindex="0"
+                  :aria-describedby="'editor-hint'"
+                  role="textbox"></ckeditor>
+        <div :id="'editor-hint'"
+             :class="[`pt-2 footer-text${this.valid ? '' : ' text-danger'}`]"
+             aria-live="polite">
+            {{ hint }}
+        </div>
     </div>
 </template>
+
 
 <script lang="ts">
     import Vue, { PropOptions } from 'vue';
     import CKEditorToolbar from './models/ckeditorToolbar';
     import CKEditor from 'ckeditor4-vue/dist/legacy.js';
-    import {getRemainingCharacters, getRemainingCharactersFromHtml} from "./helpers/ckeditorValidationHelper";
+    import { getRemainingCharacters, getRemainingCharactersFromHtml } from "./helpers/ckeditorValidationHelper";
 
     const getCharactersText = (n: number) => n === 1 ? `${n} character` : `${n} characters`;
 

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/ContentCommon.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/ContentCommon.vue
@@ -62,7 +62,7 @@
                 Write a description that explains the resource and its benefits to learners.
             </div>
             <div class="col-12 my-3">
-                <ckeditorwithhint :initialValue="this.resourceDescription" :maxLength="1800" @blur="saveDescription" @change="changeDescription" />
+                <ckeditorwithhint :initialValue="this.resourceDescription" :maxLength="1800" @blur="saveDescription" @change="changeDescription"/>
             </div>
         </div>
 

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/globalcomponents/CharacterCount.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/globalcomponents/CharacterCount.vue
@@ -77,7 +77,7 @@
         </div>
         <div id="character-count-component-status-message"
              class="character-count-component-status-message"
-             aria-live="polite">
+             >
             <span>
                 You have {{ charactersDiff }} character{{ charactersDiffPlural ? 's' : '' }} remaining
             </span>


### PR DESCRIPTION
### JIRA link
[TD-5143](https://hee-tis.atlassian.net/browse/TD-5143)

### Description
issue reading twice with screen reader on contribute resource screens - Fixed 
### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-5143]: https://hee-tis.atlassian.net/browse/TD-5143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ