### PR TITLE
Td-6760: Duplicate record in synced elfh tables in the LH database

### DIFF
--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Adf/AdfMergeUserAdminLocation.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Adf/AdfMergeUserAdminLocation.sql
@@ -13,50 +13,38 @@ AS
 BEGIN
     SET NOCOUNT ON;
 
-    -- Deduplicate source first
-    ;WITH DedupedSource AS (
-        SELECT *,
-            ROW_NUMBER() OVER (
-                PARTITION BY userId, adminLocationId, deleted
-                ORDER BY amendDate DESC, createdDate DESC
-            ) AS rn
-        FROM @UserAdminLocationList
-    ),
-    CleanSource AS (
-        SELECT * FROM DedupedSource WHERE rn = 1
-    )
-
-    MERGE elfh.userAdminLocationTBL AS target
-    USING CleanSource AS source
-        ON  target.userId          = source.userId
-        AND target.adminLocationId = source.adminLocationId
-        AND target.deleted         = source.deleted     -- IMPORTANT!
+  MERGE [elfh].[userAdminLocationTBL] AS target
+    USING @UserAdminLocationList AS source
+        ON target.[userId] = source.[userId]
+       AND target.[adminLocationId] = source.[adminLocationId]  -- composite key match
 
     WHEN MATCHED THEN
         UPDATE SET
-            target.amendUserId   = source.amendUserId,
-            target.amendDate     = source.amendDate,
-            target.createdUserId = source.createdUserId,
-            target.createdDate   = source.createdDate
+            target.[deleted]       = source.[deleted],
+            target.[amendUserId]   = source.[amendUserId],
+            target.[amendDate]     = source.[amendDate],
+            target.[createdUserId] = source.[createdUserId],
+            target.[createdDate]   = source.[createdDate]
 
     WHEN NOT MATCHED BY TARGET THEN
         INSERT (
-            userId,
-            adminLocationId,
-            deleted,
-            amendUserId,
-            amendDate,
-            createdUserId,
-            createdDate
+            [userId],
+            [adminLocationId],
+            [deleted],
+            [amendUserId],
+            [amendDate],
+            [createdUserId],
+            [createdDate]
         )
         VALUES (
-            source.userId,
-            source.adminLocationId,
-            source.deleted,
-            source.amendUserId,
-            source.amendDate,
-            source.createdUserId,
-            source.createdDate
+            source.[userId],
+            source.[adminLocationId],
+            source.[deleted],
+            source.[amendUserId],
+            source.[amendDate],
+            source.[createdUserId],
+            source.[createdDate]
         );
+
 END
 GO


### PR DESCRIPTION
### JIRA link
[TD-6760](https://hee-tis.atlassian.net/browse/TD-6760)

### Description
Fixed Duplicate record in synced elfh tables in the LH database

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-6760]: https://hee-tis.atlassian.net/browse/TD-6760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ