### PR TITLE
TD-6914:fixed  the alignment of Catalogue tag showing on 'Catalogue' …

### DIFF
--- a/LearningHub.Nhs.WebUI/Styles/nhsuk/layout.scss
+++ b/LearningHub.Nhs.WebUI/Styles/nhsuk/layout.scss
@@ -338,7 +338,17 @@ li.autosuggestion-option:last-of-type {
 }
 
 
-
+.search-catalogue-badge {
+    position: absolute;
+    top: 0;
+    right: 0;
+    background-color: #0056b3;
+    color: white;
+    padding: 5px 15px;
+    border-top-right-radius: 8px;
+    border-bottom-left-radius: 8px;
+    font-size: 0.8em;
+}
 
 .side-nav__item:last-child {
     border-bottom: none;

--- a/LearningHub.Nhs.WebUI/Views/Search/_SearchCatalogueResult.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Search/_SearchCatalogueResult.cshtml
@@ -24,30 +24,13 @@
 &query={searchSignalQueryEncoded}&name={payload?.DocumentFields?.Name}";
         return url;
     }
-    //     var catalogueResult = Model.ResourceSearchResult;
-    //     var pagingModel = Model.CatalogueResultPaging;
-    //     var searchString = HttpUtility.UrlEncode(Model.SearchString);
-    //     var suggestedSearchString = Model.DidYouMeanEnabled ? HttpUtility.UrlEncode(Model.SuggestedCatalogue) : HttpUtility.UrlEncode(Model.SearchString);
-
-    //     string GetCatalogueUrl(string catalogueUrl, int? nodePathId, int itemIndex, int catalogueId, SearchClickPayloadModel payload)
-    //     {
-    //         var searchSignal = payload?.SearchSignal;
-    //         string encodedCatalogueUrl = HttpUtility.UrlEncode("/Catalogue/" + catalogueUrl);
-    //         string groupId = HttpUtility.UrlEncode(Model.GroupId.ToString());
-    //         string searchSignalQueryEncoded = HttpUtility.UrlEncode(HttpUtility.UrlDecode(searchSignal?.Query));
-
-    //         var url = $@"/search/record-catalogue-click?url={encodedCatalogueUrl}&nodePathId={nodePathId}&itemIndex={payload?.HitNumber}
-    // &pageIndex={pagingModel.CurrentPage}&totalNumberOfHits={payload?.SearchSignal?.Stats?.TotalHits}&searchText={suggestedSearchString}&catalogueId={catalogueId}
-    // &GroupId={groupId}&searchId={searchSignal?.SearchId}&timeOfSearch={searchSignal?.TimeOfSearch}&userQuery={HttpUtility.UrlEncode(searchSignal?.UserQuery)}
-    // &query={searchSignalQueryEncoded}&name={payload?.DocumentFields?.Name}";
-    //         return url;
 }
 
 <div class="resource-item nhsuk-card nhsuk-card--clickable nhsuk-u-margin-bottom-4">
 
-    <div class="nhsuk-card__content" style="padding: 10px;">
+    <div class="nhsuk-card__content nhsuk-u-padding-bottom-2 nhsuk-u-padding-left-2 nhsuk-u-padding-right-2">
 
-        <div style="position: absolute; top: 0; right: 0; background-color: #0056b3; color: white; padding: 5px 15px; border-top-right-radius: 8px; border-bottom-left-radius: 8px; font-size: 0.8em;"> Catalogue </div>
+        <div class="search-catalogue-badge"> Catalogue </div>
 
         <h3 class="nhsuk-heading-xs nhsuk-u-margin-bottom-2">
             <a class="nhsuk-card__link" href="@GetUrl(item.CatalogueUrl, item.NodePathId ?? 0, 0, Convert.ToInt32(item.Id), item.Click.Payload)">@item.Title</a>


### PR DESCRIPTION
…search results # Removed and replaced inline styles with nhsuk design system

### JIRA link
[TD-6914](https://hee-tis.atlassian.net/browse/TD-6914)

### Description
Fixed the Issue with the alignment of Catalogue tag showing on 'Catalogue' search results
Removed the commented lines
removed inline styles and replaced styles with nhsuk design system styles

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._
<img width="776" height="507" alt="image" src="https://github.com/user-attachments/assets/22f78ac0-b5d7-4f6b-b8a5-6707ff880c52" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-6914]: https://hee-tis.atlassian.net/browse/TD-6914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ