### PR TITLE
TD-6147: Fixed issue with the wording of the headings on the 'My account - Notifications' screen

### DIFF
--- a/LearningHub.Nhs.WebUI/Models/SideMenu/SideNavigationConfiguration.cs
+++ b/LearningHub.Nhs.WebUI/Models/SideMenu/SideNavigationConfiguration.cs
@@ -46,7 +46,7 @@
                     },
                     new SideNavigationItem
                     {
-                        Text = "Notification",
+                        Text = "Notifications",
                         Controller = "Notification",
                         Action = "Index",
                         IsActive = route => MatchRoute(route, "Notification", "Index"),

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/notification/notifications.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/notification/notifications.vue
@@ -1,7 +1,7 @@
 <template>
         <div class="notifications-panel lh-container-xl">
             <div :class="[showMessage ? 'd-none' : 'd-block']">
-                <h2 class="nhsuk-heading-l nhsuk-u-padding-bottom-5">System notifications</h2>
+                <h2 class="nhsuk-heading-l nhsuk-u-padding-bottom-5">Notifications</h2>
                 <notification ref="priorityNotification"
                               :priorityType="this.NotificationPriority.Priority"
                               :showContent="this.showPriorityContent"

--- a/LearningHub.Nhs.WebUI/Views/Notification/Index.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Notification/Index.cshtml
@@ -1,5 +1,5 @@
 ﻿@{
-    ViewData["Title"] = "System notifications";
+    ViewData["Title"] = "Notifications";
 }
 @section NavBreadcrumbs {
 


### PR DESCRIPTION

### JIRA link
[TD-6147](https://hee-tis.atlassian.net/browse/TD-6147)

### Description
Fixed issue with the wording of the headings on the 'My account - Notifications' screen

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-6147]: https://hee-tis.atlassian.net/browse/TD-6147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ