### PR TITLE
TD-6899-Need to remove 'elearning for healthcare' Provider filter from the LH search results

### DIFF
--- a/LearningHub.Nhs.WebUI/Views/Search/_ResourceFilter.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Search/_ResourceFilter.cshtml
@@ -4,12 +4,11 @@
 @{
     var resourceResult = Model.ResourceSearchResult;
     var filtersApplied = resourceResult.SortItemSelected.Value != string.Empty
-                            || resourceResult.SearchFilters.Any(f => f.Selected) || resourceResult.SearchResourceAccessLevelFilters.Any(f => f.Selected) 
-                            || resourceResult.SearchProviderFilters.Any(f =>f.Selected);
+                            || resourceResult.SearchFilters.Any(f => f.Selected) || resourceResult.SearchResourceAccessLevelFilters.Any(f => f.Selected);
 
     var queryParams = QueryHelpers.ParseQuery(Context.Request.QueryString.ToString().ToLower());
     queryParams["actiontype"] = "sort-filter";
-    var pageUrl = Model.CatalogueId > 0 ? "/catalogue/" + Model.CatalogueUrl +"/search" : "/search/results";
+    var pageUrl = Model.CatalogueId > 0 ? "/catalogue/" + Model.CatalogueUrl + "/search" : "/search/results";
     var actionUrl = QueryHelpers.AddQueryString(pageUrl, queryParams);
     var pageFragment = "#search-filters";
 
@@ -25,17 +24,10 @@
                             .Select(f => $"<strong class='nhsuk-tag'>{char.ToUpper(f.DisplayName[0])}{f.DisplayName[1..]}</strong>");
 
         if (resourceAccessLevelFilters.Any())
-        {   
+        {
             summary += $" and Filtered by Audience access level {string.Join(" ", resourceAccessLevelFilters)}";
         }
-        
 
-        var providerfilters = resourceResult.SearchProviderFilters.Where(f => f.Selected).Select(f => $"<strong class='nhsuk-tag'>{f.DisplayName}</strong>");
-
-        if (providerfilters.Any())
-        {
-            summary += $" and Filtered by Provider {string.Join(" ", providerfilters)}";
-        }
 
         if (filters.Any())
         {
@@ -128,38 +120,9 @@
                                         <div class="nhsuk-u-padding-left-0">
                                             <div class="nhsuk-checkboxes__item nhsuk-u-padding-bottom-3">
                                                 <input class="nhsuk-checkboxes__input" id="chk_filter_@filter.Value" name="resourceAccessLevelId" type="checkbox"
-                                                value="@filter.Value" checked="@filter.Selected" class="@(filter.Count > 0 ? "" : "disabled")">
+                                                       value="@filter.Value" checked="@filter.Selected" class="@(filter.Count > 0 ? "" : "disabled")">
                                                 <label class="nhsuk-label nhsuk-checkboxes__label" for="chk_filter_@filter.Value">
                                                     Show @filter.DisplayName (@filter.Count)
-                                                </label>
-                                            </div>
-                                        </div>
-                                    }
-                                </div>
-                            </fieldset>
-                        </div>
-                    }
-
-                    @if (resourceResult.SearchProviderFilters.Count > 0)
-                    {
-                        <hr class="nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-4" />
-
-                        <div class="nhsuk-grid-row">
-                            <fieldset class="nhsuk-grid-column-full">
-                                <legend>
-                                    <h2>Filter by provider:</h2>
-                                </legend>
-
-                                <div class="nhsuk-checkboxes">
-                                    @foreach (var filter in resourceResult.SearchProviderFilters)
-                                    {
-                                        <div class="nhsuk-grid-column-one-third nhsuk-u-padding-left-0">
-
-                                            <div class="nhsuk-checkboxes__item nhsuk-u-padding-bottom-3">
-                                                <input class="nhsuk-checkboxes__input" id="chk_provider_filter_@filter.Value" name="providerfilters" type="checkbox"
-                                                value="@filter.Value" checked="@filter.Selected" class="@(filter.Count > 0 ? "" : "disabled")">
-                                                <label class="nhsuk-label nhsuk-checkboxes__label" for="chk_provider_filter_@filter.Value">
-                                                    @filter.DisplayName (@filter.Count)
                                                 </label>
                                             </div>
                                         </div>

--- a/LearningHub.Nhs.WebUI/Views/Search/_SearchFilter.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Search/_SearchFilter.cshtml
@@ -4,8 +4,7 @@
 @{
     var resourceResult = Model.ResourceSearchResult;
     var filtersApplied = resourceResult.SortItemSelected.Value != string.Empty
-                            || resourceResult.SearchFilters.Any(f => f.Selected) || resourceResult.SearchResourceAccessLevelFilters.Any(f => f.Selected)
-                            || resourceResult.SearchProviderFilters.Any(f => f.Selected);
+                            || resourceResult.SearchFilters.Any(f => f.Selected) || resourceResult.SearchResourceAccessLevelFilters.Any(f => f.Selected);
 
     var queryParams = QueryHelpers.ParseQuery(Context.Request.QueryString.ToString().ToLower());
     queryParams["actiontype"] = "sort-filter";
@@ -27,14 +26,6 @@
         if (resourceAccessLevelFilters.Any())
         {
             summary += $" and Filtered by Audience access level {string.Join(" ", resourceAccessLevelFilters)}";
-        }
-
-
-        var providerfilters = resourceResult.SearchProviderFilters.Where(f => f.Selected).Select(f => $"<strong class='nhsuk-tag'>{f.DisplayName}</strong>");
-
-        if (providerfilters.Any())
-        {
-            summary += $" and Filtered by Provider {string.Join(" ", providerfilters)}";
         }
 
         if (filters.Any())
@@ -73,12 +64,12 @@
 
                     <div class="nhsuk-checkboxes">
                         @foreach (var option in new[]
-                                            {
-                                        new { Id = "all",       Label = "All" },
-                                        new { Id = "catalogue", Label = "Catalogues" },
-                                        new { Id = "course",    Label = "Courses" },
-                                        new { Id = "resource",  Label = "Learning Resources" }
-                                        })
+                       {
+                    new { Id = "all",       Label = "All" },
+                    new { Id = "catalogue", Label = "Catalogues" },
+                    new { Id = "course",    Label = "Courses" },
+                    new { Id = "resource",  Label = "Learning Resources" }
+                    })
                         {
                             // Look up count from your real model
                             var filter = Model.ResourceCollectionFilter
@@ -95,7 +86,7 @@
                                            type="checkbox"
                                            value="@option.Id"
                                            checked="@(selectedResourceCollections.Contains(option.Id))"
-                                           @(count == 0 ? "disabled" : "")
+                                    @(count == 0 ? "disabled" : "")
                                            onchange="this.form.submit()" />
 
                                     <label class="nhsuk-label nhsuk-checkboxes__label"
@@ -189,35 +180,6 @@
                                                        value="@filter.Value" checked="@filter.Selected" class="@(filter.Count > 0 ? "" : "disabled")">
                                                 <label class="nhsuk-label nhsuk-checkboxes__label" for="chk_filter_@filter.Value">
                                                     Show @filter.DisplayName (@filter.Count)
-                                                </label>
-                                            </div>
-                                        </div>
-                                    }
-                                </div>
-                            </fieldset>
-                        </div>
-                    }
-
-                    @if (resourceResult.SearchProviderFilters.Count > 0)
-                    {
-                        <hr class="nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-4" />
-
-                        <div class="nhsuk-grid-row">
-                            <fieldset class="nhsuk-grid-column-full">
-                                <legend>
-                                    <h2>Filter by provider:</h2>
-                                </legend>
-
-                                <div class="nhsuk-checkboxes">
-                                    @foreach (var filter in resourceResult.SearchProviderFilters)
-                                    {
-                                        <div class="nhsuk-grid-column-one-third nhsuk-u-padding-left-0">
-
-                                            <div class="nhsuk-checkboxes__item nhsuk-u-padding-bottom-3">
-                                                <input class="nhsuk-checkboxes__input" id="chk_provider_filter_@filter.Value" name="providerfilters" type="checkbox"
-                                                       value="@filter.Value" checked="@filter.Selected" class="@(filter.Count > 0 ? "" : "disabled")">
-                                                <label class="nhsuk-label nhsuk-checkboxes__label" for="chk_provider_filter_@filter.Value">
-                                                    @filter.DisplayName (@filter.Count)
                                                 </label>
                                             </div>
                                         </div>


### PR DESCRIPTION
### JIRA link
TD-6899

### Description
removed provider by filter from search-
### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._
<img width="1213" height="662" alt="Test234555" src="https://github.com/user-attachments/assets/fec4974f-8afd-4cc6-abfd-4913d99fc12e" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [X] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [X] Confirmed that none of the work that I have undertaken requires any updates to documentation