### PR TITLE
TD-5595-LH Admin - HTML resource details cannot be seen in Resource tab

### DIFF
--- a/AdminUI/LearningHub.Nhs.AdminUI/Views/Resource/Details.cshtml
+++ b/AdminUI/LearningHub.Nhs.AdminUI/Views/Resource/Details.cshtml
@@ -571,6 +571,32 @@
                             </dl>
                         </div>
                     }
+                    @if (Model.ResourceTypeEnum == ResourceTypeEnum.Html)
+                    {
+                        <div class="col-12">
+                            <div class="id-container">Resource Reference ID: @Model.DefaultResourceReferenceId</div>
+                            <dl>
+                                <dt>Resource Version Id</dt>
+                                <dd>@Html.DisplayFor(model => model.ResourceVersionId)</dd>
+                                <dt>Resource Type</dt>
+                                <dd>
+                                    @Html.DisplayFor(model => model.ResourceTypeDescription)
+                                </dd>
+                                <dt>ESR Link</dt>
+                                <dd><a href="@Model.HtmlDetails.HostedContentUrl" target="_blank">@Model.HtmlDetails.HostedContentUrl</a></dd>
+                                @if (Model.HtmlDetails.File != null)
+                                {
+                                    <dt>Zip File</dt>
+                                    <dd>
+                                        <a href="@String.Format("{0}file/download/{1}/{2}", webSettings.Value.LearningHubAdminUrl, Model.HtmlDetails.File.FilePath, Model.HtmlDetails.File.FileName)" target="_blank" download>@Model.HtmlDetails.File.FileName</a>
+                                    </dd>
+                                }
+
+                                <dt>Content Folder</dt>
+                                <dd>@Model.HtmlDetails.ContentFilePath</dd>
+                            </dl>
+                        </div>
+                    }
 
                     @if (Model.ResourceTypeEnum == ResourceTypeEnum.Assessment)
                     {


### PR DESCRIPTION
### JIRA link
TD-5595

### Description
LH Admin - HTML resource details cannot be seen in Resource tab
### Screenshots
<img width="1242" alt="image" src="https://github.com/user-attachments/assets/c3cf0176-df06-4fc4-b99d-85c283cff6a9" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ X] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [X] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [X] Confirmed that none of the work that I have undertaken requires any updates to documentation