### PR TITLE
TD-5663: Post log in dashboard - remove banner promoting contribute a…

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/HomeController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/HomeController.cs
@@ -40,6 +40,7 @@ namespace LearningHub.Nhs.WebUI.Controllers
         private readonly IDashboardService dashboardService;
         private readonly IContentService contentService;
         private readonly IFeatureManager featureManager;
+        private readonly IUserGroupService userGroupService;
         private readonly Microsoft.Extensions.Configuration.IConfiguration configuration;
 
         /// <summary>
@@ -55,6 +56,7 @@ namespace LearningHub.Nhs.WebUI.Controllers
         /// <param name="dashboardService">Dashboard service.</param>
         /// <param name="contentService">Content service.</param>
         /// <param name="featureManager"> featureManager.</param>
+        /// <param name="userGroupService"> userGroupService.</param>
         /// <param name="configuration"> config.</param>
         public HomeController(
             IHttpClientFactory httpClientFactory,
@@ -67,6 +69,7 @@ namespace LearningHub.Nhs.WebUI.Controllers
             IDashboardService dashboardService,
             IContentService contentService,
             IFeatureManager featureManager,
+            IUserGroupService userGroupService,
             Microsoft.Extensions.Configuration.IConfiguration configuration)
         : base(hostingEnvironment, httpClientFactory, logger, settings.Value)
         {
@@ -76,6 +79,7 @@ namespace LearningHub.Nhs.WebUI.Controllers
             this.dashboardService = dashboardService;
             this.contentService = contentService;
             this.featureManager = featureManager;
+            this.userGroupService = userGroupService;
             this.configuration = configuration;
         }
 
@@ -212,6 +216,7 @@ namespace LearningHub.Nhs.WebUI.Controllers
                     var learningTask = this.dashboardService.GetMyAccessLearningsAsync(myLearningDashboard, 1);
                     var resourcesTask = this.dashboardService.GetResourcesAsync(resourceDashboard, 1);
                     var cataloguesTask = this.dashboardService.GetCataloguesAsync(catalogueDashboard, 1);
+                    var userGroupsTask = this.userGroupService.UserHasCatalogueContributionPermission();
 
                     var enrolledCoursesTask = Task.FromResult(new List<MoodleCourseResponseViewModel>());
                     var enableMoodle = Task.Run(() => this.featureManager.IsEnabledAsync(FeatureFlags.EnableMoodle)).Result;
@@ -222,7 +227,7 @@ namespace LearningHub.Nhs.WebUI.Controllers
                         enrolledCoursesTask = this.dashboardService.GetEnrolledCoursesFromMoodleAsync(this.CurrentMoodleUserId, 1);
                     }
 
-                    await Task.WhenAll(learningTask, resourcesTask, cataloguesTask);
+                    await Task.WhenAll(learningTask, resourcesTask, cataloguesTask, userGroupsTask);
 
                     var model = new DashboardViewModel()
                     {
@@ -231,7 +236,8 @@ namespace LearningHub.Nhs.WebUI.Controllers
                         Catalogues = await cataloguesTask,
                         EnrolledCourses = await enrolledCoursesTask,
                     };
-
+                    var userHasContributePermission = await userGroupsTask;
+                    this.ViewBag.userHasContributePermission = userHasContributePermission;
                     if (!string.IsNullOrEmpty(this.Request.Query["preview"]) && Convert.ToBoolean(this.Request.Query["preview"]))
                     {
                         return this.View("LandingPage", await this.GetLandingPageContent(Convert.ToBoolean(this.Request.Query["preview"])));

--- a/LearningHub.Nhs.WebUI/Services/UserGroupService.cs
+++ b/LearningHub.Nhs.WebUI/Services/UserGroupService.cs
@@ -5,6 +5,7 @@
     using System.Linq;
     using System.Threading.Tasks;
     using LearningHub.Nhs.Caching;
+    using LearningHub.Nhs.Models.Enums;
     using LearningHub.Nhs.Models.Extensions;
     using LearningHub.Nhs.Models.User;
     using LearningHub.Nhs.WebUI.Interfaces;
@@ -45,7 +46,7 @@
         /// <inheritdoc />
         public async Task<List<RoleUserGroupViewModel>> GetRoleUserGroupDetailAsync()
         {
-            var cacheKey = $"{this.contextAccessor.HttpContext.User.Identity.GetCurrentUserId()}:AllRolesWithPermissions";        
+            var cacheKey = $"{this.contextAccessor.HttpContext.User.Identity.GetCurrentUserId()}:AllRolesWithPermissions";
             return await this.cacheService.GetOrFetchAsync(cacheKey, () => this.FetchRoleUserGroupDetailAsync());
         }
 
@@ -60,7 +61,7 @@
         public async Task<bool> UserHasCatalogueContributionPermission()
         {
             var userRoleGroups = await this.GetRoleUserGroupDetailAsync();
-            if (userRoleGroups != null && userRoleGroups.Any(r => r.RoleName == "Local Admin" || r.RoleName == "Editor"))
+            if (userRoleGroups != null && userRoleGroups.Any(r => r.RoleEnum == RoleEnum.LocalAdmin || r.RoleEnum == RoleEnum.Editor))
             {
                 return true;
             }

--- a/LearningHub.Nhs.WebUI/Views/Home/Dashboard.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Home/Dashboard.cshtml
@@ -5,7 +5,15 @@
 @{
 	ViewData["Title"] = "Learning Hub - Home";
 
-	var isReadOnly = User.IsInRole("ReadOnly") || User.IsInRole("BasicUser");
+	var isReadOnly = false;
+	if (User.IsInRole("ReadOnly") || User.IsInRole("BasicUser"))
+	{
+		isReadOnly = true;
+	}
+	else if (User.IsInRole("BlueUser") && !this.ViewBag.userHasContributePermission)
+	{
+		isReadOnly = true;
+	}
 }
 
 @section styles {


### PR DESCRIPTION
… resource

### JIRA link
[TD-5663](https://hee-tis.atlassian.net/browse/TD-5663)

### Description
Post log in dashboard - remove banner promoting contribute a resource.
Users is not a catalogue admin or Editor , on the post logged in dashboard do not see the banner.

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._
<img width="933" alt="image" src="https://github.com/user-attachments/assets/54119384-5de4-441c-89ba-b8e32967bb3f" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation