### PR TITLE
TD-6873: Fixed style issues on auto suggestion results during tabbing

### DIFF
--- a/LearningHub.Nhs.WebUI/Styles/nhsuk/layout.scss
+++ b/LearningHub.Nhs.WebUI/Styles/nhsuk/layout.scss
@@ -246,7 +246,7 @@ button[data-toggle="modal"] {
 }
 
 .autosuggestion-menu {
-    padding: 16px 16px 0px 16px !important;
+    padding: 0;
     background-color: $color_nhsuk-white;
     border-bottom: 1px solid $color_nhsuk-grey-4;
     border-radius: 0px 0px 4px 4px;
@@ -263,12 +263,11 @@ button[data-toggle="modal"] {
 }
 
 .autosuggestion-option {
-    margin-bottom: 0;
+    margin-bottom: 0 !important;
     border-bottom: 1px solid $color_nhsuk-grey-4;
     color: $color_nhsuk-blue;
     cursor: pointer;
     font-size: 16px;
-    padding-bottom: 12px;
     text-align: left;
     text-decoration: none;
 }
@@ -295,6 +294,32 @@ button[data-toggle="modal"] {
 
 li.autosuggestion-option:last-of-type {
     border-bottom: none !important;
+}
+
+.autosuggestion-option a {
+    display: block;
+    width: 100%;
+    padding: 8px 16px;
+}
+
+.autosuggestion-option a:hover,
+.autosuggestion-option a:focus-visible {
+    background-color: #ffeb3b;
+    box-shadow: 0 4px 0 0 #212b32;
+    z-index: 5;
+    outline: none !important;
+    text-decoration: none;
+    padding-bottom: 10px
+}
+
+.autosuggestion-option a:focus .autosuggestion-icon, .autosuggestion-option a:hover .autosuggestion-icon {
+    fill: #212b32 !important;
+}
+
+.autosuggestion-option a:focus .autosuggestion-link, .autosuggestion-option a:hover .autosuggestion-link {
+    font-weight: 700;
+    color: #212b32;
+    text-decoration: none
 }
 
 


### PR DESCRIPTION
### JIRA link
[TD-6873](https://hee-tis.atlassian.net/browse/TD-6873)

### Description
Fixed style issues on auto suggestion results during tabbing.

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-6873]: https://hee-tis.atlassian.net/browse/TD-6873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ