### PR TITLE
TD-6318-My courses and learning dashboard - wording of "Elearning" wrong case

### DIFF
--- a/LearningHub.Nhs.WebUI/Views/Home/_MyCoursesAndElearning.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Home/_MyCoursesAndElearning.cshtml
@@ -75,7 +75,7 @@
             <a asp-action="Index" asp-route-dashboardTrayLearningResourceType="elearning" asp-route-myLearningDashboard=@Model.MyLearnings.Type asp-route-resourceDashboard="@(Model.Resources.Type)" asp-route-catalogueDashboard="@Model.Catalogues.Type" asp-fragment="my-learning"
                class="subnavwhite-link text-nowrap nhsuk-u-padding-right-3  nhsuk-u-secondary-text-color nhsuk-u-font-size-16 nhsuk-u-font-weight-bold filterlink @(Model.DashboardTrayLearningResourceType == "elearning" ? "filteractive" : "filterinactive")"
                title="Elearning">
-                Elearning
+                elearning
             </a>
         </span>
     </div>

--- a/LearningHub.Nhs.WebUI/Views/MyLearning/LearningCertificate.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/MyLearning/LearningCertificate.cshtml
@@ -1250,7 +1250,7 @@
             {
                 if (!Model.DownloadCertificate)
                 {
-                    <vc:back-link asp-controller="MyLearning" asp-action="Index" asp-all-route-data="@routeData" link-text="Back to: My learning" />
+                    <vc:back-link asp-controller="MyLearning" asp-action="Index" asp-all-route-data="@routeData" link-text="Back to: My learning activity" />
                     <div class="nhsuk-grid-column-three-quarters nhsuk-u-padding-left-0 nhsuk-u-padding-top-0">
 
                         <h1 class="nhsuk-heading-xl">Certificate</h1>
@@ -1420,7 +1420,7 @@
             }
             else
             {
-                <vc:back-link asp-controller="MyLearning" asp-action="Index" link-text="Back to: My learning" />
+                <vc:back-link asp-controller="MyLearning" asp-action="Index" link-text="Back to: My learning activity" />
                 <h1 class="nhsuk-heading-xl">Certificate</h1>
                 <span class="nhsuk-grid-column-full nhsuk-u-margin-top-3 nhsuk-u-font-size-19 nhsuk-u-margin-bottom-9 nhsuk-u-secondary-text-color">
                     Certificate not available


### PR DESCRIPTION
### JIRA link
TD-6318

### Description
My courses and learning dashboard - wording of "Elearning" wrong case

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [X] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [X] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [X] Confirmed that none of the work that I have undertaken requires any updates to documentation