### PR TITLE
query optimization to select a determined ID.

### DIFF
--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserInProgressLearningActivities.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/GetUserInProgressLearningActivities.sql
@@ -59,14 +59,14 @@ BEGIN
    LEFT JOIN (
     SELECT 
         ResourceId,
-        MAX(Id) AS LatestRefId
+        MIN(Id) AS OldestRefId
     FROM resources.ResourceReference
     WHERE Deleted = 0
     GROUP BY ResourceId
-     ) rrLatest ON rrLatest.ResourceId = rv.ResourceId
+    ) rrOldest ON rrOldest.ResourceId = rv.ResourceId
 
     LEFT JOIN resources.ResourceReference rrRef
-    ON rrRef.Id = rrLatest.LatestRefId
+        ON rrRef.Id = rrOldest.OldestRefId
 
       LEFT JOIN (
         SELECT 


### PR DESCRIPTION
### JIRA link
TD-7078

### Description
This is an optimization that isnt addressing the elearning tray.
The elearning tray issue is as a result of the GET endpoint showing as POST on swagger in test environment. a redeployment might fix that 

### Screenshots
<img width="1106" height="180" alt="image" src="https://github.com/user-attachments/assets/57bda433-3e19-4cdd-b95b-2aaa0e50bcd1" />

<img width="629" height="148" alt="image" src="https://github.com/user-attachments/assets/01acf851-8335-4e2e-948e-4d1429a8cf6f" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [X] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation