### PR TITLE
TD-5003: Issue showing 1 sec delay when played Video/Audio resources …

### DIFF
--- a/AdminUI/LearningHub.Nhs.AdminUI/Helpers/LearningActivityHelper.cs
+++ b/AdminUI/LearningHub.Nhs.AdminUI/Helpers/LearningActivityHelper.cs
@@ -85,7 +85,15 @@
                 case ResourceTypeEnum.Article:
                     return "Read";
                 case ResourceTypeEnum.Audio:
-                    return "Played " + GetDurationText(myLearningDetailedItemViewModel.ActivityDurationSeconds * 1000);
+                    if ((myLearningDetailedItemViewModel.ActivityDurationSeconds * 1000) > myLearningDetailedItemViewModel.ResourceDurationMilliseconds)
+                    {
+                        return "Played " + GetDurationText(myLearningDetailedItemViewModel.ResourceDurationMilliseconds);
+                    }
+                    else
+                    {
+                        return "Played " + GetDurationText(myLearningDetailedItemViewModel.ActivityDurationSeconds * 1000);
+                    }
+
                 case ResourceTypeEnum.Embedded:
                     return string.Empty;
                 case ResourceTypeEnum.Equipment:
@@ -113,7 +121,15 @@
                     }
 
                 case ResourceTypeEnum.Video:
-                    return "Played " + GetDurationText(myLearningDetailedItemViewModel.ActivityDurationSeconds * 1000);
+                    if ((myLearningDetailedItemViewModel.ActivityDurationSeconds * 1000) > myLearningDetailedItemViewModel.ResourceDurationMilliseconds)
+                    {
+                        return "Played " + GetDurationText(myLearningDetailedItemViewModel.ResourceDurationMilliseconds);
+                    }
+                    else
+                    {
+                        return "Played " + GetDurationText(myLearningDetailedItemViewModel.ActivityDurationSeconds * 1000);
+                    }
+
                 case ResourceTypeEnum.WebLink:
                     return "Visited";
                 case ResourceTypeEnum.Html:

--- a/LearningHub.Nhs.WebUI/Helpers/ViewActivityHelper.cs
+++ b/LearningHub.Nhs.WebUI/Helpers/ViewActivityHelper.cs
@@ -84,7 +84,15 @@
                 case ResourceTypeEnum.Article:
                     return "Read";
                 case ResourceTypeEnum.Audio:
-                    return "Played " + GetDurationText(activityDetailedItemViewModel.ActivityDurationSeconds * 1000);
+                    if ((activityDetailedItemViewModel.ActivityDurationSeconds * 1000) > activityDetailedItemViewModel.ResourceDurationMilliseconds)
+                    {
+                        return "Played " + GetDurationText(activityDetailedItemViewModel.ResourceDurationMilliseconds);
+                    }
+                    else
+                    {
+                        return "Played " + GetDurationText(activityDetailedItemViewModel.ActivityDurationSeconds * 1000);
+                    }
+
                 case ResourceTypeEnum.Embedded:
                     return string.Empty;
                 case ResourceTypeEnum.Equipment:
@@ -112,7 +120,15 @@
                     }
 
                 case ResourceTypeEnum.Video:
-                    return "Played " + GetDurationText(activityDetailedItemViewModel.ActivityDurationSeconds * 1000);
+                    if ((activityDetailedItemViewModel.ActivityDurationSeconds * 1000) > activityDetailedItemViewModel.ResourceDurationMilliseconds)
+                    {
+                        return "Played " + GetDurationText(activityDetailedItemViewModel.ResourceDurationMilliseconds);
+                    }
+                    else
+                    {
+                        return "Played " + GetDurationText(activityDetailedItemViewModel.ActivityDurationSeconds * 1000);
+                    }
+
                 case ResourceTypeEnum.WebLink:
                     return "Visited";
                 case ResourceTypeEnum.Html:


### PR DESCRIPTION
### JIRA link
[TD-5003](https://hee-tis.atlassian.net/browse/TD-5003)

### Description
Fixed the Issue showing 1 sec delay when played Video/Audio resources on 'My Learning' page

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._
**Before**
<img width="959" alt="image" src="https://github.com/user-attachments/assets/59a02065-3a67-41a2-b221-14147599cec4" />
**After**

<img width="974" alt="image" src="https://github.com/user-attachments/assets/1e1a36d9-00fe-4172-89c1-6cbdcc01ceba" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-5003]: https://hee-tis.atlassian.net/browse/TD-5003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ