### PR TITLE
TD-6179: Fixed issues related to error links on Bookmark screens.

### DIFF
--- a/LearningHub.Nhs.WebUI/Views/Bookmark/Rename.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Bookmark/Rename.cshtml
@@ -2,6 +2,8 @@
 @{
     var bookmarkType = (Model.BookmarkTypeId == 1) ? "Folder" : "Bookmark";
     ViewData["Title"] = "Rename " + bookmarkType;
+    ViewData["DisableValidation"] = true;
+    var errorHasOccurred = !ViewData.ModelState.IsValid;
 }
 
 @section styles{
@@ -13,9 +15,10 @@
         <vc:back-link asp-controller="Bookmark" asp-action="Index" link-text="Back to: My bookmarks" />
 
         <form asp-controller="Bookmark" asp-action="BookmarkRename" asp-route-returnUrl="@ViewBag.ReturnUrl" method="post">
-
-            <vc:error-summary order-of-property-names="@(new[] { nameof(Model.Title) })" />
-
+            @if (errorHasOccurred)
+            {
+                <vc:error-summary order-of-property-names="@(new[] { nameof(Model.Title) })" />
+            }
             <h1>Rename @bookmarkType.ToLower()</h1>
 
             <div class="nhsuk-grid-row">

--- a/LearningHub.Nhs.WebUI/Views/Bookmark/Toggle.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Bookmark/Toggle.cshtml
@@ -4,6 +4,8 @@
   var bookmarkType = (Model.BookmarkTypeId == 1) ? "Folder" : "Bookmark";
   var titleAction = Model.Bookmarked ? "Delete" : "Add";
   var buttonAction = Model.Bookmarked ? "Delete" : "Continue";
+  ViewData["DisableValidation"] = true;
+  var errorHasOccurred = !ViewData.ModelState.IsValid;
 
   ViewData["Title"] = $"{titleAction} {bookmarkType}";
 
@@ -63,8 +65,11 @@
     <vc:back-link asp-controller="@controller" asp-action="@action" asp-all-route-data="@routeParams" link-text="@backToText" />
 
     <form asp-controller="Bookmark" asp-action="BookmarkToggle" asp-route-returnUrl="@ViewBag.ReturnUrl" method="post">
-
-      <vc:error-summary order-of-property-names="@(new[] { nameof(Model.Title) })" />
+            @if (errorHasOccurred)
+            {
+                <vc:error-summary order-of-property-names="@(new[] { nameof(Model.Title) })" />
+            }
+      
 
       @if (Model.Bookmarked)
       {


### PR DESCRIPTION
### JIRA link
[TD-6179](https://hee-tis.atlassian.net/browse/TD-6179)

### Description
Fixed issues related to error links on Bookmark screens.

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-6179]: https://hee-tis.atlassian.net/browse/TD-6179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ