### PR TITLE
TD-6213 make certificate available for informal certificate without passmark condition

### DIFF
--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Resources/GetUsercertificateDetails.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Resources/GetUsercertificateDetails.sql
@@ -54,17 +54,25 @@ BEGIN
                 )
                 OR ra.ActivityStatusId IN (3,5)
             ))
-         OR (r.ResourceTypeId = 11 AND (
+        OR (
+            r.ResourceTypeId = 11
+            AND (
+                -- Either passed by score, or completed with no pass mark
                 EXISTS (
                     SELECT 1
                     FROM activity.AssessmentResourceActivity ara
                     JOIN resources.AssessmentResourceVersion arv
                       ON arv.ResourceVersionId = ra.ResourceVersionId
                     WHERE ara.ResourceActivityId = ra.Id
-                      AND ara.Score >= arv.PassMark
+                      AND (
+                             ara.Score >= arv.PassMark -- formal assessment
+                          OR (ra.ActivityStatusId = 3 AND arv.AssessmentType = 1) --informal assessment
+                      )
                 )
-                OR ra.ActivityStatusId IN (3,5)
-            ))
+                -- Or explicitly marked as passed
+                OR ra.ActivityStatusId = 5
+            )
+        )
          OR (r.ResourceTypeId IN (1, 5, 8, 9, 10, 12) 
              AND ra.ActivityStatusId = 3)
           )


### PR DESCRIPTION

### JIRA link
[TD-6213 ](https://hee-tis.atlassian.net/browse/TD-6213)

### Description
make certificate available for informal certificate once status is completed and ignore if user pass or fail or pass mark of assessment

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation