### PR TITLE
Develop/fixes/td 6937 fix filter audience access level

### DIFF
--- a/LearningHub.Nhs.WebUI/Helpers/UtilityHelper.cs
+++ b/LearningHub.Nhs.WebUI/Helpers/UtilityHelper.cs
@@ -386,6 +386,51 @@
         }
 
         /// <summary>
+        /// Formats an authored date string into a human-readable date if possible.
+        /// </summary>
+        /// <remarks>If the input does not match any of the supported date formats, the method returns the
+        /// original input string unchanged. This method does not validate whether the date is a valid calendar date
+        /// beyond format matching.</remarks>
+        /// <param name="authoredDate">The date string to format. Must be in one of the supported date formats, such as "yyyy-MM-dd", "dd/MM/yyyy",
+        /// "MM/dd/yyyy", "yyyyMMdd", "yyyy-MM-ddTHH:mm:ss", or "yyyy-MM-ddTHH:mm:ssZ". If null, empty, or whitespace,
+        /// an empty string is returned.</param>
+        /// <returns>A formatted date string in the form "dd MMM yyyy" if parsing succeeds; otherwise, the original input string
+        /// or an empty string if the input is null, empty, or whitespace.</returns>
+        public static string GetFormattedAuthoredDate(string authoredDate)
+        {
+            string[] dateFormats =
+            {
+                "dd/MM/yyyy",
+                "dd/MM/yyyy HH:mm:ss",
+                "yyyy-MM-dd",
+                "yyyy-MM-dd HH:mm:ss",
+                "MM/dd/yyyy",
+                "MM/dd/yyyy HH:mm:ss",
+                "yyyyMMdd",
+                "yyyyMMdd HH:mm:ss",
+            };
+
+            if (string.IsNullOrWhiteSpace(authoredDate))
+            {
+                return string.Empty;
+            }
+
+            string displayDate = authoredDate;
+
+            if (DateTime.TryParseExact(
+                    authoredDate,
+                    dateFormats,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.None,
+                    out DateTime parsedDate))
+            {
+                displayDate = parsedDate.ToString("dd MMM yyyy");
+            }
+
+            return displayDate;
+        }
+
+        /// <summary>
         /// Gets the text to display on a generic file download button according to the file extension.
         /// </summary>
         /// <param name="extension">The file extension.</param>

--- a/LearningHub.Nhs.WebUI/Views/Search/_SearchResult.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Search/_SearchResult.cshtml
@@ -139,10 +139,29 @@
 
                 <div>
                     @UtilityHelper.GetAttribution(item.Authors)
-                    @if (!string.IsNullOrEmpty(item.AuthoredDate))
+
+                    @if (!string.IsNullOrWhiteSpace(item.AuthoredDate))
                     {
-                        @UtilityHelper.GetInOn(item.AuthoredDate)
-                        @: @item.AuthoredDate
+                        string displayDate = item.AuthoredDate;
+                        {
+                            // Define expected input formats
+                            string[] formats = { "dd/MM/yyyy HH:mm:ss", "dd/MM/yyyy", "yyyy-MM-dd HH:mm:ss",
+                                                    "yyyy-MM-dd","dd MMM yyyy HH:mm:ss","dd MMM yyyy" };
+
+                            if (DateTime.TryParseExact(
+                                item.AuthoredDate,
+                                formats,
+                                System.Globalization.CultureInfo.InvariantCulture,
+                                System.Globalization.DateTimeStyles.None,
+                                out DateTime parsedDate))
+                            {
+                                displayDate = parsedDate.ToString("dd MMM yyyy"); // consistent format
+                            }
+                        }
+
+                        @* Render helper text plus formatted date *@
+                        @UtilityHelper.GetInOn(displayDate)
+                        @: @displayDate
                     }
                 </div>
             </div>

--- a/LearningHub.Nhs.WebUI/Views/Search/_SearchResult.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Search/_SearchResult.cshtml
@@ -144,22 +144,10 @@
 
                     @if (!string.IsNullOrWhiteSpace(item.AuthoredDate))
                     {
-                        string displayDate = item.AuthoredDate;
-                        {
-                            if (DateTime.TryParseExact(
-                                item.AuthoredDate,
-                                formats,
-                                System.Globalization.CultureInfo.InvariantCulture,
-                                System.Globalization.DateTimeStyles.None,
-                                out DateTime parsedDate))
-                            {
-                                displayDate = parsedDate.ToString("dd MMM yyyy"); // consistent format
-                            }
-                        }
-
+                        string formattedAuthoredDate = @UtilityHelper.GetFormattedAuthoredDate(item.AuthoredDate);
                         @* Render helper text plus formatted date *@
-                        @UtilityHelper.GetInOn(displayDate)
-                        @: @displayDate
+                        @UtilityHelper.GetInOn(formattedAuthoredDate)
+                        @: @formattedAuthoredDate
                     }
                 </div>
             </div>

--- a/LearningHub.Nhs.WebUI/Views/Search/_SearchResult.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Search/_SearchResult.cshtml
@@ -16,6 +16,8 @@
     var index = pagingModel.CurrentPage * pagingModel.PageSize;
     var searchString = HttpUtility.UrlEncode(Model.SearchString);
     string groupId = HttpUtility.UrlEncode(Model.GroupId.ToString());
+    string[] formats = { "dd/MM/yyyy HH:mm:ss", "dd/MM/yyyy", "yyyy-MM-dd HH:mm:ss",
+                                                    "yyyy-MM-dd","dd MMM yyyy HH:mm:ss","dd MMM yyyy" };
 
     string GetUrl(int resourceReferenceId, int itemIndex, int nodePathId, SearchClickPayloadModel payload)
     {
@@ -144,10 +146,6 @@
                     {
                         string displayDate = item.AuthoredDate;
                         {
-                            // Define expected input formats
-                            string[] formats = { "dd/MM/yyyy HH:mm:ss", "dd/MM/yyyy", "yyyy-MM-dd HH:mm:ss",
-                                                    "yyyy-MM-dd","dd MMM yyyy HH:mm:ss","dd MMM yyyy" };
-
                             if (DateTime.TryParseExact(
                                 item.AuthoredDate,
                                 formats,

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Models/LearningHub.Nhs.OpenApi.Models.csproj
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Models/LearningHub.Nhs.OpenApi.Models.csproj
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Azure.Search.Documents" Version="11.6.0" />
+		<PackageReference Include="Azure.Search.Documents" Version="11.7.0" />
 		<PackageReference Include="LearningHub.Nhs.Models" Version="4.0.12" />
 		<PackageReference Include="NLog.Web.AspNetCore" Version="4.15.0" />
 	</ItemGroup>

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Models/ServiceModels/AzureSearch/SearchDocument.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Models/ServiceModels/AzureSearch/SearchDocument.cs
@@ -94,6 +94,12 @@ namespace LearningHub.Nhs.OpenApi.Models.ServiceModels.AzureSearch
         public string? ResourceType { get; set; } = string.Empty;
 
         /// <summary>
+        /// Gets or sets the resource access level.
+        /// </summary>
+        [JsonPropertyName("resource_access_level")]
+        public string? ResourceAccessLevel { get; set; } = string.Empty;
+        
+        /// <summary>
         /// Gets or sets the date authored.
         /// </summary>
         [JsonPropertyName("date_authored")]

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Models/ServiceModels/AzureSearch/SearchDocument.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Models/ServiceModels/AzureSearch/SearchDocument.cs
@@ -97,7 +97,7 @@ namespace LearningHub.Nhs.OpenApi.Models.ServiceModels.AzureSearch
         /// Gets or sets the resource access level.
         /// </summary>
         [JsonPropertyName("resource_access_level")]
-        public int? ResourceAccessLevel { get; set; }
+        public string? ResourceAccessLevel { get; set; }
         
         /// <summary>
         /// Gets or sets the date authored.

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Models/ServiceModels/AzureSearch/SearchDocument.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Models/ServiceModels/AzureSearch/SearchDocument.cs
@@ -97,7 +97,7 @@ namespace LearningHub.Nhs.OpenApi.Models.ServiceModels.AzureSearch
         /// Gets or sets the resource access level.
         /// </summary>
         [JsonPropertyName("resource_access_level")]
-        public string? ResourceAccessLevel { get; set; } = string.Empty;
+        public int? ResourceAccessLevel { get; set; }
         
         /// <summary>
         /// Gets or sets the date authored.

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Services/Helpers/Search/SearchFilterBuilder.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Services/Helpers/Search/SearchFilterBuilder.cs
@@ -11,7 +11,7 @@
     public static class SearchFilterBuilder
     {
 
-        public static Dictionary<string, List<string>> CombineAndNormaliseFilters(string requestTypeFilterText, string? providerFilterText)
+        public static Dictionary<string, List<string>> CombineAndNormaliseFilters(string requestTypeFilterText, string? providerFilterText, string? resourceAccessLevelFilterText)
         {
             var filters = new Dictionary<string, List<string>>
             {
@@ -21,10 +21,12 @@
             // Parse and merge additional filters from query string
             var requestTypeFilters = ParseQueryStringFilters(requestTypeFilterText);
             var providerFilters = ParseQueryStringFilters(providerFilterText);
+            var resourceAccessLevelFilters = ParseQueryStringFilters(resourceAccessLevelFilterText);
 
             // Merge filters from both sources
             MergeFilterDictionary(filters, requestTypeFilters);
             MergeFilterDictionary(filters, providerFilters);
+            MergeFilterDictionary(filters, resourceAccessLevelFilters);
 
             //NormaliseFilters(filters);
 

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Services/LearningHub.Nhs.OpenApi.Services.csproj
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Services/LearningHub.Nhs.OpenApi.Services.csproj
@@ -23,7 +23,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Azure.Search.Documents" Version="11.6.0" />
+		<PackageReference Include="Azure.Search.Documents" Version="11.7.0" />
 		<PackageReference Include="Azure.Storage.Queues" Version="12.11.0" />
 		<PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
 		<PackageReference Include="IdentityModel" Version="4.6.0" />

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Services/Services/AzureSearch/AzureSearchService.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Services/Services/AzureSearch/AzureSearchService.cs
@@ -891,24 +891,6 @@
             return facets ?? new Dictionary<string, IList<FacetResult>>();
         }
 
-        private static int? ExtractResourceAccessLevel(IDictionary<string, IList<FacetResult>> facets)
-        {
-            if (facets == null)
-                return null;
-
-            if (!facets.TryGetValue("resource_access_level", out var accessFacet))
-                return null;
-
-            if (accessFacet == null || accessFacet.Count == 0)
-                return null;
-
-            var rawValue = accessFacet.FirstOrDefault()?.Value;
-
-            var stringValue = rawValue?.ToString();
-
-            return int.TryParse(stringValue, out var parsed) ? parsed : (int?)null;
-        }
-
         private ResourceMetadataViewModel MapToViewModel(Resource resource, List<ResourceActivityDTO> resourceActivities)
         {
             var hasCurrentResourceVersion = resource.CurrentResourceVersion != null;

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Services/Services/AzureSearch/AzureSearchService.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Services/Services/AzureSearch/AzureSearchService.cs
@@ -860,7 +860,7 @@
         /// </summary>
         /// <param name="searchText">The search text.</param>
         /// <param name="facets">The facet results.</param>
-        /// <param name="resourceAccessLevel">The resource access level filter, if any, used to further differentiate cache entries.</param>
+        /// <param name="resourceAccessLevel">The resource access level filter, if any, used to further differentiate cache entries. </param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The unfiltered facet results.</returns>
         private async Task<IDictionary<string, IList<FacetResult>>> GetUnfilteredFacetsAsync(

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Services/Services/AzureSearch/AzureSearchService.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Services/Services/AzureSearch/AzureSearchService.cs
@@ -184,6 +184,7 @@
                 var unfilteredFacets = await GetUnfilteredFacetsAsync(
                    searchRequestModel.SearchText,
                    filteredResponse.Facets,
+                   searchRequestModel.ResourceAccessLevelFilterText,
                    cancellationToken);
 
                 // Merge facets from filtered and unfiltered results
@@ -859,14 +860,19 @@
         /// </summary>
         /// <param name="searchText">The search text.</param>
         /// <param name="facets">The facet results.</param>
+        /// <param name="resourceAccessLevel">The resource access level filter, if any, used to further differentiate cache entries.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The unfiltered facet results.</returns>
         private async Task<IDictionary<string, IList<FacetResult>>> GetUnfilteredFacetsAsync(
             string searchText,
             IDictionary<string, IList<FacetResult>> facets,
+            string? resourceAccessLevel, 
             CancellationToken cancellationToken)
         {
-            var cacheKey = $"AllFacets_{searchText?.ToLowerInvariant() ?? "*"}";
+            var normalizedSearch = searchText?.ToLowerInvariant() ?? "*";
+            var accessLevelKey = resourceAccessLevel?.ToString() ?? "null";
+            var cacheKey = $"AllFacets_{normalizedSearch}_ral_{accessLevelKey}";
+
             var cacheResponse = await this.cachingService.GetAsync<IDictionary<string, IList<CacheableFacetResult>>>(cacheKey);
 
             if (cacheResponse.ResponseEnum == CacheReadResponseEnum.Found)
@@ -883,6 +889,24 @@
             }
 
             return facets ?? new Dictionary<string, IList<FacetResult>>();
+        }
+
+        private static int? ExtractResourceAccessLevel(IDictionary<string, IList<FacetResult>> facets)
+        {
+            if (facets == null)
+                return null;
+
+            if (!facets.TryGetValue("resource_access_level", out var accessFacet))
+                return null;
+
+            if (accessFacet == null || accessFacet.Count == 0)
+                return null;
+
+            var rawValue = accessFacet.FirstOrDefault()?.Value;
+
+            var stringValue = rawValue?.ToString();
+
+            return int.TryParse(stringValue, out var parsed) ? parsed : (int?)null;
         }
 
         private ResourceMetadataViewModel MapToViewModel(Resource resource, List<ResourceActivityDTO> resourceActivities)

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Services/Services/AzureSearch/AzureSearchService.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Services/Services/AzureSearch/AzureSearchService.cs
@@ -120,7 +120,7 @@
                 }
 
                 // Normalize resource_type filter values
-                var filters = SearchFilterBuilder.CombineAndNormaliseFilters(searchRequestModel.FilterText, searchRequestModel.ProviderFilterText);
+                var filters = SearchFilterBuilder.CombineAndNormaliseFilters(searchRequestModel.FilterText, searchRequestModel.ProviderFilterText, searchRequestModel.ResourceAccessLevelFilterText);
 
                 if (searchRequestModel.CatalogueId.HasValue)
                 {
@@ -157,6 +157,7 @@
                                         ?? new List<int>()
                                     ),
                             Rating = Convert.ToDecimal(doc.Rating),
+                            ResourceAccessLevel = Convert.ToInt32(doc.ResourceAccessLevel),
                             Author = doc.Author,
                             Authors = doc.Author?.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(a => a.Trim()).ToList(),
                             AuthoredDate = doc.DateAuthored?.ToString(),


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6937

### Description
There is an issue seeing on ‘General user account’ when applied ‘Audience access level’ in combination with ‘resource’ filter after ‘Searching’ with any keyword. And also fixed the inconsistent date time issue in search page

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation