### PR TITLE
TD-6860: My Learning history page issue

### DIFF
--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserInProgressLearningActivities.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserInProgressLearningActivities.sql
@@ -5,6 +5,7 @@
 --
 -- Modification History
 -- 01-10-2025  SA added assesment score and passmark and provider details
+-- 05-02-2025  SA TD-6860 : Fixed the null issue with the search history
 -------------------------------------------------------------------------------
 CREATE PROCEDURE [activity].[GetUserInProgressLearningActivities] (
 	 @userId INT
@@ -23,7 +24,7 @@ BEGIN
     (
         SELECT TOP 1 rr.OriginalResourceReferenceId
 		FROM [resources].[ResourceReference] rr		
-		WHERE rr.ResourceId = rv.ResourceId AND rr.Deleted = 0
+		WHERE rr.ResourceId = rv.ResourceId --AND rr.Deleted = 0
     ) AS ResourceReferenceID,
     ra.MajorVersion AS MajorVersion,
     ra.MinorVersion AS MinorVersion,

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserRecentLearningActivities.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserRecentLearningActivities.sql
@@ -7,6 +7,7 @@
 -- 02-Sep-2025       SA        Incorrect Syntax 
 -- 23-09-2025  SA Added new columns for displaying video/Audio Progress
 -- 01-10-2025  SA added assesment score and passmark and provider details
+-- 05-02-2025  SA TD-6860 : Fixed the null issue with the search history
 -------------------------------------------------------------------------------
 CREATE PROCEDURE [activity].[GetUserRecentLearningActivities] (
 	 @userId INT,
@@ -26,7 +27,7 @@ BEGIN
     (
         SELECT TOP 1 rr.OriginalResourceReferenceId
 		FROM [resources].[ResourceReference] rr		
-		WHERE rr.ResourceId = rv.ResourceId AND rr.Deleted = 0
+		WHERE rr.ResourceId = rv.ResourceId --AND rr.Deleted = 0
     ) AS ResourceReferenceID,
     ra.MajorVersion AS MajorVersion,
     ra.MinorVersion AS MinorVersion,

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUsersLearningHistory.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUsersLearningHistory.sql
@@ -6,6 +6,7 @@
 -- Modification History
 -- 23-09-2025  SA Added new columns for displaying video/Audio Progress
 -- 01-10-2025  SA added assesment score and passmark and provider details
+-- 05-02-2025  SA TD-6860 : Fixed the null issue with the search history
 -------------------------------------------------------------------------------
 CREATE PROCEDURE [activity].[GetUsersLearningHistory] (
 	  @userId INT,
@@ -24,7 +25,7 @@ BEGIN
 			(
 				SELECT TOP 1 rr.OriginalResourceReferenceId
 				FROM [resources].[ResourceReference] rr		
-				WHERE rr.ResourceId = rv.ResourceId AND rr.Deleted = 0
+				WHERE rr.ResourceId = rv.ResourceId --AND rr.Deleted = 0
 			) AS ResourceReferenceId,
 			ra.MajorVersion AS MajorVersion,
 			ra.MinorVersion AS MinorVersion,

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUsersLearningHistory_Search.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUsersLearningHistory_Search.sql
@@ -6,6 +6,7 @@
 -- Modification History
 -- 23-09-2025  SA Added new columns for displaying video/Audio Progress
 -- 01-10-2025  SA added assesment score and passmark and provider details
+-- 05-02-2025  SA TD-6860 : Fixed the null issue with the search history
 -------------------------------------------------------------------------------
 CREATE PROCEDURE [activity].[GetUsersLearningHistory_Search] (
 	 @userId INT,
@@ -27,7 +28,7 @@ BEGIN
 					(
 						SELECT TOP 1 rr.OriginalResourceReferenceId
 						FROM [resources].[ResourceReference] rr		
-						WHERE rr.ResourceId = rv.ResourceId AND rr.Deleted = 0
+						WHERE rr.ResourceId = rv.ResourceId --AND rr.Deleted = 0
 					) AS ResourceReferenceId,
 					ra.MajorVersion AS MajorVersion,
 					ra.MinorVersion AS MinorVersion,


### PR DESCRIPTION
### JIRA link
[TD-6860](https://hee-tis.atlassian.net/browse/TD-6860)

### Description
Fixed the issue preventing the history page from loading for some users. The issue was caused by the resource reference ID being populated as null for certain resources. The resource reference ID should not be null for any resource, so we updated the conditions to handle and correct this data issue.

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._
![Uploading image.png…]()

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-6860]: https://hee-tis.atlassian.net/browse/TD-6860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ