### PR TITLE
TD-5653-Cataolge Access Request-Typo Error

### DIFF
--- a/LearningHub.Nhs.WebUI/Views/Catalogue/AccessRequested.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Catalogue/AccessRequested.cshtml
@@ -13,7 +13,7 @@
         <vc:back-link asp-controller="Catalogue" asp-action="@Model.CatalogueUrl" link-text="Back to: @Model.CatalogueName" />
         <h1>Access requested</h1>
 
-        <p>Your request to access this cataloque has seen sent to the cataloque administrator.</p>
+        <p>Your request to access this catalogue has seen sent to the catalogue administrator.</p>
 
         <h2>What happens next?</h2>
         <p>The catalogue administrator will review your request and you will be notified of their decision by email.</p>


### PR DESCRIPTION
### JIRA link
TD-5653
### Description
Fixed typo error in Catalogue Access Request
### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [X] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [X] Confirmed that none of the work that I have undertaken requires any updates to documentation