### PR TITLE
TD-5836-Article attachment filesize incorrect -ResourseDeatilsPage

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/ContributeController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/ContributeController.cs
@@ -197,8 +197,9 @@
             var file = inputForm.Files[0];
             int.TryParse(inputForm["resourceVersionId"], out int resourceVersionId);
             int.TryParse(inputForm["changeingFileId"], out int existingFileId);
+            int.TryParse(inputForm["fileSize"], out int fileSize);
             var currentUserId = this.User.Identity.GetCurrentUserId();
-            return await this.contributeService.ProcessArticleFileAsync(resourceVersionId, file, existingFileId, currentUserId);
+            return await this.contributeService.ProcessArticleFileAsync(resourceVersionId, file, fileSize, existingFileId, currentUserId);
         }
 
         /// <summary>

--- a/LearningHub.Nhs.WebUI/Interfaces/IContributeService.cs
+++ b/LearningHub.Nhs.WebUI/Interfaces/IContributeService.cs
@@ -87,10 +87,11 @@ namespace LearningHub.Nhs.WebUI.Interfaces
         /// </summary>
         /// <param name="resourceVersionId">Resource version id.</param>
         /// <param name="file">File.</param>
+        /// <param name="fileSize">fileSize.</param>
         /// <param name="changeingFileId">Changing file id.</param>
         /// <param name="currentUserId">Current user id.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        Task<FileUploadResult> ProcessArticleFileAsync(int resourceVersionId, IFormFile file, int changeingFileId, int currentUserId);
+        Task<FileUploadResult> ProcessArticleFileAsync(int resourceVersionId, IFormFile file, int fileSize,int changeingFileId, int currentUserId);
 
         /// <summary>
         /// The ProcessResourceAttachedFileAsync.

--- a/LearningHub.Nhs.WebUI/Services/ContributeService.cs
+++ b/LearningHub.Nhs.WebUI/Services/ContributeService.cs
@@ -382,10 +382,11 @@
         /// </summary>
         /// <param name="resourceVersionId">The resourceVersionId<see cref="int"/>.</param>
         /// <param name="file">The file<see cref="IFormFile"/>.</param>
+        /// <param name="fileSize">The fileSize<see cref="int"/>.</param>
         /// <param name="existingFileId">The existingFileId<see cref="int"/>.</param>
         /// <param name="currentUserId">The currentUserId<see cref="int"/>.</param>
         /// <returns>The <see cref="Task{FileUploadResult}"/>.</returns>
-        public async Task<FileUploadResult> ProcessArticleFileAsync(int resourceVersionId, IFormFile file, int existingFileId, int currentUserId)
+        public async Task<FileUploadResult> ProcessArticleFileAsync(int resourceVersionId, IFormFile file, int fileSize, int existingFileId, int currentUserId)
         {
             var filelocation = string.Empty;
             string extension = Path.GetExtension(file.FileName).Replace(".", string.Empty);
@@ -415,7 +416,7 @@
                 FileTypeId = fileType == null ? 0 : fileType.Id,
                 FileName = file.FileName,
                 FilePath = filelocation,
-                FileSize = (int)(file.Length / 1000),
+                FileSize = (int)(fileSize / 1000),
                 ReplacedFileId = existingFileId,
             });
 
@@ -425,7 +426,7 @@
                 ResourceVersionId = resourceVersionId,
                 FileName = file.FileName,
                 FileTypeId = fileType == null ? 0 : fileType.Id,
-                FileSizeKb = (int)(file.Length / 1000),
+                FileSizeKb = (int)(fileSize / 1000),
                 Invalid = false,
             };
         }


### PR DESCRIPTION
### JIRA link
TD-5836

### Description
fixed the issue of displaying incorrect file size 

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [X] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [X] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [X] Confirmed that none of the work that I have undertaken requires any updates to documentation