### PR TITLE
TD-6899 Refactor of Case Completion status

### DIFF
--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/activity.ts
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/activity.ts
@@ -10,13 +10,18 @@ const recordActivityLaunched = async function (
     resourceVersionId: number,
     nodePathId: number,
     activityDatetime: Date,
+    isMultiPageCase: boolean = false,
     extraAttemptReason?: string): Promise<LearningHubValidationResultModel> {
 
     var data = {
         resourceVersionId: resourceVersionId,
         nodePathId: nodePathId,
-        activityStatus: (resourceType == ResourceType.ASSESSMENT || resourceType == ResourceType.VIDEO || resourceType == ResourceType.AUDIO ||
-            resourceType == ResourceType.SCORM) ? ActivityStatus.Incomplete : ActivityStatus.Completed,
+        activityStatus: (resourceType == ResourceType.ASSESSMENT ||
+            resourceType == ResourceType.VIDEO ||
+            resourceType == ResourceType.AUDIO ||
+            resourceType == ResourceType.SCORM ||
+            (resourceType == ResourceType.CASE && isMultiPageCase)
+        ) ? ActivityStatus.Incomplete : ActivityStatus.Completed,
         activityStart: activityDatetime,
         extraAttemptReason
     };
@@ -35,8 +40,10 @@ const recordActivityLaunched = async function (
             console.log('recordActivityLaunched:' + e);
             throw e;
         });
-
 };
+
+
+
 const recordActivity = async function (
     resourceVersionId: number,
     nodePathId: number,
@@ -215,6 +222,24 @@ const recordAssessmentResourceActivityInteraction = async function (
         });
 }
 
+// handle case completion
+const recordCaseActivityComplete = async function (
+    resourceVersionId: number,
+    nodePathId: number,
+    activityStart: Date,
+    activityEnd: Date,
+    launchResourceActivityId: number
+): Promise<LearningHubValidationResultModel> {
+    return await recordActivity(
+        resourceVersionId,
+        nodePathId,
+        activityStart,
+        activityEnd,
+        ActivityStatus.Completed,
+        launchResourceActivityId
+    );
+};
+
 export const activityRecorder = {
     recordActivityLaunched,
     recordActivity,
@@ -222,5 +247,6 @@ export const activityRecorder = {
     recordMediaResourceActivityInteraction,
     recordActivityAndInteractionTogether,
     recordAssessmentResourceActivity,
-    recordAssessmentResourceActivityInteraction
+    recordAssessmentResourceActivityInteraction,
+    recordCaseActivityComplete
 };

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/resource/CaseOrAssessmentResource.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/resource/CaseOrAssessmentResource.vue
@@ -244,10 +244,12 @@
                     page === this.pageCount - 1 &&
                     this.resourceActivityId > 0) {
 
+                    let startDate = new Date(this.activityStart as any);
+
                     await activityRecorder.recordCaseActivityComplete(
                         this.resourceItem.resourceVersionId,
                         this.resourceItem.nodePathId,
-                        this.activityStart,
+                        startDate,
                         new Date(),
                         this.resourceActivityId
                     );
@@ -322,7 +324,13 @@
 
                 // Only make a new activity if the latest activity is finished
                 if (typeof latest.userScore === 'number') {
-                    const result = await activityRecorder.recordActivityLaunched(this.resourceItem.resourceTypeEnum, this.resourceItem.resourceVersionId, this.resourceItem.nodePathId, new Date() as Date, false, reason);
+                    const result = await activityRecorder.recordActivityLaunched(
+                        this.resourceItem.resourceTypeEnum,
+                        this.resourceItem.resourceVersionId,
+                        this.resourceItem.nodePathId,
+                        new Date(),
+                        false as boolean
+                    );
                     this.shuffleMatchQuestionsState();
                     await activityRecorder.recordAssessmentResourceActivity(result.createdId, this.matchQuestionsState, reason);
                 }

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/resource/CaseOrAssessmentResource.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/resource/CaseOrAssessmentResource.vue
@@ -116,6 +116,7 @@
         props: {
             resourceItem: { type: Object } as PropOptions<ResourceItemModel>,
             resourceActivityId: { type: Number } as PropOptions<number>,
+            activityStart: { type: Date },
             assessmentProgress: { type: Object } as PropOptions<AssessmentProgressModel>,
             keepUserSessionAliveIntervalSeconds: { type: Number } as PropOptions<number>,
         },
@@ -234,10 +235,24 @@
                 this.questionsInFocus = [...this.questionsInFocus];
                 this.selectedQuestionValues = [...this.selectedQuestionValues];
             },
-            updateProgress(page: number, isCompleted: boolean) {
+            async updateProgress(page: number, isCompleted: boolean) {
                 if (isCompleted) {
                     this.pagesProgress.completePage(page);
                 }
+                if (this.resourceItem.resourceTypeEnum === ResourceType.CASE &&
+                    isCompleted &&
+                    page === this.pageCount - 1 &&
+                    this.resourceActivityId > 0) {
+
+                    await activityRecorder.recordCaseActivityComplete(
+                        this.resourceItem.resourceVersionId,
+                        this.resourceItem.nodePathId,
+                        this.activityStart,
+                        new Date(),
+                        this.resourceActivityId
+                    );
+                }
+
                 if (this.allPagesCompleted && this.isAssessment) {
                     this.allAssessmentInteractionsSubmitted = true;
                 }
@@ -307,7 +322,7 @@
 
                 // Only make a new activity if the latest activity is finished
                 if (typeof latest.userScore === 'number') {
-                    const result = await activityRecorder.recordActivityLaunched(this.resourceItem.resourceTypeEnum, this.resourceItem.resourceVersionId, this.resourceItem.nodePathId, new Date(), reason);
+                    const result = await activityRecorder.recordActivityLaunched(this.resourceItem.resourceTypeEnum, this.resourceItem.resourceVersionId, this.resourceItem.nodePathId, new Date() as Date, false, reason);
                     this.shuffleMatchQuestionsState();
                     await activityRecorder.recordAssessmentResourceActivity(result.createdId, this.matchQuestionsState, reason);
                 }

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/resource/ResourceContent.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/resource/ResourceContent.vue
@@ -72,7 +72,7 @@
             <div class="resource-panel-container" v-if="hasCatalogueAccess && hasCaseAssessmentAccees">
                 <div class="resource-item-row">
                     <div class="col-12 d-flex flex-column align-items-left p-0">
-                        <CaseOrAssessmentResource :resourceItem="resourceItem" :resourceActivityId="launchedResourceActivityId" :assessmentProgress="assessmentProgress" :keepUserSessionAliveIntervalSeconds="keepUserSessionAliveIntervalSeconds" />
+                        <CaseOrAssessmentResource :resourceItem="resourceItem" :resourceActivityId="launchedResourceActivityId" :activityStart="activityStart" :assessmentProgress="assessmentProgress" :keepUserSessionAliveIntervalSeconds="keepUserSessionAliveIntervalSeconds" />
                     </div>
                 </div>
             </div>
@@ -102,6 +102,7 @@
     import { MKPlayer } from '@mediakind/mkplayer';
     import { MKPlayerType, MKStreamType } from '../MKPlayerConfigEnum';
     import { MKPlayerControlbar } from '../mkioplayer-controlbar';
+    import { BlockCollectionModel } from '../models/contribute-resource/blocks/blockCollectionModel';
 
     Vue.use(Vuelidate as any);
 
@@ -122,6 +123,7 @@
                 ResourceAccessibility: ResourceAccessibility,
                 launchedResourceActivityId: 0,
                 mediaResourceActivityId: 0,
+                activityStart: null,
                 activityLogged: false,
                 activityEndLogged: false, // Applies to media only.
                 mediaResourceActivityLogged: false,
@@ -410,10 +412,16 @@
                 const userAgent = navigator.userAgent || navigator.vendor;
                 this.isIphone = /iPhone/i.test(userAgent);
             },
-            initialise(): void {
+            async initialise(): Promise<void> {
                 // record activity on page created for resource article
                 if (this.userAuthenticated && this.resourceItem.resourceTypeEnum === ResourceType.CASE) {
-                    this.recordActivityLaunched();
+                    let isMultiPageCase = false;
+                    if (this.resourceItem.resourceTypeEnum === ResourceType.CASE && this.resourceItem.caseDetails) {
+                        const blockCollection = new BlockCollectionModel(this.resourceItem.caseDetails.blockCollection);
+                        isMultiPageCase = blockCollection.getPages().length > 1;
+                    }
+
+                    await this.recordActivityLaunched(isMultiPageCase);
                 }
                 else if (this.userAuthenticated && this.resourceItem.resourceTypeEnum === ResourceType.ASSESSMENT) {
                     this.getCurrentAssessmentActivity();
@@ -456,11 +464,12 @@
             hasResourceAccess(): boolean {
                 return this.userAuthenticated && (!(this.isGeneralUser && this.resourceItem.resourceAccessibilityEnum == this.ResourceAccessibility.FullAccess))
             },
-            async recordActivityLaunched(): Promise<void> {
+            async recordActivityLaunched(isMultiPageCase: boolean = false): Promise<void> {
 
                 if (!this.activityLogged) {
                     this.activityLogged = true;
-                    await activityRecorder.recordActivityLaunched(this.resourceItem.resourceTypeEnum, this.resourceItem.resourceVersionId, this.resourceItem.nodePathId, new Date())
+                    this.activityStart = new Date();
+                    await activityRecorder.recordActivityLaunched(this.resourceItem.resourceTypeEnum, this.resourceItem.resourceVersionId, this.resourceItem.nodePathId, this.activityStart,isMultiPageCase)
                         // await activityRecorder.recordActivityLaunched(this.resourceItem.resourceVersionId, this.resourceItem.nodePathId, new Date())
                         .then(response => {
                             this.launchedResourceActivityId = response.createdId;

--- a/LearningHub.Nhs.WebUI/package-lock.json
+++ b/LearningHub.Nhs.WebUI/package-lock.json
@@ -36,7 +36,7 @@
         "vue-carousel-3d": "^1.0.1",
         "vue-clamp": "0.4.1",
         "vue-click-outside": "1.1.0",
-        "vue-ctk-date-time-picker": "^2.5.0",
+        "vue-ctk-date-time-picker": "2.5.0",
         "vue-router": "^3.6.5",
         "vue-simple-progress": "^1.1.1",
         "vue-typeahead": "^2.3.2",


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6899

### Description
Once a case resourcce is accessed, the status is changed to completed. We've added to prevent this for multipage case resource until all pages has been viewed


### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation