### PR TITLE
bugfix for failing report update

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/ReportsController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/ReportsController.cs
@@ -171,8 +171,7 @@
             }
 
             this.ModelState.AddModelError("Courses", CommonValidationErrorMessages.CourseRequired);
-            reportCreation.Courses = null;
-            await this.multiPageFormService.SetMultiPageFormData(reportCreation, MultiPageFormDataFeature.AddCustomWebForm("ReportWizardCWF"), this.TempData);
+
             courseSelection.BuildCourses(await this.GetCoursesAsync());
             courseSelection.Courses = reportCreation.Courses;
             this.ViewBag.ReturnUrl = returnUrl;


### PR DESCRIPTION
### JIRA link
TD-6522

### Description
When updating an existing report, and a user updates the list of courses. If validation fails upon submission, it deletes the previous in-memory course selection. If user decides to navigate back to previous in memory report, it fails because the previous course has been deleted. This has now been reversed.

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation