### PR TITLE
Fixed the issue with filter combos

### DIFF
--- a/LearningHub.Nhs.WebUI/Helpers/UtilityHelper.cs
+++ b/LearningHub.Nhs.WebUI/Helpers/UtilityHelper.cs
@@ -408,6 +408,9 @@
                 "MM/dd/yyyy HH:mm:ss",
                 "yyyyMMdd",
                 "yyyyMMdd HH:mm:ss",
+                "M/d/yyyy",
+                "M/d/yyyy h:mm:ss tt",
+                "M/d/yyyy h:mm tt",
             };
 
             if (string.IsNullOrWhiteSpace(authoredDate))
@@ -415,19 +418,13 @@
                 return string.Empty;
             }
 
-            string displayDate = authoredDate;
-
-            if (DateTime.TryParseExact(
-                    authoredDate,
-                    dateFormats,
-                    CultureInfo.InvariantCulture,
-                    DateTimeStyles.None,
-                    out DateTime parsedDate))
+            if (DateTime.TryParse(authoredDate, CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, out var date) ||
+                DateTime.TryParseExact(authoredDate, dateFormats, CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces, out date))
             {
-                displayDate = parsedDate.ToString("dd MMM yyyy");
+                return date.ToString("dd MMM yyyy");
             }
 
-            return displayDate;
+            return authoredDate;
         }
 
         /// <summary>

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Services/Helpers/Search/AzureSearchFacetHelper.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Services/Helpers/Search/AzureSearchFacetHelper.cs
@@ -115,26 +115,54 @@ namespace LearningHub.Nhs.OpenApi.Services.Helpers.Search
                     ? filteredFacets[facetKey].ToDictionary(f => f.Value?.ToString()?.ToLower() ?? "", f => (int)f.Count)
                     : new Dictionary<string, int>();
 
+                var filters = facetGroup.Value.Select(f =>
+                {
+                    var displayName = f.Value?.ToString()?.ToLower() ?? "";
+                    var isSelected = appliedValues.Any(av => av.Equals(f.Value?.ToString(), StringComparison.OrdinalIgnoreCase));
+
+                    // Default to the unfiltered count. This is used when:
+                    //  - no filtered search has been performed, OR
+                    //  - the filter value is selected (keep count so the option remains visible for deselection), OR
+                    //  - this facet group itself has an applied filter (multi-select pattern: a group's own
+                    //    counts are not narrowed down by its own selections so the user can still pick other values).
+                    // Only update counts using the filtered results when a filter from a DIFFERENT group
+                    // is driving the narrowing of this group.
+                    var count = (int)f.Count;
+                    if (!isSelected && filteredFacets != null && !hasAppliedFilter)
+                    {
+                        count = filteredFacetValues.TryGetValue(displayName, out var filteredCount) ? filteredCount : 0;
+                    }
+
+                    return new Filter
+                    {
+                        DisplayName = displayName,
+                        Count = count,
+                        Selected = isSelected
+                    };
+                }).ToList();
+
+                // Ensure all selected filter values remain visible even if absent from the unfiltered
+                // baseline (e.g. a resource selected under a resource-level filter that yields no results).
+                foreach (var selectedValue in appliedValues)
+                {
+                    var alreadyPresent = filters.Any(f =>
+                        f.DisplayName.Equals(selectedValue, StringComparison.OrdinalIgnoreCase));
+
+                    if (!alreadyPresent)
+                    {
+                        filters.Add(new Filter
+                        {
+                            DisplayName = selectedValue.ToLower(),
+                            Count = 0,
+                            Selected = true,
+                        });
+                    }
+                }
+
                 facets[index++] = new Facet
                 {
                     Id = facetKey,
-                    Filters = facetGroup.Value.Select(f =>
-                    {
-                        var displayName = f.Value?.ToString()?.ToLower() ?? "";
-                        var isSelected = appliedValues.Any(av => av.Equals(f.Value?.ToString(), StringComparison.OrdinalIgnoreCase));
-
-                        // Use filtered count if available and filter is not selected, otherwise use unfiltered count
-                        var count = !isSelected && filteredFacetValues.ContainsKey(displayName)
-                            ? filteredFacetValues[displayName]
-                            : (int)f.Count;
-
-                        return new Filter
-                        {
-                            DisplayName = displayName,
-                            Count = count,
-                            Selected = isSelected
-                        };
-                    }).ToArray()
+                    Filters = filters.ToArray()
                 };
             }
 

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Services/Services/AzureSearch/AzureSearchService.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Services/Services/AzureSearch/AzureSearchService.cs
@@ -866,12 +866,14 @@
         private async Task<IDictionary<string, IList<FacetResult>>> GetUnfilteredFacetsAsync(
             string searchText,
             IDictionary<string, IList<FacetResult>> facets,
-            string? resourceAccessLevel, 
+            string? resourceAccessLevel,
             CancellationToken cancellationToken)
         {
             var normalizedSearch = searchText?.ToLowerInvariant() ?? "*";
             var accessLevelKey = resourceAccessLevel?.ToString() ?? "null";
-            var cacheKey = $"AllFacets_{normalizedSearch}_ral_{accessLevelKey}";
+            var cacheKey = $"Facets_{normalizedSearch}";
+            if (!string.IsNullOrWhiteSpace(accessLevelKey))
+                cacheKey += $"_{accessLevelKey.Replace("=", "_")}";
 
             var cacheResponse = await this.cachingService.GetAsync<IDictionary<string, IList<CacheableFacetResult>>>(cacheKey);
 


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-6937

### Description
The is an issue  has been fixed on ‘General user account’ when applied ‘Audience access level’ in combination with ‘resource’ filter after ‘Searching’ with any keyword.

Fix has been implemented to display authored date in consistent format dd MMM yyyy

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation