### PR TITLE
TD-6805: Catalogue Appears Blank When It Contains Only Courses

### DIFF
--- a/LearningHub.Nhs.WebUI/Views/Catalogue/Index.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Catalogue/Index.cshtml
@@ -55,7 +55,11 @@
         }
     }
 
-    if (ViewBag.ActiveTab == "courses")
+    if (ViewBag.ActiveTab == "browse" && Model.NodeContents.Count() == 0)
+    {
+        ViewBag.ActiveTab = "courses";
+    }
+    else if (ViewBag.ActiveTab == "courses")
     {
         if (Model.Catalogue.SelectedCategoryId == 0 ||
          (Model.Catalogue.SelectedCategoryId > 0 &&


### PR DESCRIPTION
### JIRA link
[TD-6805](https://hee-tis.atlassian.net/browse/TD-6805)

### Description
Catalogue Appears Blank When It Contains Only Courses (No Resources)

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._
<img width="950" height="679" alt="image" src="https://github.com/user-attachments/assets/47fc6672-fa22-40f0-9629-27c13faf13c3" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-6805]: https://hee-tis.atlassian.net/browse/TD-6805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ