### PR TITLE
TD-6283 optimization updates

### DIFF
--- a/OpenAPI/LearningHub.Nhs.OpenApi.Models/Configuration/LearningHubConfig.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Models/Configuration/LearningHubConfig.cs
@@ -48,6 +48,11 @@ namespace LearningHub.Nhs.OpenApi.Models.Configuration
         public bool UseRedisCache { get; set; } = false;
 
         /// <summary>
+        /// Gets or sets <see cref="MaxDatabaseRetryAttempts"/>.
+        /// </summary>
+        public int MaxDatabaseRetryAttempts {  get; set; } = 0;
+
+        /// <summary>
         /// Gets or sets <see cref="HierarchyEditPublishQueueName"/>.
         /// </summary>
         public string HierarchyEditPublishQueueName { get; set; } = null!;

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Repositories/Repositories/Activity/ScormActivityRepository.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Repositories/Repositories/Activity/ScormActivityRepository.cs
@@ -220,12 +220,13 @@ namespace LearningHub.Nhs.OpenApi.Repositories.Repositories.Activity
 
         private async Task UpdateScormActivityAsync(int userId, ScormActivity updatedScormActivity)
         {
-            var existingScormActivity = DbContext.ScormActivity.Where(s => s.Id == updatedScormActivity.Id)
+            var existingScormActivity = this.DbContext.ScormActivity.Where(s => s.Id == updatedScormActivity.Id)
                         .Include(sao => sao.ScormActivityObjective)
                         .Include(sao => sao.ScormActivityInteraction)
                         .ThenInclude(sai => sai.ScormActivityInteractionCorrectResponse)
                         .Include(sai => sai.ScormActivityInteraction)
                         .ThenInclude(sai => sai.ScormActivityInteractionObjective)
+                        .AsSplitQuery()
                         .SingleOrDefault();
 
             updatedScormActivity.ResourceActivityId = existingScormActivity.ResourceActivityId;

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Repositories/Repositories/UserProfileRepository.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Repositories/Repositories/UserProfileRepository.cs
@@ -26,9 +26,9 @@
         /// </summary>
         /// <param name="id">The id.</param>
         /// <returns>The userProfile.</returns>
-        public Task<UserProfile> GetByIdAsync(int id)
+        public async Task<UserProfile> GetByIdAsync(int id)
         {
-            return DbContext.UserProfile.AsNoTracking().SingleOrDefaultAsync(x => x.Id == id);
+            return await DbContext.UserProfile.AsNoTracking().SingleOrDefaultAsync(x => x.Id == id);
         }
 
         /// <summary>

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Services/Services/CatalogueService.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Services/Services/CatalogueService.cs
@@ -543,7 +543,7 @@
             await this.RecordNodeActivity(userId, catalogue);
 
             var catalogueVM = this.mapper.Map<CatalogueViewModel>(catalogue);
-            var bookmark = this.bookmarkRepository.GetAll().Where(b => b.NodeId == catalogue.NodeId && b.UserId == userId).FirstOrDefault();
+            var bookmark = await this.bookmarkRepository.GetAll().Where(b => b.NodeId == catalogue.NodeId && b.UserId == userId).FirstOrDefaultAsync();
             catalogueVM.BookmarkId = bookmark?.Id;
             catalogueVM.IsBookmarked = !bookmark?.Deleted ?? false;
             catalogueVM.Providers = await this.providerService.GetByCatalogueVersionIdAsync(catalogueVM.Id);

--- a/OpenAPI/LearningHub.Nhs.OpenApi/Controllers/BookmarkController.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi/Controllers/BookmarkController.cs
@@ -37,15 +37,17 @@
         [Route("GetAllByParent/{parentId?}")]
         public async Task<IActionResult> GetAllByParent(int? parentId, bool? all = false)
         {
-            if (this.CurrentUserId.GetValueOrDefault() != null)
+            var userId = this.CurrentUserId;
+
+            if (userId.HasValue && userId.Value != 4)
             {
-                var bookmarks = await this.bookmarkService.GetAllByParent(this.CurrentUserId.GetValueOrDefault(), parentId, all);
+                var bookmarks = await this.bookmarkService.GetAllByParent(userId.Value, parentId, all);
                 return this.Ok(bookmarks);
             }
-            else
-            {
-                return this.Ok(await this.bookmarkService.GetAllByParent(this.TokenWithoutBearer));
-            }
+
+            var fallbackBookmarks = await this.bookmarkService.GetAllByParent(this.TokenWithoutBearer);
+            return this.Ok(fallbackBookmarks);
+
         }
 
         /// <summary>

--- a/OpenAPI/LearningHub.Nhs.OpenApi/Controllers/OpenApiControllerBase.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi/Controllers/OpenApiControllerBase.cs
@@ -11,6 +11,8 @@
     /// </summary>
     public abstract class OpenApiControllerBase : ControllerBase, IDisposable
     {
+        private const int PortalAdminId = 4;
+
         /// <summary>
         /// Gets the current user's ID.
         /// </summary>
@@ -28,14 +30,14 @@
                     }
                     else
                     {
-                        // If parsing fails, return null - for apikey this will be the name
-                        return null;
+                        // If parsing fails, return PortalAdminId as default userId - for apikey this will be the name
+                        return PortalAdminId;
                     }
                 }
                 else
                 {
                     // When authorizing by ApiKey we do not have a user for example
-                    return null;
+                    return PortalAdminId;
                 }
             }
         }

--- a/OpenAPI/LearningHub.Nhs.OpenApi/Startup.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi/Startup.cs
@@ -84,10 +84,6 @@ namespace LearningHub.NHS.OpenAPI
 
             services.AddRepositories(this.Configuration);
             services.AddServices();
-
-            services.AddDbContext<LearningHubDbContext>(
-                options =>
-                    options.UseSqlServer(this.Configuration.GetConnectionString("LearningHub")));
             services.AddApplicationInsightsTelemetry();
             services.AddControllers(options =>
             {

--- a/OpenAPI/LearningHub.Nhs.OpenApi/appsettings.json
+++ b/OpenAPI/LearningHub.Nhs.OpenApi/appsettings.json
@@ -76,6 +76,7 @@
     "SupportPages": "https://support.learninghub.nhs.uk/",
     "SupportForm": "https://support.learninghub.nhs.uk/support/tickets/new",
     "UseRedisCache": true,
+    "MaxDatabaseRetryAttempts": 3,
     "ResourcePublishQueueRouteName": "",
     "HierarchyEditPublishQueueName": "",
     "ContentManagementQueueName": "",

--- a/WebAPI/LearningHub.Nhs.Repository/Activity/ScormActivityRepository.cs
+++ b/WebAPI/LearningHub.Nhs.Repository/Activity/ScormActivityRepository.cs
@@ -226,6 +226,7 @@ namespace LearningHub.Nhs.Repository.Activity
                         .ThenInclude(sai => sai.ScormActivityInteractionCorrectResponse)
                         .Include(sai => sai.ScormActivityInteraction)
                         .ThenInclude(sai => sai.ScormActivityInteractionObjective)
+                        .AsSplitQuery()
                         .SingleOrDefault();
 
             updatedScormActivity.ResourceActivityId = existingScormActivity.ResourceActivityId;


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6283

### Description
Area updated includes: 
Database connection and retry config
Added splitQuery to Scorm update.
Added await to inner methods in the catalogue endpoint
Added default user of 4 in the controllerbase when current user is unknown.

Open API and Web API to be released.

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation