### PR TITLE
TD-6101: Login Wizard changes

### DIFF
--- a/LearningHub.Nhs.WebUI/Styles/nhsuk/layout.scss
+++ b/LearningHub.Nhs.WebUI/Styles/nhsuk/layout.scss
@@ -377,7 +377,10 @@ li.autosuggestion-option:last-of-type {
     transform: rotate(180deg);
 }
 
-
+.form-group-wrapper--error {
+    border-left: none !important;
+    padding-left: 0 !important;
+}
 
 /* large desktop */
 @media (min-width: px2rem(990)) {

--- a/LearningHub.Nhs.WebUI/Views/LoginWizard/SecurityQuestionsDetails.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/LoginWizard/SecurityQuestionsDetails.cshtml
@@ -2,15 +2,15 @@
 
 @{
     ViewData["DisableValidation"] = true;
-    ViewData["Title"] = "My Account - Change security question";
+    ViewData["Title"] = "Login Wizard";
     var errorHasOccurred = !ViewData.ModelState.IsValid;
 }
 
 <div class="bg-white">
     <div class="nhsuk-width-container app-width-container">
-        <vc:back-link asp-controller="MyAccount" asp-action="Index" link-text="Go back" />
-
-        <form asp-controller="MyAccount" asp-action="MyAccountSecurityQuestionsDetails" method="get">
+@*         <vc:back-link asp-controller="MyAccount" asp-action="Index" link-text="Go back" /> *@
+        
+        <form asp-controller="LoginWizard" asp-action="UpdateSecurityQuestionPost" asp-route-returnUrl="@ViewData["ReturnUrl"]" method="post">
 
             <partial name="~/Views/MyAccount/_MyAccountSecurityQuestions.cshtml" model="@Model" />
 

--- a/LearningHub.Nhs.WebUI/Views/MyAccount/Index.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/MyAccount/Index.cshtml
@@ -132,7 +132,7 @@
                 {
                     <form asp-controller="MyAccount" asp-action="CheckDetails" method="post">
                         <input name="returnUrl" type="hidden" asp-for="@Context.Request.Query["returnUrl"]" />
-                        <div class="nhsuk-u-padding-bottom-5">
+                        <div class="nhsuk-u-padding-bottom-5 nhsuk-u-padding-top-5">
                             <button class="nhsuk-button" data-module="nhsuk-button" type="submit">
                                 Confirm
                             </button>

--- a/LearningHub.Nhs.WebUI/Views/MyAccount/MyEmployment.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/MyAccount/MyEmployment.cshtml
@@ -30,6 +30,14 @@
                 @await Component.InvokeAsync("SideNav", new { groupTitle = "Account" })
             </div>
             <div class="nhsuk-grid-column-three-quarters">
+                @if (this.ViewBag.CheckDetails == true)
+                {
+                    <div class="nhsuk-inset-text">
+                        <span class="nhsuk-u-visually-hidden">Information: </span>
+                        <p>Please check that your details are up-to-date.</p>
+                    </div>
+                }
+
                 @if (!ViewData.ModelState.IsValid)
                 {
                     <vc:error-summary order-of-property-names="@(new[] { nameof(Model) })" />
@@ -115,7 +123,7 @@
                 {
                     <form asp-controller="MyAccount" asp-action="CheckDetails" method="post">
                         <input name="returnUrl" type="hidden" asp-for="@Context.Request.Query["returnUrl"]" />
-                        <div class="nhsuk-u-padding-bottom-5">
+                        <div class="nhsuk-u-padding-bottom-5 nhsuk-u-padding-top-5">
                             <button class="nhsuk-button" data-module="nhsuk-button" type="submit">
                                 Confirm
                             </button>

--- a/LearningHub.Nhs.WebUI/Views/MyAccount/_MyAccountSecurityQuestions.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/MyAccount/_MyAccountSecurityQuestions.cshtml
@@ -1,0 +1,81 @@
+﻿@model LearningHub.Nhs.WebUI.Models.UserProfile.MyAcountSecurityQuestionsViewModel
+
+@{
+    ViewData["DisableValidation"] = true;
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
+}
+
+<div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-three-quarters nhsuk-u-padding-bottom-5">
+        @if (errorHasOccurred)
+        {
+            <vc:error-summary order-of-property-names="@(new[] { nameof(Model) })" />
+        }
+        <div class="nhsuk-grid-row">
+            <div class="nhsuk-grid-column-full">
+                <div class="nhsuk-caption-l" id="contact-hint">
+                    Set your security questions
+                </div>
+                <h1 class="nhsuk-heading-xl">Choose your security questions</h1>
+            </div>
+        </div>
+        <div class="nhsuk-label nhsuk-u-width-two-thirds nhsuk-u-padding-bottom-3" id="contact-hint">
+            These security questions can be used to help you to sign in if you forget your password. Please be assured that anything you enter on this page is encrypted and will not be visible to anyone, including system administrators.
+        </div>
+        <div class="nhsuk-label nhsuk-padding-top-2" id="contact-hint">
+            <p>Your two security questions must be different from each other.</p>
+        </div>
+        <div class="nhsuk-label nhsuk-padding-top-2" id="contact-hint">
+            <p>We will only use this information to help you sign in to the Learning Hub.</p>
+        </div>
+
+        <div>
+            <vc:select-list asp-for="SelectedFirstQuestionId"
+                            label="Set your first security question"
+                            value="@Model.SelectedFirstQuestionId"
+                            hint-text=""
+                            required="true"
+                            css-class="nhsuk-u-width-two-thirds"
+                            default-option=""
+                            select-list-options="@Model.FirstSecurityQuestions" />
+        </div>
+
+        <div>
+            <vc:text-input asp-for="SecurityFirstQuestionAnswerHash"
+                           label="Enter your answer"
+                           populate-with-current-value="true"
+                           type="password"
+                           spell-check="false"
+                           hint-text=""
+                           autocomplete=""
+                           css-class="nhsuk-u-width-two-thirds"
+                           required="true"
+                           required-client-side-error-message="Enter an answer" />
+            <input type="hidden" name="UserSecurityFirstQuestionId" value="@Model.UserSecurityFirstQuestionId" />
+        </div>
+        <div>
+            <vc:select-list asp-for="SelectedSecondQuestionId"
+                            label="Set your second security question"
+                            value="@Model.SelectedSecondQuestionId"
+                            hint-text=""
+                            required="true"
+                            css-class="nhsuk-u-width-two-thirds"
+                            default-option=""
+                            select-list-options="@Model.SecondSecurityQuestions" />
+        </div>
+
+        <div>
+            <vc:text-input asp-for="SecuritySecondQuestionAnswerHash"
+                           label="Enter your answer"
+                           populate-with-current-value="true"
+                           type="password"
+                           spell-check="false"
+                           hint-text=""
+                           autocomplete=""
+                           css-class="nhsuk-u-width-two-thirds"
+                           required="true"
+                           required-client-side-error-message="Enter an answer" />
+            <input type="hidden" name="UserSecuritySecondQuestionId" value="@Model.UserSecuritySecondQuestionId" />
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
### JIRA link
[TD-6101](https://hee-tis.atlassian.net/browse/TD-6101)

### Description
Updated the login wizard controller, changed the redirection from old my account screens to new my account screens.

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-6101]: https://hee-tis.atlassian.net/browse/TD-6101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ