### PR TITLE
TD-6899: Added multipage check for case resource before status chage

### DIFF
--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/activity.ts
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/activity.ts
@@ -10,13 +10,16 @@ const recordActivityLaunched = async function (
     resourceVersionId: number,
     nodePathId: number,
     activityDatetime: Date,
+    isMultiPageCase: boolean = false,
     extraAttemptReason?: string): Promise<LearningHubValidationResultModel> {
 
     var data = {
         resourceVersionId: resourceVersionId,
         nodePathId: nodePathId,
         activityStatus: (resourceType == ResourceType.ASSESSMENT || resourceType == ResourceType.VIDEO || resourceType == ResourceType.AUDIO ||
-            resourceType == ResourceType.SCORM) ? ActivityStatus.Incomplete : ActivityStatus.Completed,
+            resourceType == ResourceType.SCORM ||
+            (resourceType == ResourceType.CASE && isMultiPageCase)
+        ) ? ActivityStatus.Incomplete : ActivityStatus.Completed,
         activityStart: activityDatetime,
         extraAttemptReason
     };
@@ -169,6 +172,26 @@ const recordActivityAndInteractionTogether = async function (
 
 };
 
+const recordCaseActivityComplete = async function (resourceActivityId: number, activityDatetime: Date): Promise<LearningHubValidationResultModel> {
+    var data = {
+        resourceActivityId: resourceActivityId,
+        activityStatus: ActivityStatus.Completed,
+        activityEnd: activityDatetime
+    };
+
+    return await AxiosWrapper.axios.post<LearningHubValidationResultModel>('/api/activity/CompleteCaseActivity', data)
+        .then(response => {
+            if (!response.data.isValid) {
+                window.location.pathname = './Home/Error';
+            }
+            return response.data;
+        })
+        .catch(e => {
+            console.log('recordCaseActivityComplete:' + e);
+            throw e;
+        });
+};
+
 const recordAssessmentResourceActivity = async function (
     resourceActivityId: number,
     matchQuestions: MatchQuestionState[],
@@ -222,5 +245,6 @@ export const activityRecorder = {
     recordMediaResourceActivityInteraction,
     recordActivityAndInteractionTogether,
     recordAssessmentResourceActivity,
-    recordAssessmentResourceActivityInteraction
+    recordAssessmentResourceActivityInteraction,
+    recordCaseActivityComplete
 };

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/activity.ts
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/activity.ts
@@ -172,14 +172,22 @@ const recordActivityAndInteractionTogether = async function (
 
 };
 
-const recordCaseActivityComplete = async function (resourceActivityId: number, activityDatetime: Date): Promise<LearningHubValidationResultModel> {
+const recordCaseActivityComplete = async function (resourceVersionId: number,
+    nodePathId: number,
+    activityStart: Date,
+    activityEnd: Date,
+    launchResourceActivityId: number): Promise<LearningHubValidationResultModel> {
+
     var data = {
-        resourceActivityId: resourceActivityId,
+        resourceVersionId: resourceVersionId,
+        nodePathId: nodePathId,
         activityStatus: ActivityStatus.Completed,
-        activityEnd: activityDatetime
+        activityStart: activityStart,
+        activityEnd: activityEnd,
+        launchResourceActivityId: launchResourceActivityId
     };
 
-    return await AxiosWrapper.axios.post<LearningHubValidationResultModel>('/api/activity/CompleteCaseActivity', data)
+    return await AxiosWrapper.axios.post<LearningHubValidationResultModel>('/api/activity/CreateResourceActivity', data)
         .then(response => {
             if (!response.data.isValid) {
                 window.location.pathname = './Home/Error';

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/resource/CaseOrAssessmentResource.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/resource/CaseOrAssessmentResource.vue
@@ -238,6 +238,19 @@
                 if (isCompleted) {
                     this.pagesProgress.completePage(page);
                 }
+
+                // complete Case activity
+                if (this.allPagesCompleted && 
+                    this.resourceItem.resourceTypeEnum === ResourceType.CASE && 
+                    !this.isPreview && 
+                    this.resourceActivityId > 0) {
+        
+                    await activityRecorder.recordCaseActivityComplete(this.resourceActivityId, new Date());
+        
+                    // Refresh certificate status upon completion
+                    this.checkUserCertificateAvailability();
+                }
+
                 if (this.allPagesCompleted && this.isAssessment) {
                     this.allAssessmentInteractionsSubmitted = true;
                 }

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/resource/ResourceContent.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/resource/ResourceContent.vue
@@ -102,6 +102,7 @@
     import { MKPlayer } from '@mediakind/mkplayer';
     import { MKPlayerType, MKStreamType } from '../MKPlayerConfigEnum';
     import { MKPlayerControlbar } from '../mkioplayer-controlbar';
+    import { BlockTypeEnum } from '../models/contribute-resource/blocks/blockTypeEnum';
 
     Vue.use(Vuelidate as any);
 
@@ -413,7 +414,9 @@
             initialise(): void {
                 // record activity on page created for resource article
                 if (this.userAuthenticated && this.resourceItem.resourceTypeEnum === ResourceType.CASE) {
-                    this.recordActivityLaunched();
+                   const blocks = this.resourceItem.caseDetails.blockCollection.blocks;
+                   const isMultiPage = blocks.some(b => b.blockType === BlockTypeEnum.PageBreak);
+                   this.recordActivityLaunched(isMultiPage);
                 }
                 else if (this.userAuthenticated && this.resourceItem.resourceTypeEnum === ResourceType.ASSESSMENT) {
                     this.getCurrentAssessmentActivity();
@@ -456,11 +459,11 @@
             hasResourceAccess(): boolean {
                 return this.userAuthenticated && (!(this.isGeneralUser && this.resourceItem.resourceAccessibilityEnum == this.ResourceAccessibility.FullAccess))
             },
-            async recordActivityLaunched(): Promise<void> {
+            async recordActivityLaunched(isMultiPageCase: boolean = false): Promise<void> {
 
                 if (!this.activityLogged) {
                     this.activityLogged = true;
-                    await activityRecorder.recordActivityLaunched(this.resourceItem.resourceTypeEnum, this.resourceItem.resourceVersionId, this.resourceItem.nodePathId, new Date())
+                    await activityRecorder.recordActivityLaunched(this.resourceItem.resourceTypeEnum, this.resourceItem.resourceVersionId, this.resourceItem.nodePathId, new Date(),isMultiPageCase)
                         // await activityRecorder.recordActivityLaunched(this.resourceItem.resourceVersionId, this.resourceItem.nodePathId, new Date())
                         .then(response => {
                             this.launchedResourceActivityId = response.createdId;


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6899

### Description
Once a case resourcce is accessed, the status is changed to completed. We've added to prevent this for multipage case resource until all pages has been viewed.

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation