### PR TITLE
TD-7217: Removed unused file refrences from DB project

### DIFF
--- a/WebAPI/LearningHub.Nhs.Database/Scripts/Post-Deploy/Script.PostDeployment.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Scripts/Post-Deploy/Script.PostDeployment.sql
@@ -70,21 +70,5 @@ END
 UPDATE [resources].[ResourceVersion] SET CertificateEnabled = 0 WHERE VersionStatusId <> 1 AND CertificateEnabled IS NULL
 
 -- do not delete the script AddDigitalLearningSolutionsExternalSystem
-:r .\Scripts\AddDigitalLearningSolutionsExternalSystem.sql
-:r .\Scripts\Bookmark.sql
-:r .\Scripts\PopulateEventTypes.sql
-:r .\Scripts\InternalSystem.sql
-:r .\Scripts\UpdateDataForEmailTemplates.sql
-:r .\Scripts\RolePermissionForReleaseOffline.sql
-:r .\Scripts\ExternalSystemData.sql
-:r .\Scripts\EmailChangeMessageSeed.sql
-:r .\Scripts\PopulateProviders.sql
-:r .\Scripts\HtmlResourceType.sql
-:r .\Scripts\InitialiseDataForEmailTemplates.sql
-:r .\Scripts\TD-2929_ActivityStatusUpdates.sql
-:r .\Scripts\InitialiseDataForEmailTemplates.sql
-:r .\Scripts\AttributeData.sql 
-:r .\Scripts\PPSXFileType.sql
-:r .\Scripts\UpdateFileTypes.sql
 :r .\Scripts\TD-7116-mib_new_env.sql
 :r .\Scripts\TD-7106-Resume-Databricks-Ingestion.sql

--- a/WebAPI/LearningHub.Nhs.Database/Scripts/Post-Deploy/Scripts/HtmlResourceType.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Scripts/Post-Deploy/Scripts/HtmlResourceType.sql
@@ -14,7 +14,7 @@ VALUES (6, 12, 'HtmlResource_RootIndexPresent', 0, 4, @now, 4, @now)
 END
 
 UPDATE resources.FileType SET NotAllowed = 1 WHERE Extension IN ('odp','key','pages','numbers','dhtml','odt')
-UPDATE [resources].[FileType] SET Deleted = 1 WHERE Id =0 
+--UPDATE [resources].[FileType] SET Deleted = 1 WHERE Id =0 
 
 
 IF NOT EXISTS(SELECT Id FROM [resources].[FileType] WHERE Extension = 'pub')

--- a/WebAPI/LearningHub.Nhs.Database/Scripts/Post-Deploy/Scripts/HtmlResourceType.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Scripts/Post-Deploy/Scripts/HtmlResourceType.sql
@@ -14,7 +14,7 @@ VALUES (6, 12, 'HtmlResource_RootIndexPresent', 0, 4, @now, 4, @now)
 END
 
 UPDATE resources.FileType SET NotAllowed = 1 WHERE Extension IN ('odp','key','pages','numbers','dhtml','odt')
---UPDATE [resources].[FileType] SET Deleted = 1 WHERE Id =0 
+UPDATE [resources].[FileType] SET Deleted = 0 WHERE Id =0 
 
 
 IF NOT EXISTS(SELECT Id FROM [resources].[FileType] WHERE Extension = 'pub')

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/ScormActivityComplete.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/ScormActivityComplete.sql
@@ -45,12 +45,15 @@ BEGIN
 		
 	IF EXISTS (SELECT 'X' FROM activity.ResourceActivity WHERE LaunchResourceActivityId = @ScormResourceActivityId AND ActivityStatusId IN (3, 4, 5))
 	BEGIN
-		DECLARE @ActivityStatusErrorMessage nvarchar(1024)
-		SELECT @ActivityStatusErrorMessage = 'ResourceActivity entry with Completed status already exists for ScormActivityId=' + CONVERT(nvarchar(20), @ScormActivityId);
-		RAISERROR (@ActivityStatusErrorMessage,   
-				   16, -- Severity.  
-				   1 -- State.  
-				   );  
+		UPDATE activity.ResourceActivity SET ActivityStatusId = @ActivityStatusId, 
+		                                     DurationSeconds = @DurationSeconds, 
+											 Score = @Score, 
+											 ActivityEnd = DATEADD(second, @DurationSeconds, ActivityStart),
+											 CreateUserId = @UserId,
+											CreateDate = @AmendDate,
+											AmendUserId = @UserId,
+											AmendDate = @AmendDate
+											where LaunchResourceActivityId = @ScormResourceActivityId  
 	END
 ELSE
 BEGIN


### PR DESCRIPTION
### JIRA link
[TD-7217](https://hee-tis.atlassian.net/browse/TD-7217)

### Description
Removed unused DB file references from post deployment DB file

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-7217]: https://hee-tis.atlassian.net/browse/TD-7217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ