### PR TITLE
TD-6612: Integrated Roadmap API into WebUI

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/JiraRoadmapController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/JiraRoadmapController.cs
@@ -1,0 +1,50 @@
+﻿namespace LearningHub.Nhs.WebUI.Controllers
+{
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using LearningHub.Nhs.WebUI.Configuration;
+    using LearningHub.Nhs.WebUI.Interfaces;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Options;
+
+    /// <summary>
+    /// Defines the <see cref="JiraRoadmapController"/>.
+    /// </summary>
+    public class JiraRoadmapController : BaseController
+    {
+        private readonly IJiraRoadmapService jiraRoadmapService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JiraRoadmapController"/> class.
+        /// </summary>
+        /// <param name="hostingEnvironment">hostingEnvironment.</param>
+        /// <param name="logger">logger.</param>
+        /// <param name="settings">settings.</param>
+        /// <param name="httpClientFactory">httpClientFactory.</param>
+        /// <param name="jiraRoadmapService">jiraRoadmapService.</param>
+        public JiraRoadmapController(
+            IWebHostEnvironment hostingEnvironment,
+            ILogger<ResourceController> logger,
+            IOptions<Settings> settings,
+            IHttpClientFactory httpClientFactory,
+            IJiraRoadmapService jiraRoadmapService)
+            : base(hostingEnvironment, httpClientFactory, logger, settings.Value)
+        {
+            this.jiraRoadmapService = jiraRoadmapService;
+        }
+
+        /// <summary>
+        /// Returns public roadmap issues (data only endpoint for WebUI).
+        /// </summary>
+        /// <returns>The <see cref="Task{IActionResult}"/>.</returns>
+        [HttpGet]
+        [Route("getRoadmapIssues")]
+        public async Task<IActionResult> GetRoadmapIssues()
+        {
+            var roadmapResponse = await this.jiraRoadmapService.GetPublicRoadmapIssues();
+            return this.Json(roadmapResponse);
+        }
+     }
+}

--- a/LearningHub.Nhs.WebUI/Interfaces/IJiraRoadmapService.cs
+++ b/LearningHub.Nhs.WebUI/Interfaces/IJiraRoadmapService.cs
@@ -1,0 +1,18 @@
+﻿namespace LearningHub.Nhs.WebUI.Interfaces
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using LearningHub.Nhs.Models.JiraRoadmap;
+
+    /// <summary>
+    /// Defines the <see cref="IJiraRoadmapService" />.
+    /// </summary>
+    public interface IJiraRoadmapService
+    {
+        /// <summary>
+        /// Gets public roadmap issues from Jira Open API.
+        /// </summary>
+        /// <returns>The <see cref="Task"/>.</returns>
+        Task<RoadmapResponseDto> GetPublicRoadmapIssues();
+    }
+}

--- a/LearningHub.Nhs.WebUI/Services/JiraRoadmapService.cs
+++ b/LearningHub.Nhs.WebUI/Services/JiraRoadmapService.cs
@@ -1,0 +1,52 @@
+﻿namespace LearningHub.Nhs.WebUI.Services
+{
+    using System;
+    using System.Threading.Tasks;
+    using LearningHub.Nhs.Models.JiraRoadmap;
+    using LearningHub.Nhs.WebUI.Interfaces;
+    using Microsoft.Extensions.Logging;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Defines the <see cref="JiraRoadmapService" />.
+    /// </summary>
+    public class JiraRoadmapService : BaseService<JiraRoadmapService>, IJiraRoadmapService
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="JiraRoadmapService"/> class.
+        /// </summary>
+        /// <param name="learningHubHttpClient">The learningHubHttpClient<see cref="ILearningHubHttpClient"/>.</param>
+        /// <param name="openApiHttpClient">The openApiHttpClient<see cref="IOpenApiHttpClient"/>.</param>
+        /// <param name="logger">The logger<see cref="ILogger{JiraRoadmapService}"/>.</param>
+        public JiraRoadmapService(
+            ILearningHubHttpClient learningHubHttpClient,
+            IOpenApiHttpClient openApiHttpClient,
+            ILogger<JiraRoadmapService> logger)
+            : base(learningHubHttpClient, openApiHttpClient, logger)
+        {
+        }
+
+        /// <inheritdoc />
+        public async Task<RoadmapResponseDto> GetPublicRoadmapIssues()
+        {
+            var client = await this.OpenApiHttpClient.GetClientAsync();
+            var request = "JiraRoadmap/GetRoadmapIssues";
+            var response = await client.GetAsync(request).ConfigureAwait(false);
+            if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized
+                        ||
+                     response.StatusCode == System.Net.HttpStatusCode.Forbidden)
+            {
+                throw new Exception("AccessDenied");
+            }
+
+            RoadmapResponseDto roadmapResponse = new RoadmapResponseDto();
+            if (response.IsSuccessStatusCode)
+            {
+                var result = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                roadmapResponse = JsonConvert.DeserializeObject<RoadmapResponseDto>(result);
+            }
+
+            return roadmapResponse;
+        }
+    }
+}

--- a/LearningHub.Nhs.WebUI/Startup/ServiceMappings.cs
+++ b/LearningHub.Nhs.WebUI/Startup/ServiceMappings.cs
@@ -115,6 +115,7 @@
             services.AddSingleton<IJsDetectionLogger, JsDetectionLogger>();
             services.AddScoped<IInternalSystemService, InternalSystemService>();
             services.AddScoped<IProviderService, ProviderService>();
+            services.AddScoped<IJiraRoadmapService, JiraRoadmapService>();
 
             // Filters (that require DI)
             services.AddScoped<LoginWizardFilter>();


### PR DESCRIPTION
### JIRA link
[TD-6612](https://hee-tis.atlassian.net/browse/TD-6612)

### Description
_Created controller and service classes for integrating the Roadmap API._

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-6612]: https://hee-tis.atlassian.net/browse/TD-6612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ