### PR TITLE
TD-6228: Fixed headings issue on Activity report

### DIFF
--- a/LearningHub.Nhs.WebUI/Views/MyLearning/DownloadActivityRecords.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/MyLearning/DownloadActivityRecords.cshtml
@@ -37,1022 +37,1022 @@
         /*! CSS Used from: Embedded */
 
         html {
-        font-family: sans-serif;
-        line-height: 1.15;
-        -webkit-text-size-adjust: 100%;
-        -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-        -webkit-print-color-adjust: exact;
-        zoom: 0.68;
+            font-family: sans-serif;
+            line-height: 1.15;
+            -webkit-text-size-adjust: 100%;
+            -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+            -webkit-print-color-adjust: exact;
+            zoom: 0.68;
         }
 
         .nhs-progress-container {
-        display: flex;
-        height: 10px;
-        overflow: hidden;
-        line-height: 0;
-        font-size: 0.75rem;
-        background-color: #e9ecef;
-        border-radius: 0.25rem;
+            display: flex;
+            height: 10px;
+            overflow: hidden;
+            line-height: 0;
+            font-size: 0.75rem;
+            background-color: #e9ecef;
+            border-radius: 0.25rem;
         }
 
         .nhs-progress-bar {
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        overflow: hidden;
-        color: #fff;
-        text-align: center;
-        white-space: nowrap;
-        background-color: #007f3b;
-        transition: width .6s ease;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            overflow: hidden;
+            color: #fff;
+            text-align: center;
+            white-space: nowrap;
+            background-color: #007f3b;
+            transition: width .6s ease;
         }
 
         .nhsuk-hero {
-        background-color: #005eb8;
-        color: #fff;
-        position: relative;
+            background-color: #005eb8;
+            color: #fff;
+            position: relative;
         }
 
         .nhs-item-row {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
         }
 
         table {
-        border-collapse: collapse;
+            border-collapse: collapse;
         }
 
         th {
-        text-align: inherit;
-        text-align: -webkit-match-parent;
+            text-align: inherit;
+            text-align: -webkit-match-parent;
         }
 
         h2 {
-        margin-bottom: 0.5rem;
-        font-weight: 500;
-        line-height: 1.2;
+            margin-bottom: 0.5rem;
+            font-weight: 500;
+            line-height: 1.2;
         }
 
         h2 {
-        font-size: 2rem;
+            font-size: 2rem;
         }
 
         .align-items-center {
-        align-items: center !important;
+            align-items: center !important;
         }
 
         a {
-        text-decoration: underline;
-        color: #005eb8;
+            text-decoration: underline;
+            color: #005eb8;
         }
 
         h2 {
-        font-family: Frutiger W01, Arial, Sans-serif;
+            font-family: Frutiger W01, Arial, Sans-serif;
         }
 
         html {
-        -moz-box-sizing: border-box;
-        -webkit-box-sizing: border-box;
-        box-sizing: border-box;
+            -moz-box-sizing: border-box;
+            -webkit-box-sizing: border-box;
+            box-sizing: border-box;
         }
 
 
         table {
-        margin-bottom: 40px;
-        border-spacing: 0;
-        vertical-align: top;
-        width: 100%;
+            margin-bottom: 40px;
+            border-spacing: 0;
+            vertical-align: top;
+            width: 100%;
         }
 
 
         thead th {
-        border-bottom: 2px solid #d8dde0;
+            border-bottom: 2px solid #d8dde0;
         }
 
         th,
         td {
-        font-size: 16px;
-        font-size: 1rem;
-        line-height: 1.5;
-        padding-bottom: 8px;
-        padding-right: 16px;
-        padding-top: 8px;
-        border-bottom: 1px solid #d8dde0;
-        text-align: left;
-        vertical-align: top;
+            font-size: 16px;
+            font-size: 1rem;
+            line-height: 1.5;
+            padding-bottom: 8px;
+            padding-right: 16px;
+            padding-top: 8px;
+            border-bottom: 1px solid #d8dde0;
+            text-align: left;
+            vertical-align: top;
         }
 
         @@media (min-width: 40.0625em) {
-        th,
-        td {
-        font-size: 19px;
-        font-size: 1.1875rem;
-        line-height: 1.47368;
-        }
+            th,
+            td {
+                font-size: 19px;
+                font-size: 1.1875rem;
+                line-height: 1.47368;
+            }
         }
 
         @@media print {
-        th,
-        td {
-        font-size: 14pt;
-        line-height: 1.15;
-        }
-        }
-
-        @@media (min-width: 40.0625em) {
-        th,
-        td {
-        padding-bottom: 16px;
-        }
+            th,
+            td {
+                font-size: 14pt;
+                line-height: 1.15;
+            }
         }
 
         @@media (min-width: 40.0625em) {
-        th,
-        td {
-        padding-right: 24px;
-        }
+            th,
+            td {
+                padding-bottom: 16px;
+            }
         }
 
         @@media (min-width: 40.0625em) {
-        th,
-        td {
-        padding-top: 16px;
+            th,
+            td {
+                padding-right: 24px;
+            }
         }
+
+        @@media (min-width: 40.0625em) {
+            th,
+            td {
+                padding-top: 16px;
+            }
         }
 
         th:last-child,
         td:last-child {
-        padding-right: 0;
+            padding-right: 0;
         }
 
         th {
-        font-weight: 600;
+            font-weight: 600;
         }
 
 
         .nhsuk-grid-column-full {
-        box-sizing: border-box;
-        padding: 0 16px;
+            box-sizing: border-box;
+            padding: 0 16px;
         }
 
         @@media (min-width: 48.0625em) {
-        .nhsuk-grid-column-full {
-        float: left;
-        width: 100%;
-        }
+            .nhsuk-grid-column-full {
+                float: left;
+                width: 100%;
+            }
         }
 
         .nhsuk-width-container {
-        margin: 0 16px;
-        max-width: 960px;
+            margin: 0 16px;
+            max-width: 960px;
         }
 
         @@media (min-width: 48.0625em) {
-        .nhsuk-width-container {
-        margin: 0 32px;
-        }
+            .nhsuk-width-container {
+                margin: 0 32px;
+            }
         }
 
         @@media (min-width: 1024px) {
-        .nhsuk-width-container {
-        margin: 0 auto;
-        }
+            .nhsuk-width-container {
+                margin: 0 auto;
+            }
         }
 
 
         h2 {
-        font-size: 24px;
-        font-size: 1.5rem;
-        line-height: 1.33333;
-        display: block;
-        font-weight: 600;
-        margin-top: 0;
-        margin-bottom: 16px;
+            font-size: 24px;
+            font-size: 1.5rem;
+            line-height: 1.33333;
+            display: block;
+            font-weight: 600;
+            margin-top: 0;
+            margin-bottom: 16px;
         }
 
         @@media (min-width: 40.0625em) {
-        h2 {
-        font-size: 32px;
-        font-size: 2rem;
-        line-height: 1.25;
-        }
+            h2 {
+                font-size: 32px;
+                font-size: 2rem;
+                line-height: 1.25;
+            }
         }
 
 
         .nhsuk-body-l {
-        font-size: 20px;
-        font-size: 1.25rem;
-        line-height: 1.4;
-        display: block;
-        margin-top: 0;
-        margin-bottom: 24px;
+            font-size: 20px;
+            font-size: 1.25rem;
+            line-height: 1.4;
+            display: block;
+            margin-top: 0;
+            margin-bottom: 24px;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-body-l {
-        font-size: 24px;
-        font-size: 1.5rem;
-        line-height: 1.33333;
-        }
+            .nhsuk-body-l {
+                font-size: 24px;
+                font-size: 1.5rem;
+                line-height: 1.33333;
+            }
         }
 
         @@media print {
-        .nhsuk-body-l {
-        font-size: 18pt;
-        line-height: 1.15;
-        }
+            .nhsuk-body-l {
+                font-size: 18pt;
+                line-height: 1.15;
+            }
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-body-l {
-        margin-bottom: 32px;
-        }
+            .nhsuk-body-l {
+                margin-bottom: 32px;
+            }
         }
 
         p,
         .nhsuk-body-m {
-        font-size: 16px;
-        font-size: 1rem;
-        line-height: 1.5;
-        display: block;
-        margin-top: 0;
-        margin-bottom: 16px;
+            font-size: 16px;
+            font-size: 1rem;
+            line-height: 1.5;
+            display: block;
+            margin-top: 0;
+            margin-bottom: 16px;
         }
 
         @@media (min-width: 40.0625em) {
-        p,
-        .nhsuk-body-m {
-        font-size: 19px;
-        font-size: 1.1875rem;
-        line-height: 1.47368;
-        }
+            p,
+            .nhsuk-body-m {
+                font-size: 19px;
+                font-size: 1.1875rem;
+                line-height: 1.47368;
+            }
         }
 
         @@media print {
-        p,
-        .nhsuk-body-m {
-        font-size: 14pt;
-        line-height: 1.15;
-        }
-        }
-
-        @@media (min-width: 40.0625em) {
-        p,
-        .nhsuk-body-m {
-        margin-bottom: 24px;
-        }
-        }
-
-        p,
-        .nhsuk-body-m {
-        color: inherit;
-        }
-
-        .nhsuk-body-s {
-        font-size: 14px;
-        font-size: 0.875rem;
-        line-height: 1.71429;
-        display: block;
-        margin-top: 0;
-        margin-bottom: 16px;
+            p,
+            .nhsuk-body-m {
+                font-size: 14pt;
+                line-height: 1.15;
+            }
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-body-s {
-        font-size: 16px;
-        font-size: 1rem;
-        line-height: 1.5;
+            p,
+            .nhsuk-body-m {
+                margin-bottom: 24px;
+            }
         }
+
+        p,
+        .nhsuk-body-m {
+            color: inherit;
+        }
+
+        .nhsuk-body-s {
+            font-size: 14px;
+            font-size: 0.875rem;
+            line-height: 1.71429;
+            display: block;
+            margin-top: 0;
+            margin-bottom: 16px;
+        }
+
+        @@media (min-width: 40.0625em) {
+            .nhsuk-body-s {
+                font-size: 16px;
+                font-size: 1rem;
+                line-height: 1.5;
+            }
         }
 
         @@media print {
-        .nhsuk-body-s {
-        font-size: 14pt;
-        line-height: 1.2;
-        }
+            .nhsuk-body-s {
+                font-size: 14pt;
+                line-height: 1.2;
+            }
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-body-s {
-        margin-bottom: 24px;
-        }
+            .nhsuk-body-s {
+                margin-bottom: 24px;
+            }
         }
 
         .nhsuk-body-l + h2 {
-        padding-top: 4px;
+            padding-top: 4px;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-body-l + h2 {
-        padding-top: 8px;
-        }
+            .nhsuk-body-l + h2 {
+                padding-top: 8px;
+            }
         }
 
         p + h2 {
-        padding-top: 16px;
+            padding-top: 16px;
         }
 
         @@media (min-width: 40.0625em) {
-        p + h2 {
-        padding-top: 24px;
-        }
+            p + h2 {
+                padding-top: 24px;
+            }
         }
 
         b {
-        font-weight: 600;
+            font-weight: 600;
         }
 
         .nhsuk-u-margin-bottom-0 {
-        margin-bottom: 0 !important;
+            margin-bottom: 0 !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-margin-bottom-0 {
-        margin-bottom: 0 !important;
-        }
+            .nhsuk-u-margin-bottom-0 {
+                margin-bottom: 0 !important;
+            }
         }
 
         .nhsuk-u-margin-bottom-3 {
-        margin-bottom: 8px !important;
+            margin-bottom: 8px !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-margin-bottom-3 {
-        margin-bottom: 16px !important;
-        }
+            .nhsuk-u-margin-bottom-3 {
+                margin-bottom: 16px !important;
+            }
         }
 
         .nhsuk-u-margin-top-7 {
-        margin-top: 40px !important;
+            margin-top: 40px !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-margin-top-7 {
-        margin-top: 48px !important;
-        }
+            .nhsuk-u-margin-top-7 {
+                margin-top: 48px !important;
+            }
         }
 
         .nhsuk-u-margin-bottom-7 {
-        margin-bottom: 40px !important;
+            margin-bottom: 40px !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-margin-bottom-7 {
-        margin-bottom: 48px !important;
-        }
+            .nhsuk-u-margin-bottom-7 {
+                margin-bottom: 48px !important;
+            }
         }
 
         .nhsuk-u-margin-bottom-9 {
-        margin-bottom: 56px !important;
+            margin-bottom: 56px !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-margin-bottom-9 {
-        margin-bottom: 64px !important;
-        }
+            .nhsuk-u-margin-bottom-9 {
+                margin-bottom: 64px !important;
+            }
         }
 
         .nhsuk-u-padding-top-1 {
-        padding-top: 4px !important;
+            padding-top: 4px !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-padding-top-1 {
-        padding-top: 4px !important;
-        }
+            .nhsuk-u-padding-top-1 {
+                padding-top: 4px !important;
+            }
         }
 
         .nhsuk-u-padding-bottom-1 {
-        padding-bottom: 4px !important;
+            padding-bottom: 4px !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-padding-bottom-1 {
-        padding-bottom: 4px !important;
-        }
+            .nhsuk-u-padding-bottom-1 {
+                padding-bottom: 4px !important;
+            }
         }
 
         .nhsuk-u-padding-top-2 {
-        padding-top: 8px !important;
+            padding-top: 8px !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-padding-top-2 {
-        padding-top: 8px !important;
-        }
+            .nhsuk-u-padding-top-2 {
+                padding-top: 8px !important;
+            }
         }
 
         .nhsuk-u-padding-right-2 {
-        padding-right: 8px !important;
+            padding-right: 8px !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-padding-right-2 {
-        padding-right: 8px !important;
-        }
+            .nhsuk-u-padding-right-2 {
+                padding-right: 8px !important;
+            }
         }
 
         .nhsuk-u-padding-bottom-2 {
-        padding-bottom: 8px !important;
+            padding-bottom: 8px !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-padding-bottom-2 {
-        padding-bottom: 8px !important;
-        }
+            .nhsuk-u-padding-bottom-2 {
+                padding-bottom: 8px !important;
+            }
         }
 
         .nhsuk-u-padding-left-2 {
-        padding-left: 8px !important;
+            padding-left: 8px !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-padding-left-2 {
-        padding-left: 8px !important;
-        }
+            .nhsuk-u-padding-left-2 {
+                padding-left: 8px !important;
+            }
         }
 
         .nhsuk-u-padding-3 {
-        padding: 8px !important;
+            padding: 8px !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-padding-3 {
-        padding: 16px !important;
-        }
+            .nhsuk-u-padding-3 {
+                padding: 16px !important;
+            }
         }
 
         .nhsuk-u-padding-top-3 {
-        padding-top: 8px !important;
+            padding-top: 8px !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-padding-top-3 {
-        padding-top: 16px !important;
-        }
+            .nhsuk-u-padding-top-3 {
+                padding-top: 16px !important;
+            }
         }
 
         .nhsuk-u-padding-right-3 {
-        padding-right: 8px !important;
+            padding-right: 8px !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-padding-right-3 {
-        padding-right: 16px !important;
-        }
+            .nhsuk-u-padding-right-3 {
+                padding-right: 16px !important;
+            }
         }
 
         .nhsuk-u-padding-bottom-3 {
-        padding-bottom: 8px !important;
+            padding-bottom: 8px !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-padding-bottom-3 {
-        padding-bottom: 16px !important;
-        }
+            .nhsuk-u-padding-bottom-3 {
+                padding-bottom: 16px !important;
+            }
         }
 
         .nhsuk-u-padding-left-3 {
-        padding-left: 8px !important;
+            padding-left: 8px !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-padding-left-3 {
-        padding-left: 16px !important;
-        }
+            .nhsuk-u-padding-left-3 {
+                padding-left: 16px !important;
+            }
         }
 
         .nhsuk-u-padding-top-4 {
-        padding-top: 16px !important;
+            padding-top: 16px !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-padding-top-4 {
-        padding-top: 24px !important;
-        }
+            .nhsuk-u-padding-top-4 {
+                padding-top: 24px !important;
+            }
         }
 
         .nhsuk-u-padding-bottom-4 {
-        padding-bottom: 16px !important;
+            padding-bottom: 16px !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-padding-bottom-4 {
-        padding-bottom: 24px !important;
-        }
+            .nhsuk-u-padding-bottom-4 {
+                padding-bottom: 24px !important;
+            }
         }
 
         .nhsuk-u-padding-right-5 {
-        padding-right: 24px !important;
+            padding-right: 24px !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-padding-right-5 {
-        padding-right: 32px !important;
-        }
+            .nhsuk-u-padding-right-5 {
+                padding-right: 32px !important;
+            }
         }
 
         .nhsuk-u-padding-left-5 {
-        padding-left: 24px !important;
+            padding-left: 24px !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-padding-left-5 {
-        padding-left: 32px !important;
-        }
+            .nhsuk-u-padding-left-5 {
+                padding-left: 32px !important;
+            }
         }
 
         .nhsuk-u-padding-top-9 {
-        padding-top: 56px !important;
+            padding-top: 56px !important;
         }
 
         .nhsuk-u-padding-bottom-9 {
-        padding-bottom: 56px !important;
+            padding-bottom: 56px !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-padding-bottom-9 {
-        padding-bottom: 64px !important;
-        }
+            .nhsuk-u-padding-bottom-9 {
+                padding-bottom: 64px !important;
+            }
         }
 
         .nhsuk-u-text-align-right {
-        text-align: right !important;
+            text-align: right !important;
         }
 
         .nhsuk-u-font-size-32 {
-        font-size: 24px !important;
-        font-size: 1.5rem !important;
-        line-height: 1.33333 !important;
+            font-size: 24px !important;
+            font-size: 1.5rem !important;
+            line-height: 1.33333 !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-font-size-32 {
-        font-size: 32px !important;
-        font-size: 2rem !important;
-        line-height: 1.25 !important;
-        }
+            .nhsuk-u-font-size-32 {
+                font-size: 32px !important;
+                font-size: 2rem !important;
+                line-height: 1.25 !important;
+            }
         }
 
         @@media print {
-        .nhsuk-u-font-size-32 {
-        font-size: 24pt !important;
-        line-height: 1.05 !important;
-        }
+            .nhsuk-u-font-size-32 {
+                font-size: 24pt !important;
+                line-height: 1.05 !important;
+            }
         }
 
         .nhsuk-u-font-size-24 {
-        font-size: 20px !important;
-        font-size: 1.25rem !important;
-        line-height: 1.4 !important;
+            font-size: 20px !important;
+            font-size: 1.25rem !important;
+            line-height: 1.4 !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-font-size-24 {
-        font-size: 24px !important;
-        font-size: 1.5rem !important;
-        line-height: 1.33333 !important;
-        }
+            .nhsuk-u-font-size-24 {
+                font-size: 24px !important;
+                font-size: 1.5rem !important;
+                line-height: 1.33333 !important;
+            }
         }
 
         @@media print {
-        .nhsuk-u-font-size-24 {
-        font-size: 18pt !important;
-        line-height: 1.15 !important;
-        }
+            .nhsuk-u-font-size-24 {
+                font-size: 18pt !important;
+                line-height: 1.15 !important;
+            }
         }
 
         .nhsuk-u-font-size-19 {
-        font-size: 16px !important;
-        font-size: 1rem !important;
-        line-height: 1.5 !important;
+            font-size: 16px !important;
+            font-size: 1rem !important;
+            line-height: 1.5 !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-font-size-19 {
-        font-size: 19px !important;
-        font-size: 1.1875rem !important;
-        line-height: 1.47368 !important;
-        }
+            .nhsuk-u-font-size-19 {
+                font-size: 19px !important;
+                font-size: 1.1875rem !important;
+                line-height: 1.47368 !important;
+            }
         }
 
         @@media print {
-        .nhsuk-u-font-size-19 {
-        font-size: 14pt !important;
-        line-height: 1.15 !important;
-        }
+            .nhsuk-u-font-size-19 {
+                font-size: 14pt !important;
+                line-height: 1.15 !important;
+            }
         }
 
         .nhsuk-u-font-size-16 {
-        font-size: 14px !important;
-        font-size: 0.875rem !important;
-        line-height: 1.71429 !important;
+            font-size: 14px !important;
+            font-size: 0.875rem !important;
+            line-height: 1.71429 !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-font-size-16 {
-        font-size: 16px !important;
-        font-size: 1rem !important;
-        line-height: 1.5 !important;
-        }
+            .nhsuk-u-font-size-16 {
+                font-size: 16px !important;
+                font-size: 1rem !important;
+                line-height: 1.5 !important;
+            }
         }
 
         @@media print {
-        .nhsuk-u-font-size-16 {
-        font-size: 14pt !important;
-        line-height: 1.2 !important;
-        }
+            .nhsuk-u-font-size-16 {
+                font-size: 14pt !important;
+                line-height: 1.2 !important;
+            }
         }
 
         .nhsuk-u-font-size-14 {
-        font-size: 12px !important;
-        font-size: 0.75rem !important;
-        line-height: 1.66667 !important;
+            font-size: 12px !important;
+            font-size: 0.75rem !important;
+            line-height: 1.66667 !important;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-u-font-size-14 {
-        font-size: 14px !important;
-        font-size: 0.875rem !important;
-        line-height: 1.71429 !important;
-        }
+            .nhsuk-u-font-size-14 {
+                font-size: 14px !important;
+                font-size: 0.875rem !important;
+                line-height: 1.71429 !important;
+            }
         }
 
         @@media print {
-        .nhsuk-u-font-size-14 {
-        font-size: 12pt !important;
-        line-height: 1.2 !important;
-        }
+            .nhsuk-u-font-size-14 {
+                font-size: 12pt !important;
+                line-height: 1.2 !important;
+            }
         }
 
         .nhsuk-header__logo {
-        float: left;
+            float: left;
         }
 
         @@media (max-width: 40.0525em) {
-        .nhsuk-header__logo {
-        position: relative;
-        z-index: 1;
-        }
+            .nhsuk-header__logo {
+                position: relative;
+                z-index: 1;
+            }
         }
 
         .nhsuk-header__logo .nhsuk-logo__background {
-        fill: #fff;
+            fill: #fff;
         }
 
         .nhsuk-header__logo .nhsuk-logo__text {
-        fill: #005eb8;
+            fill: #005eb8;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-header__logo {
-        padding-left: 0;
-        }
+            .nhsuk-header__logo {
+                padding-left: 0;
+            }
         }
 
         .nhsuk-header__logo .nhsuk-logo {
-        height: 40px;
-        width: 100px;
-        border: 0;
+            height: 40px;
+            width: 100px;
+            border: 0;
         }
 
         @@media (max-width: 48.0525em) {
-        .nhsuk-header__logo {
-        max-width: 60%;
-        }
+            .nhsuk-header__logo {
+                max-width: 60%;
+            }
         }
 
         @@media (max-width: 450px) {
-        .nhsuk-header__logo {
-        max-width: 50%;
-        }
+            .nhsuk-header__logo {
+                max-width: 50%;
+            }
         }
 
         .nhsuk-header__link {
-        height: 40px;
-        width: 100px;
-        display: block;
+            height: 40px;
+            width: 100px;
+            display: block;
         }
 
-        .nhsuk-header__link:hover .nhsuk-logo {
-        box-shadow: 0 0 0 4px #003d78;
-        }
+            .nhsuk-header__link:hover .nhsuk-logo {
+                box-shadow: 0 0 0 4px #003d78;
+            }
 
-        .nhsuk-header__link:focus {
-        box-shadow: none;
-        }
+            .nhsuk-header__link:focus {
+                box-shadow: none;
+            }
 
-        .nhsuk-header__link:focus .nhsuk-logo {
-        box-shadow: 0 0 0 4px #ffeb3b, 0 4px 0 4px #212b32;
-        }
+                .nhsuk-header__link:focus .nhsuk-logo {
+                    box-shadow: 0 0 0 4px #ffeb3b, 0 4px 0 4px #212b32;
+                }
 
         .nhsuk-header__link--service {
-        height: auto;
-        margin-bottom: -4px;
-        text-decoration: none;
-        width: auto;
+            height: auto;
+            margin-bottom: -4px;
+            text-decoration: none;
+            width: auto;
         }
 
         @@media (min-width: 61.875em) {
-        .nhsuk-header__link--service {
-        align-items: center;
-        display: flex;
-        -ms-flex-align: center;
-        margin-bottom: 0;
-        width: auto;
-        }
+            .nhsuk-header__link--service {
+                align-items: center;
+                display: flex;
+                -ms-flex-align: center;
+                margin-bottom: 0;
+                width: auto;
+            }
         }
 
 
         .nhsuk-header__service-name {
-        font-weight: 400;
-        font-size: 16px;
-        font-size: 1rem;
-        line-height: 1.5;
-        color: #fff;
-        display: block;
-        padding-left: 0;
-        padding-right: 0;
+            font-weight: 400;
+            font-size: 16px;
+            font-size: 1rem;
+            line-height: 1.5;
+            color: #fff;
+            display: block;
+            padding-left: 0;
+            padding-right: 0;
         }
 
         @@media (min-width: 40.0625em) {
-        .nhsuk-header__service-name {
-        font-size: 19px;
-        font-size: 1.1875rem;
-        line-height: 1.47368;
-        }
+            .nhsuk-header__service-name {
+                font-size: 19px;
+                font-size: 1.1875rem;
+                line-height: 1.47368;
+            }
         }
 
         @@media (min-width: 61.875em) {
-        .nhsuk-header__service-name {
-        padding-left: 16px;
-        }
+            .nhsuk-header__service-name {
+                padding-left: 16px;
+            }
         }
 
         @@media (max-width: 61.865em) {
-        .nhsuk-header__service-name {
-        max-width: 220px;
-        }
+            .nhsuk-header__service-name {
+                max-width: 220px;
+            }
         }
 
         .nhsuk-table__row:hover {
-        background-color: #f0f4f5;
+            background-color: #f0f4f5;
         }
 
         .nhsuk-table-responsive {
-        margin-bottom: 0;
-        width: 100%;
+            margin-bottom: 0;
+            width: 100%;
         }
 
-        .nhsuk-table-responsive thead {
-        border: 0;
-        clip: rect(0 0 0 0);
-        -webkit-clip-path: inset(50%);
-        clip-path: inset(50%);
-        height: 1px;
-        margin: 0;
-        overflow: hidden;
-        padding: 0;
-        position: absolute;
-        white-space: nowrap;
-        width: 1px;
-        }
+            .nhsuk-table-responsive thead {
+                border: 0;
+                clip: rect(0 0 0 0);
+                -webkit-clip-path: inset(50%);
+                clip-path: inset(50%);
+                height: 1px;
+                margin: 0;
+                overflow: hidden;
+                padding: 0;
+                position: absolute;
+                white-space: nowrap;
+                width: 1px;
+            }
 
         @@media (min-width: 48.0625em) {
-        .nhsuk-table-responsive thead {
-        clip: auto;
-        -webkit-clip-path: initial;
-        clip-path: initial;
-        display: table-header-group;
-        height: auto;
-        overflow: auto;
-        position: relative;
-        width: auto;
-        }
+            .nhsuk-table-responsive thead {
+                clip: auto;
+                -webkit-clip-path: initial;
+                clip-path: initial;
+                display: table-header-group;
+                height: auto;
+                overflow: auto;
+                position: relative;
+                width: auto;
+            }
         }
 
         .nhsuk-table-responsive .nhsuk-table__body .nhsuk-table-responsive__heading {
-        font-weight: 600;
-        padding-right: 16px;
-        text-align: left;
+            font-weight: 600;
+            padding-right: 16px;
+            text-align: left;
         }
 
         @@media (min-width: 48.0625em) {
-        .nhsuk-table-responsive .nhsuk-table__body .nhsuk-table-responsive__heading {
-        display: none;
-        }
+            .nhsuk-table-responsive .nhsuk-table__body .nhsuk-table-responsive__heading {
+                display: none;
+            }
         }
 
         .nhsuk-table-responsive .nhsuk-table__body .nhsuk-table__row {
-        display: block;
-        margin-bottom: 24px;
+            display: block;
+            margin-bottom: 24px;
         }
 
-        .nhsuk-table-responsive .nhsuk-table__body .nhsuk-table__row:last-child {
-        margin-bottom: 0;
-        }
+            .nhsuk-table-responsive .nhsuk-table__body .nhsuk-table__row:last-child {
+                margin-bottom: 0;
+            }
 
         @@media (min-width: 48.0625em) {
-        .nhsuk-table-responsive .nhsuk-table__body .nhsuk-table__row {
-        display: table-row;
-        }
+            .nhsuk-table-responsive .nhsuk-table__body .nhsuk-table__row {
+                display: table-row;
+            }
         }
 
         .nhsuk-table-responsive .nhsuk-table__body .nhsuk-table__row td {
-        display: block;
-        display: flex;
-        justify-content: space-between;
-        min-width: 1px;
+            display: block;
+            display: flex;
+            justify-content: space-between;
+            min-width: 1px;
         }
 
         @@media all and (-ms-high-contrast: none) {
-        .nhsuk-table-responsive .nhsuk-table__body .nhsuk-table__row td {
-        display: block;
-        }
+            .nhsuk-table-responsive .nhsuk-table__body .nhsuk-table__row td {
+                display: block;
+            }
         }
 
         @@media (min-width: 48.0625em) {
-        .nhsuk-table-responsive .nhsuk-table__body .nhsuk-table__row td {
-        display: table-cell;
-        }
+            .nhsuk-table-responsive .nhsuk-table__body .nhsuk-table__row td {
+                display: table-cell;
+            }
         }
 
         @@media (max-width: 48.0525em) {
-        .nhsuk-table-responsive .nhsuk-table__body .nhsuk-table__row td {
-        padding-right: 0;
-        text-align: right;
-        }
+            .nhsuk-table-responsive .nhsuk-table__body .nhsuk-table__row td {
+                padding-right: 0;
+                text-align: right;
+            }
 
-        .nhsuk-table-responsive .nhsuk-table__body .nhsuk-table__row td:last-child {
-        border-bottom: 3px solid #d8dde0;
-        }
+                .nhsuk-table-responsive .nhsuk-table__body .nhsuk-table__row td:last-child {
+                    border-bottom: 3px solid #d8dde0;
+                }
         }
 
         .nhsuk-width-container.app-width-container {
-        max-width: 75.5rem;
-        margin: 0 auto;
-        padding-left: 2rem;
-        padding-right: 2rem;
+            max-width: 75.5rem;
+            margin: 0 auto;
+            padding-left: 2rem;
+            padding-right: 2rem;
         }
 
         .nhsuk-header__logo {
-        flex: 1 0 0;
+            flex: 1 0 0;
         }
 
-        .nhsuk-header__logo .nhsuk-header__link--service {
-        display: inline-flex;
-        }
+            .nhsuk-header__logo .nhsuk-header__link--service {
+                display: inline-flex;
+            }
 
         .nhsuk-header__service-name {
-        font-size: 1.1875rem;
+            font-size: 1.1875rem;
         }
 
         @@media (min-width: 48.0625rem) {
-        .display-desktop--show {
-        display: block !important;
-        }
+            .display-desktop--show {
+                display: block !important;
+            }
         }
 
         @@media (max-width: 61.8125rem) {
-        .nhsuk-header__link--service {
-        align-items: center;
-        -ms-flex-align: center;
-        margin-bottom: 0;
-        width: auto;
-        }
+            .nhsuk-header__link--service {
+                align-items: center;
+                -ms-flex-align: center;
+                margin-bottom: 0;
+                width: auto;
+            }
 
-        .nhsuk-header__service-name {
-        padding-left: 1rem;
-        }
+            .nhsuk-header__service-name {
+                padding-left: 1rem;
+            }
 
-        .nhsuk-header__logo {
-        order: 0;
-        }
+            .nhsuk-header__logo {
+                order: 0;
+            }
         }
 
         @@media (max-width: 48rem) {
-        .nhsuk-width-container.app-width-container {
-        padding-left: 1rem;
-        padding-right: 1rem;
-        }
+            .nhsuk-width-container.app-width-container {
+                padding-left: 1rem;
+                padding-right: 1rem;
+            }
         }
 
         .fal {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        display: inline-block;
-        font-style: normal;
-        font-variant: normal;
-        text-rendering: auto;
-        line-height: 1;
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            display: inline-block;
+            font-style: normal;
+            font-variant: normal;
+            text-rendering: auto;
+            line-height: 1;
         }
 
         .fa-chevron-right:before {
-        content: "\f054";
+            content: "\f054";
         }
 
         .fal {
-        font-family: "Font Awesome 5 Pro";
-        font-weight: 300;
+            font-family: "Font Awesome 5 Pro";
+            font-weight: 300;
         }
 
         .my-learning .certificateHead {
-        background-color: #005eb8 !important;
-        height: 72px;
+            background-color: #005eb8 !important;
+            height: 72px;
         }
 
         .my-learning thead th {
-        border-bottom: none;
+            border-bottom: none;
         }
 
         .my-learning tbody td {
-        border-bottom: none;
+            border-bottom: none;
         }
 
         .my-learning th,
         .my-learning td {
-        text-align: left;
+            text-align: left;
         }
 
         .my-learning .certificateSummaryBody,
         .my-learning .certificateBody {
-        border-left: 1px solid #aeb7bd;
-        border-right: 1px solid #aeb7bd;
+            border-left: 1px solid #aeb7bd;
+            border-right: 1px solid #aeb7bd;
         }
 
         .my-learning .summaryTableHead {
-        background-color: #f0f4f5 !important;
-        border-bottom: none;
+            background-color: #f0f4f5 !important;
+            border-bottom: none;
         }
 
         .my-learning .word-wrapper {
-        word-wrap: break-word;
-        overflow-wrap: break-word;
+            word-wrap: break-word;
+            overflow-wrap: break-word;
         }
 
         .my-learning table, th, td {
-        width: 100%;
+            width: 100%;
         }
 
         .my-learning th.Learningresource {
-        width: 15%;
+            width: 15%;
         }
 
         @@media (max-width: 599px) {
-        .my-learning .summaryTableHead {
-        width: 100vw;
-        }
+            .my-learning .summaryTableHead {
+                width: 100vw;
+            }
         }
 
         .my-learning .breadcrumbtable {
-        border: 1px solid #005eb8;
+            border: 1px solid #005eb8;
         }
 
         .my-learning .summarytabledetails {
-        border: 1px solid #005eb8;
+            border: 1px solid #005eb8;
         }
 
         .my-learning .certificateBody {
-        text-align: center;
+            text-align: center;
         }
 
         .my-learning .certificateFooter {
-        background-color: #f0f4f5 !important;
-        text-align: center;
-        border-left: 1px solid #aeb7bd;
-        border-right: 1px solid #aeb7bd;
-        border-bottom: 1px solid #aeb7bd;
+            background-color: #f0f4f5 !important;
+            text-align: center;
+            border-left: 1px solid #aeb7bd;
+            border-right: 1px solid #aeb7bd;
+            border-bottom: 1px solid #aeb7bd;
         }
 
         @@media (max-width: 599px) {
-        .my-learning .nhsuk-table-responsive .nhsuk-table__body .nhsuk-table__row td {
-        display: grid;
-        text-align: left;
-        }
+            .my-learning .nhsuk-table-responsive .nhsuk-table__body .nhsuk-table__row td {
+                display: grid;
+                text-align: left;
+            }
         }
 
         .my-learning table {
-        width: 100%;
+            width: 100%;
         }
 
         .my-learning .no-table-spacing {
-        margin-bottom: 0px;
-        padding-bottom: 0px;
+            margin-bottom: 0px;
+            padding-bottom: 0px;
         }
 
         .page-spacer {
-        margin-top: 250px;
+            margin-top: 250px;
         }
 
         .page-max-width {
-        max-width: 100rem
+            max-width: 100rem
         }
 
 
         @@page {
-        size: landscape;
-        margin: 0;
+            size: landscape;
+            margin: 0;
         }
 
         .my-learning-column-width {
@@ -1074,17 +1074,17 @@
     <div class="nhsuk-width-container app-width-container">
         <div class="nhsuk-grid-row">
             <div class="nhsuk-u-padding-top-4 nhsuk-u-padding-bottom-2">
-                    <div class="lh-container-xl">
-                        <div>
-                            <img src="https://learninghub.nhs.uk/images/NHS-white.svg" alt="NHS" />
-                            <div class="header-title">Learning Hub<sup class="header-beta" style="color: #768692;">Beta</sup></div>
-                        </div>
+                <div class="lh-container-xl">
+                    <div>
+                        <img src="https://learninghub.nhs.uk/images/NHS-white.svg" alt="NHS" />
+                        <div class="header-title">Learning Hub<sup class="header-beta" style="color: #768692;">Beta</sup></div>
                     </div>
-                    <div class="lh-container-xl">
-                        <div class="activity-report-heading pb-4">
+                </div>
+                <div class="lh-container-xl">
+                    <div class="activity-report-heading pb-4">
                         <h1 class="nhsuk-heading-l">Activity report:  <span class="nhsuk-caption-l no-wrap">  @Model.Item1.FirstName @Model.Item1.LastName (@Model.Item1.UserName)</span></h1>
-                        </div>
                     </div>
+                </div>
             </div>
 
             <table style="width:100%;table-layout:fixed" role="table" class="nhsuk-table-responsive">
@@ -1094,15 +1094,15 @@
                             Id
                         </th>
                         <th role="columnheader" class="nhsuk-u-padding-top-2" scope="col">
-                           Title
+                            Title
                         </th>
                         <th role="columnheader" class="nhsuk-u-padding-top-2 my-learning-column-width" scope="col">
-                           Status
+                            Status
                         </th>
                     </tr>
                 </thead>
                 <tbody class="nhsuk-table__body">
-                     @foreach (var activity in Model.Item2.Activities)
+                    @foreach (var activity in Model.Item2.Activities)
                     {
                         var isCompleted = ViewActivityHelper.GetActivityStatusDisplayText(activity) == ActivityStatusEnum.Completed.ToString();
 
@@ -1117,11 +1117,11 @@
                         var dateTimeText = activityDate == today ? "Today"
                         : activityDate == today.AddDays(-1) ? "Yesterday"
                         : activityDate.ToString("dd MMM yyyy");
-                    <tr role="row" class="nhsuk-table__row">
-                        <td role="cell" class="nhsuk-table__cell word-wrapper">
-                            <span>@activity.ResourceReferenceId</span>
-                        </td>
-                        <td>
+                        <tr role="row" class="nhsuk-table__row">
+                            <td role="cell" class="nhsuk-table__cell word-wrapper">
+                                <span>@activity.ResourceReferenceId</span>
+                            </td>
+                            <td>
                                 <span class="nhsuk-u-padding-bottom-3">
                                     @if (ViewActivityHelper.GetResourceTypeDesc(activity.ResourceType) == "Course")
                                     {
@@ -1219,16 +1219,16 @@
                                         }
                                     </div>
                                 }
-                        </td>
-                        <td>
+                            </td>
+                            <td>
                                 <span class="nhsuk-u-text-align-left  table-content-spacing">
                                     <strong class="nhsuk-tag @tagColorClass">
                                         @statusText
                                     </strong>
                                 </span>
-                        </td>
+                            </td>
 
-                    </tr>
+                        </tr>
                     }
                 </tbody>
             </table>


### PR DESCRIPTION
### JIRA link
[TD-6228](https://hee-tis.atlassian.net/browse/TD-6228)

### Description
Added ID column and headers (Id, Title and Status) in Activity report

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-6228]: https://hee-tis.atlassian.net/browse/TD-6228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ