### PR TITLE
 TD-5727-Fix for Full user who is not a catalogue editor/admin can access My contribution page by navigating to the link directly 

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/ContributeController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/ContributeController.cs
@@ -171,8 +171,8 @@
         [Route("my-contributions/{selectedTab}/{catalogueId}/{nodeId}")]
         public async Task<IActionResult> MyContributions()
         {
-            bool usergroup = await this.userGroupService.UserHasCatalogueContributionPermission();
-            if ((this.User.IsInRole("ReadOnly") || this.User.IsInRole("BasicUser")) || (!usergroup && (!await this.resourceService.UserHasPublishedResourcesAsync())))
+            bool catalogueContributionPermission = await this.userGroupService.UserHasCatalogueContributionPermission();
+            if ((this.User.IsInRole("ReadOnly") || this.User.IsInRole("BasicUser")) || (!catalogueContributionPermission && (!await this.resourceService.UserHasPublishedResourcesAsync())))
             {
                 return this.RedirectToAction("AccessDenied", "Home");
             }

--- a/LearningHub.Nhs.WebUI/Controllers/ContributeController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/ContributeController.cs
@@ -28,6 +28,7 @@
         private readonly IFileService fileService;
         private readonly IResourceService resourceService;
         private readonly IUserService userService;
+        private readonly IUserGroupService userGroupService;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ContributeController"/> class.
@@ -37,6 +38,7 @@
         /// <param name="logger">Logger.</param>
         /// <param name="settings">Settings.</param>
         /// <param name="userService">User service.</param>
+        /// <param name="userGroupService"> userGroupService.</param>
         /// <param name="fileService">File service.</param>
         /// <param name="resourceService">Resource service.</param>
         /// <param name="azureMediaService">Azure media service.</param>
@@ -48,6 +50,7 @@
             ILogger<ContributeController> logger,
             IOptions<Settings> settings,
             IUserService userService,
+            IUserGroupService userGroupService,
             IFileService fileService,
             IResourceService resourceService,
             IAzureMediaService azureMediaService,
@@ -58,6 +61,7 @@
             this.authConfig = authConfig;
 
             this.userService = userService;
+            this.userGroupService = userGroupService;
             this.fileService = fileService;
             this.resourceService = resourceService;
             this.azureMediaService = azureMediaService;
@@ -167,7 +171,8 @@
         [Route("my-contributions/{selectedTab}/{catalogueId}/{nodeId}")]
         public async Task<IActionResult> MyContributions()
         {
-            if ((this.User.IsInRole("ReadOnly") || this.User.IsInRole("BasicUser")) && !await this.resourceService.UserHasPublishedResourcesAsync())
+            bool usergroup = await this.userGroupService.UserHasCatalogueContributionPermission();
+            if ((this.User.IsInRole("ReadOnly") || this.User.IsInRole("BasicUser")) || (!usergroup && (!await this.resourceService.UserHasPublishedResourcesAsync())))
             {
                 return this.RedirectToAction("AccessDenied", "Home");
             }


### PR DESCRIPTION
### JIRA link
TD-5727
### Description
_-Fix for Full user who is not a catalogue editor/admin can access My contribution page by navigating to the link directly

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [X] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [X] Confirmed that none of the work that I have undertaken requires any updates to documentation