### PR TITLE
TD-5703: Fixed issues in auto suggestion and search feedback

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/SearchController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/SearchController.cs
@@ -81,7 +81,7 @@ namespace LearningHub.Nhs.WebUI.Controllers
 
             if (filterApplied)
             {
-                await this.searchService.RegisterSearchEventsAsync(search, SearchFormActionTypeEnum.ApplyFilter, searchResult.ResourceSearchResult.TotalHits);
+                await this.searchService.RegisterSearchEventsAsync(search, SearchFormActionTypeEnum.ApplyFilter, searchResult.ResourceSearchResult?.TotalHits ?? 0);
             }
 
             if (noSortFilterError)

--- a/LearningHub.Nhs.WebUI/Views/Search/_SearchBar.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Search/_SearchBar.cshtml
@@ -48,8 +48,8 @@
         function autocomplete(input, minLength) {
             if (input != null) {
                 input.addEventListener("input", function () {
-                    var val = this.value;
-                    if (val.length < minLength) {
+                    var val = this.value.trimStart();
+                    if (val.length < minLength || val.trim() === "") {
                         closeAllLists();
                         return false;
                     }

--- a/LearningHub.Nhs.WebUI/Views/Shared/Components/NavigationItems/Searchbar.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Shared/Components/NavigationItems/Searchbar.cshtml
@@ -72,8 +72,8 @@
         function autocomplete(input, minLength) {
             if (input != null) {
                 input.addEventListener("input", function () {
-                    var val = this.value;
-                    if (val.length < minLength) {
+                    var val = this.value.trimStart();
+                    if (val.length < minLength || val.trim() === "") {
                         closeAllLists();
                         return false;
                     }


### PR DESCRIPTION
### JIRA link
[TD-5703](https://hee-tis.atlassian.net/browse/TD-5703)

### Description
Fixed issues related to blank spaces in auto suggestion and search feedback submission.

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-5703]: https://hee-tis.atlassian.net/browse/TD-5703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ