### PR TITLE
TD-5700- Reorder resource tabs on LH home page 

### DIFF
--- a/LearningHub.Nhs.WebUI/Views/Home/_ResourceTray.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Home/_ResourceTray.cshtml
@@ -43,10 +43,6 @@
         </div>
         <div class="navbar-collapse collapse" id="collapsingResourcesSubNavbar">
             <ul class="navbar-nav">
-                <li class="subnavwhite-item @(Model.Resources.Type == "popular-resources" ? "active" : string.Empty)">
-                    <a tabindex="0" class="subnavwhite-link text-nowrap"
-                       asp-controller="Home" asp-action="Index" asp-route-myLearningDashboard="@(Model.MyLearnings.Type)" asp-route-resourceDashboard="popular-resources" asp-route-catalogueDashboard="@Model.Catalogues.Type" asp-fragment="resources">Most accessed</a>
-                </li>
                 <li class="subnavwhite-item @(Model.Resources.Type == "rated-resources" ? "active" : string.Empty)">
                     <a tabindex="0" class="subnavwhite-link text-nowrap"
                        asp-controller="Home" asp-action="Index" asp-route-myLearningDashboard="@(Model.MyLearnings.Type)" asp-route-resourceDashboard="rated-resources" asp-route-catalogueDashboard="@Model.Catalogues.Type" asp-fragment="resources">Highly rated</a>
@@ -55,6 +51,11 @@
                     <a tabindex="0" class="subnavwhite-link text-nowrap"
                        asp-controller="Home" asp-action="Index" asp-route-myLearningDashboard="@(Model.MyLearnings.Type)" asp-route-resourceDashboard="recent-resources" asp-route-catalogueDashboard="@Model.Catalogues.Type" asp-fragment="resources">Recently added</a>
                 </li>
+                <li class="subnavwhite-item @(Model.Resources.Type == "popular-resources" ? "active" : string.Empty)">
+                    <a tabindex="0" class="subnavwhite-link text-nowrap"
+                       asp-controller="Home" asp-action="Index" asp-route-myLearningDashboard="@(Model.MyLearnings.Type)" asp-route-resourceDashboard="popular-resources" asp-route-catalogueDashboard="@Model.Catalogues.Type" asp-fragment="resources">Most accessed</a>
+                </li>
+
             </ul>
         </div>
     </nav>
@@ -62,7 +63,7 @@
     <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-full">
             <ul class="nhsuk-grid-row nhsuk-card-group nhsuk-card-group--centred nhsuk-u-margin-bottom-2">
-                @if(@Model.Resources.Resources != null)
+                @if (@Model.Resources.Resources != null)
                 {
                     @foreach (var resource in Model.Resources.Resources)
                     {


### PR DESCRIPTION
### JIRA link
TD-5700

### Description
Reorder resource tabs on LH home page
1.Highly rated

2.Recently Added

3.Most accessed
### Screenshots
![image](https://github.com/user-attachments/assets/3133b430-9ea7-43f8-a3b1-e9ea44b20233)
-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [X] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [X] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [X] Confirmed that none of the work that I have undertaken requires any updates to documentation