### PR TITLE
TD-6138: Fixed issues on security tab on my account and added user icon.

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/LoginWizardController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/LoginWizardController.cs
@@ -616,13 +616,9 @@
                     this.ModelState.AddModelError("DuplicateQuestion", CommonValidationErrorMessages.DuplicateQuestion);
                 }
 
-                if (model.SelectedFirstQuestionId > 0 && string.IsNullOrEmpty(model.SecurityFirstQuestionAnswerHash))
+                if ((model.SelectedFirstQuestionId > 0 && string.IsNullOrEmpty(model.SecurityFirstQuestionAnswerHash)) || (model.SelectedSecondQuestionId > 0 && string.IsNullOrEmpty(model.SecuritySecondQuestionAnswerHash)))
                 {
                     this.ModelState.AddModelError(nameof(model.SecurityFirstQuestionAnswerHash), CommonValidationErrorMessages.InvalidSecurityQuestionAnswer);
-                }
-
-                if (model.SelectedSecondQuestionId > 0 && string.IsNullOrEmpty(model.SecuritySecondQuestionAnswerHash))
-                {
                     this.ModelState.AddModelError(nameof(model.SecuritySecondQuestionAnswerHash), CommonValidationErrorMessages.InvalidSecurityQuestionAnswer);
                 }
 

--- a/LearningHub.Nhs.WebUI/Controllers/MyAccountController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/MyAccountController.cs
@@ -366,14 +366,9 @@
                     return this.View("MyAccountSecurityQuestionsDetails", securityViewModel);
                 }
 
-                if (viewModel.SelectedFirstQuestionId > 0 && string.IsNullOrEmpty(viewModel.SecurityFirstQuestionAnswerHash))
+                if ((viewModel.SelectedFirstQuestionId > 0 && string.IsNullOrEmpty(viewModel.SecurityFirstQuestionAnswerHash)) || (viewModel.SelectedSecondQuestionId > 0 && string.IsNullOrEmpty(viewModel.SecuritySecondQuestionAnswerHash)))
                 {
                     this.ModelState.AddModelError(nameof(viewModel.SecurityFirstQuestionAnswerHash), CommonValidationErrorMessages.InvalidSecurityQuestionAnswer);
-                    return this.View("MyAccountSecurityQuestionsDetails", securityViewModel);
-                }
-
-                if (viewModel.SelectedSecondQuestionId > 0 && string.IsNullOrEmpty(viewModel.SecuritySecondQuestionAnswerHash))
-                {
                     this.ModelState.AddModelError(nameof(viewModel.SecuritySecondQuestionAnswerHash), CommonValidationErrorMessages.InvalidSecurityQuestionAnswer);
                     return this.View("MyAccountSecurityQuestionsDetails", securityViewModel);
                 }

--- a/LearningHub.Nhs.WebUI/Styles/nhsuk/layout.scss
+++ b/LearningHub.Nhs.WebUI/Styles/nhsuk/layout.scss
@@ -108,8 +108,8 @@ body {
 
 .nhsuk-header__notification-dot {
     position: absolute;
-    top: px2rem(-8);
-    right: px2rem(86);
+    top: px2rem(8);
+    right: px2rem(-10);
     font-size: px2rem(11);
     line-height: px2rem(18);
     font-weight: 900;

--- a/LearningHub.Nhs.WebUI/Styles/nhsuk/layout.scss
+++ b/LearningHub.Nhs.WebUI/Styles/nhsuk/layout.scss
@@ -96,10 +96,20 @@ body {
     gap: px2rem(24);
 }
 
+.nhsuk-account__myaccount {
+    float: right;
+    position: relative;
+    z-index: 2;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: px2rem(8);
+}
+
 .nhsuk-header__notification-dot {
     position: absolute;
-    top: px2rem(8);
-    right: px2rem(-10);
+    top: px2rem(-8);
+    right: px2rem(86);
     font-size: px2rem(11);
     line-height: px2rem(18);
     font-weight: 900;

--- a/LearningHub.Nhs.WebUI/Styles/nhsuk/nhsuk-overrides.scss
+++ b/LearningHub.Nhs.WebUI/Styles/nhsuk/nhsuk-overrides.scss
@@ -239,8 +239,8 @@ form label.nhsuk-u-visually-hidden {
 
 .nhsuk-header__notification-dot {
     position: absolute;
-    top: px2rem(8);
-    right: px2rem(-10);
+    top: px2rem(-8);
+    right: px2rem(76);
     font-size: px2rem(11);
     line-height: px2rem(18);
     font-weight: 900;
@@ -453,8 +453,8 @@ form label.nhsuk-u-visually-hidden {
 
     .nhsuk-header__notification-dot {
         position: absolute;
-        top: px2rem(15);
-        left: px2rem(115);
+        top: px2rem(-8);
+        left: px2rem(16);
         font-size: px2rem(11);
         line-height: px2rem(18);
         font-weight: 900;

--- a/LearningHub.Nhs.WebUI/Views/MyAccount/ChangePassword.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/MyAccount/ChangePassword.cshtml
@@ -7,7 +7,7 @@
 }
 <div class="bg-white">
   <div class="nhsuk-width-container app-width-container">
-    <vc:back-link asp-controller="MyAccount" asp-action="Index" link-text="Go back" />
+        <vc:back-link asp-controller="MyAccount" asp-action="MyAccountSecurity" link-text="Go back" />
     <form asp-controller="MyAccount" asp-action="UpdatePassword" method="post">
       <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-three-quarters nhsuk-u-padding-bottom-5">

--- a/LearningHub.Nhs.WebUI/Views/MyAccount/ConfirmPassword.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/MyAccount/ConfirmPassword.cshtml
@@ -8,7 +8,7 @@
 
 <div class="bg-white">
   <div class="nhsuk-width-container app-width-container">
-    <vc:back-link asp-controller="MyAccount" asp-action="Index" link-text="Go back" />
+        <vc:back-link asp-controller="MyAccount" asp-action="MyAccountSecurity" link-text="Go back" />
     <form asp-controller="MyAccount" asp-action="ChangePassword" method="post">
       <div class="nhsuk-grid-row">
         <div class="nhsuk-grid-column-three-quarters nhsuk-u-padding-bottom-5">

--- a/LearningHub.Nhs.WebUI/Views/MyAccount/MyAccountSecurityQuestionsDetails.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/MyAccount/MyAccountSecurityQuestionsDetails.cshtml
@@ -8,7 +8,7 @@
 
 <div class="bg-white">
     <div class="nhsuk-width-container app-width-container">
-        <vc:back-link asp-controller="MyAccount" asp-action="Index" link-text="Go back" />
+        <vc:back-link asp-controller="MyAccount" asp-action="MyAccountSecurity" link-text="Go back" />
 
         <form asp-controller="MyAccount" asp-action="MyAccountSecurityQuestionsDetails" method="get">
 

--- a/LearningHub.Nhs.WebUI/Views/Shared/Components/NavigationItems/Topnav.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Shared/Components/NavigationItems/Topnav.cshtml
@@ -8,7 +8,27 @@
 <!-- start Topnav -->
 @if (Model.ShowMyAccount)
 {
+    <div class="nhsuk-account__myaccount">
+        <svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 26 26" fill="none">
+            <g clip-path="url(#clip0_5102_1890)">
+                <path d="M12.9984 14.7859C10.4797 14.7859 8.36719 12.7547 8.36719 10.1547C8.36719 7.55469 10.3984 5.52344 12.9984 5.52344C15.5172 5.52344 17.6297 7.55469 17.6297 10.1547C17.6297 12.7547 15.5172 14.7859 12.9984 14.7859Z" fill="white" />
+                <path d="M13 0C5.85 0 0 5.85 0 13C0 20.15 5.85 26 13 26C20.15 26 26 20.15 26 13C26 5.85 20.15 0 13 0ZM19.5813 22.3438V21.125C19.5813 18.2812 17.55 16.0063 14.95 16.0063H11.05C8.53125 15.925 6.5 18.2812 6.5 21.125V22.425C1.3 18.7688 0 11.6188 3.65625 6.5C7.3125 1.38125 14.3812 0 19.5 3.65625C24.6187 7.3125 26 14.3812 22.3438 19.5C21.6125 20.6375 20.6375 21.6125 19.5813 22.3438Z" fill="white" />
+            </g>
+            <defs>
+                <clipPath id="clip0_5102_1890">
+                    <rect width="26" height="26" fill="white" />
+                </clipPath>
+            </defs>
+        </svg>
+        @if (Model.NotificationCount > 0)
+        {
+            <div class="nhsuk-header__notification-dot">@NotificationDisplay()</div>
+
+        }
+    
+   
     <a class="nhsuk-account__login--link" asp-controller="Myaccount" asp-action="Index">My account</a>
+    </div>
 }
 @if (Model.ShowSignOut)
 {
@@ -20,3 +40,22 @@
 } *@
 
 <!-- end Topnav -->
+@functions {
+    public string NotificationDisplay()
+    {
+        if (Model.NotificationCount < 1)
+        {
+            return "";
+        }
+
+        var returnString = Model.NotificationCount.ToString();
+
+        if (Model.NotificationCount > 9)
+        {
+            returnString = "9+";
+        }
+
+        return returnString;
+
+    }
+}


### PR DESCRIPTION
### JIRA link
[TD-6138](https://hee-tis.atlassian.net/browse/TD-6138)

### Description
TD-6138: Fixed issue son security tab on my account and added user icon.

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-6138]: https://hee-tis.atlassian.net/browse/TD-6138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ