### PR TITLE
TD-6923: Fixed console error during auto suggestion search results

### DIFF
--- a/LearningHub.Nhs.WebUI/Views/Search/_SearchBar.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Search/_SearchBar.cshtml
@@ -67,6 +67,12 @@
                         }
                     }
                 });
+
+                searchInput.addEventListener("focus", function () {
+                currentIndex = -1;
+                });
+                searchInput.addEventListener("keydown", handleArrowKeys);
+                suggestionsList.addEventListener("keydown", handleArrowKeys);
             }
         }
 
@@ -100,12 +106,6 @@
                 break;
                }
             }
-
-        searchInput.addEventListener("focus", function () {
-            currentIndex = -1;
-        });
-        searchInput.addEventListener("keydown", handleArrowKeys);
-        suggestionsList.addEventListener("keydown", handleArrowKeys);
 
         function closeAllLists() {
             suggestionsList.innerHTML = '';

--- a/LearningHub.Nhs.WebUI/Views/Shared/Components/NavigationItems/Searchbar.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Shared/Components/NavigationItems/Searchbar.cshtml
@@ -91,6 +91,12 @@
                         }
                     }
                 });
+
+                searchInput.addEventListener("focus", function () {
+                currentIndex = -1;
+                });
+                searchInput.addEventListener("keydown", handleArrowKeys);
+                suggestionsList.addEventListener("keydown", handleArrowKeys);
             }
         }
 
@@ -124,12 +130,6 @@
                 break;
                }
             }
-
-        searchInput.addEventListener("focus", function () {
-            currentIndex = -1;
-        });
-        searchInput.addEventListener("keydown", handleArrowKeys);
-        suggestionsList.addEventListener("keydown", handleArrowKeys);
 
         function closeAllLists() {
             suggestionsList.innerHTML = '';


### PR DESCRIPTION
### JIRA link
[TD-6923](https://hee-tis.atlassian.net/browse/TD-6923)

### Description
Fixed console error during auto suggestion search results

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-6923]: https://hee-tis.atlassian.net/browse/TD-6923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ