### PR TITLE
TD-7106-Resume Change Tracking after each deployment.

### DIFF
--- a/WebAPI/LearningHub.Nhs.Database/LearningHub.Nhs.Database.sqlproj
+++ b/WebAPI/LearningHub.Nhs.Database/LearningHub.Nhs.Database.sqlproj
@@ -568,6 +568,7 @@
     <Build Include="Stored Procedures\Adf\AdfMergeattribute.sql" />
     <Build Include="Tables\MIB\MoodleInstanceConfigs.sql" />
     <None Include="Scripts\Post-Deploy\Scripts\TD-7116-mib_new_env.sql" />
+    <None Include="Scripts\Post-Deploy\Scripts\TD-7106-Resume-Databricks-Ingestion.sql" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Scripts\Pre-Deploy\Scripts\Card5766_AuthorTableChanges.PreDeployment.sql" />

--- a/WebAPI/LearningHub.Nhs.Database/Scripts/Post-Deploy/Script.PostDeployment.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Scripts/Post-Deploy/Script.PostDeployment.sql
@@ -87,5 +87,4 @@ UPDATE [resources].[ResourceVersion] SET CertificateEnabled = 0 WHERE VersionSta
 :r .\Scripts\PPSXFileType.sql
 :r .\Scripts\UpdateFileTypes.sql
 :r .\Scripts\TD-7116-mib_new_env.sql
-:r .\Script\TD-7106-Resume-Databricks-Ingestion.sql
-
+:r .\Scripts\TD-7106-Resume-Databricks-Ingestion.sql

--- a/WebAPI/LearningHub.Nhs.Database/Scripts/Post-Deploy/Script.PostDeployment.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Scripts/Post-Deploy/Script.PostDeployment.sql
@@ -87,4 +87,5 @@ UPDATE [resources].[ResourceVersion] SET CertificateEnabled = 0 WHERE VersionSta
 :r .\Scripts\PPSXFileType.sql
 :r .\Scripts\UpdateFileTypes.sql
 :r .\Scripts\TD-7116-mib_new_env.sql
+:r .\Script\TD-7106-Resume-Databricks-Ingestion.sql
 

--- a/WebAPI/LearningHub.Nhs.Database/Scripts/Post-Deploy/Scripts/TD-7106-Resume-Databricks-Ingestion.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Scripts/Post-Deploy/Scripts/TD-7106-Resume-Databricks-Ingestion.sql
@@ -1,0 +1,17 @@
+﻿IF EXISTS (
+    SELECT 1
+    FROM sys.change_tracking_databases
+    WHERE database_id = DB_ID()
+)
+BEGIN
+    PRINT 'Change Tracking is enabled. Executing setup...';
+
+    EXEC dbo.lakeflowSetupChangeTracking
+        @Tables = 'activity.ResourceActivity',  --(to include all other tables with CT enabled)
+        @User = 'Elfhadmin',
+        @Retention = '2 DAYS';
+END
+ELSE
+BEGIN
+    PRINT 'Change Tracking is NOT enabled on this database. Skipping execution.';
+END


### PR DESCRIPTION
### JIRA link
https://hee-tis.atlassian.net/browse/TD-7106

### Description
Include the execution of a script to always activate change tracking on specified tables after each database deployment.
The process below has the tendency of disrupting change tracking and we need to make those change outside of dacpac such as a in the post deployment script.

- Changing column datatype
- Changing nullability
- Changing primary key
- Renaming a column

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation