### PR TITLE
Enable automatic detection of views coming from nuget packagees

### DIFF
--- a/LearningHub.Nhs.WebUI/Program.cs
+++ b/LearningHub.Nhs.WebUI/Program.cs
@@ -1,14 +1,17 @@
 ﻿#pragma warning disable SA1200 // Using directives should be placed correctly
 using System;
 using System.Diagnostics;
+using System.Linq;
 using LearningHub.Nhs.WebUI;
 using LearningHub.Nhs.WebUI.Interfaces;
 using LearningHub.Nhs.WebUI.JsDetection;
 using LearningHub.Nhs.WebUI.Middleware;
+using LearningHub.Nhs.WebUI.Services;
 using LearningHub.Nhs.WebUI.Startup;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.Mvc.ApplicationParts;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -37,6 +40,21 @@ try
 
     builder.Services.AddHostedService<TimedHostedService>();
     builder.Services.ConfigureServices(builder.Configuration, builder.Environment);
+
+    // Automatically detect set of views stored in library that comes with it and registers them
+    builder.Services.AddControllersWithViews()
+    .ConfigureApplicationPartManager(manager =>
+    {
+        var razorAssemblies = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(asm => asm.GetTypes()
+                .Any(type => type.Namespace == "AspNetCoreGeneratedDocument"));
+
+        foreach (var assembly in razorAssemblies)
+        {
+            manager.ApplicationParts.Add(new AssemblyPart(assembly));
+            manager.ApplicationParts.Add(new CompiledRazorAssemblyPart(assembly));
+        }
+    });
 
     var app = builder.Build();
 


### PR DESCRIPTION
### JIRA link
[TD-6632](https://hee-tis.atlassian.net/browse/TD-6632)

### Description
Enable automatic detection of views coming from nuget packagees

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-6632]: https://hee-tis.atlassian.net/browse/TD-6632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ