### PR TITLE
TD-5765 null check for activity start and end date

### DIFF
--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Resources/GetUsercertificateDetails.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Resources/GetUsercertificateDetails.sql
@@ -86,7 +86,7 @@ BEGIN
         ) AS ResourceReferenceID,
         rv.MajorVersion,
         rv.MinorVersion,
-        ra.ActivityStart AS AwardedDate,
+        COALESCE(ra.ActivityEnd, ra.ActivityStart) AS AwardedDate,
 		NULL AS CertificateDownloadUrl,
 		NULL AS CertificatePreviewUrl
     FROM #MyActivity ma


### PR DESCRIPTION
### JIRA link
TD-5765

### Description
update  to always use activity end date but where such is null as we have in some resource type(e.g article), use activity start date.

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation