### PR TITLE
TD-5651-Add User Group -Not displaying error message during Duplicate User Group's creation

### DIFF
--- a/AdminUI/LearningHub.Nhs.AdminUI/Controllers/UserGroupController.cs
+++ b/AdminUI/LearningHub.Nhs.AdminUI/Controllers/UserGroupController.cs
@@ -197,7 +197,15 @@
             if (userGroup.IsNew())
             {
                 validationResult = await this.userGroupService.CreateUserGroup(userGroup);
-                userGroup = await this.userGroupService.GetUserGroupAdminDetailbyIdAsync(validationResult.CreatedId.Value);
+                if (validationResult.IsValid)
+                {
+                    userGroup = await this.userGroupService.GetUserGroupAdminDetailbyIdAsync(validationResult.CreatedId.Value);
+                }
+                else
+                {
+                    this.ViewBag.ErrorMessage = $"Update failed: {string.Join(Environment.NewLine, validationResult.Details)}";
+                    return this.View("Details", userGroup);
+                }
             }
             else
             {


### PR DESCRIPTION
### JIRA link
TD-5651
### Description
  added proper validation message for duplicate user group
### Screenshots
_
<img width="1237" alt="image" src="https://github.com/user-attachments/assets/dab505a1-95bf-44c1-960e-7229b2f2e39c" />
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [X] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [X] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [X] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [X] Confirmed that none of the work that I have undertaken requires any updates to documentation