### PR TITLE
TD-7125: LH Admin UI - when category is not assigned to the catalogue…

### DIFF
--- a/AdminUI/LearningHub.Nhs.AdminUI/Controllers/CatalogueController.cs
+++ b/AdminUI/LearningHub.Nhs.AdminUI/Controllers/CatalogueController.cs
@@ -738,20 +738,29 @@ namespace LearningHub.Nhs.AdminUI.Controllers
             if (string.IsNullOrEmpty(catalogueViewModel.SelectedCategoryId))
             {
                 this.ModelState.AddModelError("SelectedCategoryId", "Please select a category.");
-            }
-            var vm = await this.catalogueService.GetCatalogueAsync(catalogueViewModel.CatalogueNodeVersionId);
-            vm.SelectedCategoryId = catalogueViewModel.SelectedCategoryId;
-            var vr = await this.catalogueService.AddCategoryToCatalogue(vm);
-            if (vr.Success)
-            {
+                var vm = await this.catalogueService.GetCatalogueAsync(catalogueViewModel.CatalogueNodeVersionId);
                 var categories = await this.moodleBridgeApiService.GetAllMoodleCategoriesAsync();
                 vm.MoodleCategorySelectList = BuildMoodleCategorySelectList(categories);
+
                 return this.View("MoodleCategory", vm);
             }
+
             else
             {
-                this.ViewBag.ErrorMessage = $"Category Update failed.";
-                return this.View("MoodleCategory", vm);
+                var vm = await this.catalogueService.GetCatalogueAsync(catalogueViewModel.CatalogueNodeVersionId);
+                vm.SelectedCategoryId = catalogueViewModel.SelectedCategoryId;
+                var vr = await this.catalogueService.AddCategoryToCatalogue(vm);
+                if (vr.Success)
+                {
+                    var categories = await this.moodleBridgeApiService.GetAllMoodleCategoriesAsync();
+                    vm.MoodleCategorySelectList = BuildMoodleCategorySelectList(categories);
+                    return this.View("MoodleCategory", vm);
+                }
+                else
+                {
+                    this.ViewBag.ErrorMessage = $"Category Update failed.";
+                    return this.View("MoodleCategory", vm);
+                }
             }
         }
 


### PR DESCRIPTION
… and clicked save results in error

### JIRA link
[TD-7125](https://hee-tis.atlassian.net/browse/TD-7125)

### Description
LH Admin UI - when category is not assigned to the catalogue and clicked save results in error - Fixed the issue

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._
<img width="1027" height="582" alt="image" src="https://github.com/user-attachments/assets/68aaaa12-1846-4353-95f0-c7ce1714c5b4" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-7125]: https://hee-tis.atlassian.net/browse/TD-7125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ