### PR TITLE
TD-6213 Informal Assessment filtering update fix

### DIFF
--- a/OpenAPI/LearningHub.Nhs.OpenApi.Services/Services/MyLearningService.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Services/Services/MyLearningService.cs
@@ -407,7 +407,7 @@
                 }
                 else if (assessmentType == AssessmentTypeEnum.Informal)
                 {
-                    activityEntities = activityEntities.Where(x =>x.ActivityStatusId == (int)ActivityStatusEnum.Completed).ToList();
+                    activityEntities = activityEntities.Where(x => x.AssessmentResourceActivity != null && x.AssessmentResourceActivity.FirstOrDefault() != null && x.AssessmentResourceActivity.First().Score.HasValue).ToList();// x.ActivityStatusId == (int)ActivityStatusEnum.Completed).ToList();
                 }
             }
             else if (activityEntities.Any() && (activityEntities.FirstOrDefault()?.Resource.ResourceTypeEnum == ResourceTypeEnum.Video || activityEntities.FirstOrDefault()?.Resource.ResourceTypeEnum == ResourceTypeEnum.Audio))
@@ -502,7 +502,8 @@
                 if (latestActivityCheck.Any() && latestActivityCheck.FirstOrDefault()?.Resource.ResourceTypeEnum == ResourceTypeEnum.Assessment)
                 {
 
-                    latestActivityCheck = latestActivityCheck.Where(x => x.AssessmentResourceActivity.FirstOrDefault() != null && (x.ResourceVersion.AssessmentResourceVersion.AssessmentType == AssessmentTypeEnum.Formal && x.AssessmentResourceActivity.First().Score.HasValue && (int)Math.Round(x.AssessmentResourceActivity.First().Score.Value, MidpointRounding.AwayFromZero) >= x.ResourceVersion.AssessmentResourceVersion.PassMark) ||(x.ResourceVersion.AssessmentResourceVersion.AssessmentType == AssessmentTypeEnum.Informal && x.ActivityStatusId == (int)ActivityStatusEnum.Completed)).ToList();
+                    latestActivityCheck = latestActivityCheck.Where(x => x.AssessmentResourceActivity.FirstOrDefault() != null && (x.ResourceVersion.AssessmentResourceVersion.AssessmentType == AssessmentTypeEnum.Formal && x.AssessmentResourceActivity.FirstOrDefault() != null && x.AssessmentResourceActivity.First().Score.HasValue && (int)Math.Round(x.AssessmentResourceActivity.First().Score.Value, MidpointRounding.AwayFromZero) >= x.ResourceVersion.AssessmentResourceVersion.PassMark) ||
+                    (x.ResourceVersion.AssessmentResourceVersion.AssessmentType == AssessmentTypeEnum.Informal && x.AssessmentResourceActivity.FirstOrDefault() != null && x.AssessmentResourceActivity.First().Score.HasValue)).ToList();
                 }
 
                 ResourceActivity expectedActivity = null;

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Resources/GetUsercertificateDetails.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Resources/GetUsercertificateDetails.sql
@@ -66,8 +66,8 @@ BEGIN
                       ON arv.ResourceVersionId = ra.ResourceVersionId
                     WHERE ara.ResourceActivityId = ra.Id
                       AND (
-                             ara.Score >= arv.PassMark -- formal assessment
-                          OR (ra.ActivityStatusId = 3 AND arv.AssessmentType = 1) --informal assessment
+                             (arv.AssessmentType = 2 AND ara.Score >= arv.PassMark) -- formal assessment
+                          OR (arv.AssessmentType = 1 AND ara.Score is not null) -- informal assessment
                       )
                 )
                 -- Or explicitly marked as passed


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6213

### Description
The ef core filter for informal assessment was updated to pick assessment activities where scores are attached .
SP equally updated to filter using this parameter.

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation