### PR TITLE
TD-6614: Integration testing of newly created modules

### DIFF
--- a/LearningHub.Nhs.WebUI/Controllers/JiraRoadmapController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/JiraRoadmapController.cs
@@ -36,15 +36,15 @@
         }
 
         /// <summary>
-        /// Returns public roadmap issues (data only endpoint for WebUI).
+        /// Returns public roadmap tickets (data only endpoint for WebUI).
         /// </summary>
         /// <returns>The <see cref="Task{IActionResult}"/>.</returns>
         [HttpGet]
-        [Route("getRoadmapIssues")]
-        public async Task<IActionResult> GetRoadmapIssues()
+        [Route("getRoadmapContent")]
+        public async Task<IActionResult> Index()
         {
             var roadmapResponse = await this.jiraRoadmapService.GetPublicRoadmapIssues();
-            return this.Json(roadmapResponse);
+            return this.View(roadmapResponse);
         }
      }
 }

--- a/LearningHub.Nhs.WebUI/Controllers/JiraRoadmapController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/JiraRoadmapController.cs
@@ -43,7 +43,7 @@
         [Route("getRoadmapContent")]
         public async Task<IActionResult> Index()
         {
-            var roadmapResponse = await this.jiraRoadmapService.GetPublicRoadmapIssues();
+            var roadmapResponse = await this.jiraRoadmapService.GetPublicRoadmapTickets();
             return this.View(roadmapResponse);
         }
      }

--- a/LearningHub.Nhs.WebUI/Interfaces/IJiraRoadmapService.cs
+++ b/LearningHub.Nhs.WebUI/Interfaces/IJiraRoadmapService.cs
@@ -10,9 +10,9 @@
     public interface IJiraRoadmapService
     {
         /// <summary>
-        /// Gets public roadmap issues from Jira Open API.
+        /// Gets public roadmap tickets from Jira Open API.
         /// </summary>
         /// <returns>The <see cref="Task"/>.</returns>
-        Task<RoadmapResponseDto> GetPublicRoadmapIssues();
+        Task<RoadmapResponseDto> GetPublicRoadmapTickets();
     }
 }

--- a/LearningHub.Nhs.WebUI/Services/JiraRoadmapService.cs
+++ b/LearningHub.Nhs.WebUI/Services/JiraRoadmapService.cs
@@ -27,10 +27,10 @@
         }
 
         /// <inheritdoc />
-        public async Task<RoadmapResponseDto> GetPublicRoadmapIssues()
+        public async Task<RoadmapResponseDto> GetPublicRoadmapTickets()
         {
             var client = await this.OpenApiHttpClient.GetClientAsync();
-            var request = "JiraRoadmap/GetRoadmapIssues";
+            var request = "JiraRoadmap/GetRoadmapTickets";
             var response = await client.GetAsync(request).ConfigureAwait(false);
             if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized
                         ||

--- a/LearningHub.Nhs.WebUI/Styles/nhsuk/pages/jira_roadmap.scss
+++ b/LearningHub.Nhs.WebUI/Styles/nhsuk/pages/jira_roadmap.scss
@@ -1,28 +1,9 @@
 ﻿@use "../../abstracts/all" as *;
 
-.jira-roadmap-intro {
-    /*padding-left: 170px;*/
-    max-width: 75.5rem;
-    margin: 0 auto;
-    padding-left: 1rem;
-    padding-right: 2rem;
-}
-
-.jira-roadmap-banner {
-    width: 100%;
-    padding-bottom: 16px;
-    background-color: $nhsuk-grey-lighter;
-    margin-bottom: 24px;
-}
-
-
 .jira-roadmap-state {
-    /*box-shadow: 0 0 0 1px $nhsuk-border-colour;*/
-    box-shadow: inset 0 0 0 2px #d8dde0;
-    /*border: 2px solid #d8dde0;*/
+    box-shadow: inset 0 0 0 2px $nhsuk-grey-lighter;
     border-radius: .333rem;
     overflow: hidden;
-    /*margin-bottom: 16px;*/
 }
 
 .jira-roadmap-state-heading {
@@ -30,21 +11,21 @@
     background-color: $nhsuk-blue;
     color: $nhsuk-white;
     padding: 8px 16px;
-    /*line-height: 1;*/
     border-radius: 5px 0px 5px 0px;
 }
 
 .jira-roadmap-card-body {
-   /* display: block;
-    border-radius: 4px 0 4px 0;*/
     padding: 8px 16px;
 }
 
 .nhsuk-icon--tick {
     fill: $nhsuk-green-hover;
     height: 2rem;
-/*    left: -.25rem;
-    margin-top: -.25rem -4px;*/
     width: 2rem;
+}
+.jira-roadmap__tick-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
 }
 

--- a/LearningHub.Nhs.WebUI/Styles/nhsuk/pages/jira_roadmap.scss
+++ b/LearningHub.Nhs.WebUI/Styles/nhsuk/pages/jira_roadmap.scss
@@ -1,35 +1,50 @@
 ﻿@use "../../abstracts/all" as *;
 
 .jira-roadmap-intro {
-    padding-left: 170px;
+    /*padding-left: 170px;*/
+    max-width: 75.5rem;
+    margin: 0 auto;
+    padding-left: 1rem;
+    padding-right: 2rem;
 }
 
 .jira-roadmap-banner {
     width: 100%;
-    padding-bottom: 20px;
-    background-color: $nhsuk-grey;
+    padding-bottom: 16px;
+    background-color: $nhsuk-grey-lighter;
+    margin-bottom: 24px;
 }
 
 
 .jira-roadmap-state {
-    box-shadow: 0 0 0 1px $nhsuk-border-colour;
-    border-radius: 8px;
+    /*box-shadow: 0 0 0 1px $nhsuk-border-colour;*/
+    box-shadow: inset 0 0 0 2px #d8dde0;
+    /*border: 2px solid #d8dde0;*/
+    border-radius: .333rem;
     overflow: hidden;
-    margin-bottom: 16px;
+    /*margin-bottom: 16px;*/
 }
 
 .jira-roadmap-state-heading {
     display: inline-block;
     background-color: $nhsuk-blue;
     color: $nhsuk-white;
-    padding: 9px 20px 13px;
-    line-height: 1;
-    border-radius: 8px 0px 8px 0px;
+    padding: 8px 16px;
+    /*line-height: 1;*/
+    border-radius: 5px 0px 5px 0px;
 }
 
 .jira-roadmap-card-body {
-    display: inline-block;
-    border-radius: 4px 0 4px 0;
-    padding: 4px 16px;
+   /* display: block;
+    border-radius: 4px 0 4px 0;*/
+    padding: 8px 16px;
+}
+
+.nhsuk-icon--tick {
+    fill: $nhsuk-green-hover;
+    height: 2rem;
+/*    left: -.25rem;
+    margin-top: -.25rem -4px;*/
+    width: 2rem;
 }
 

--- a/LearningHub.Nhs.WebUI/Views/JiraRoadmap/Index.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/JiraRoadmap/Index.cshtml
@@ -9,28 +9,10 @@
 
 }
 
-@* <div class="jira-roadmap-banner">
-    <div class="jira-roadmap-intro">
-        <div class="nhsuk-grid-column-full">
-            <h1 class="nhsuk-heading-xl nhsuk-u-margin-top-5">Learning Hub Roadmap</h1>
-            <div class="nhsuk-u-reading-width">
-                <p class="nhsuk-body-l nhsuk-u-reading-width">
-                    Introduction text - needs to be replaced with approved copy.
-                </p>
-            </div>
-        </div>
-    </div>
-</div> *@
-
 <section class="nhsuk-hero">
     <div class="nhsuk-width-container app-width-container">
         <div class="nhsuk-grid-row">
             <div class="nhsuk-grid-column-full">
-
-                @*                 <div class="nhsuk-u-padding-top-3 nhsuk-u-padding-bottom-3">
-                    <a href="/">Home</a>
-                    <i class="fa-solid fa-chevron-right nhsuk-u-padding-top-1 nhsuk-u-padding-bottom-1 nhsuk-u-padding-left-2 nhsuk-u-padding-right-2"></i>
-                </div> *@
                 <div class="nhsuk-u-padding-top-4 nhsuk-u-padding-bottom-7">
                     <h1 class="nhsuk-heading-xl">Learning Hub Roadmap</h1>
                 </div>
@@ -38,80 +20,6 @@
         </div>
     </div>
 </section>
-
-@* <div class="nhsuk-width-container app-width-container">
-    <div class="jira-roadmap">
-        <div class="nhsuk-grid-row">
-            <div class="nhsuk-grid-column-one-third">
-                <nav class="nhsuk-contents-list" aria-label="Page contents">
-                    <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">Page contents</h2>
-                    <ol class="nhsuk-contents-list__list">
-                        @foreach (var component in Model.Components)
-                        {
-                            var anchorId = component.ComponentName.ToLower().Replace(" ", "-");
-
-                            <li class="nhsuk-contents-list__item">
-                                <a class="nhsuk-contents-list__link" href="#@anchorId">@component.ComponentName</a>
-                            </li>
-                        }
-                    </ol>
-                </nav>
-            </div>
-            <div class="nhsuk-grid-column-two-thirds">
-
-
-                @foreach (var component in Model.Components)
-                {
-
-                    var anchorId = System.Text.RegularExpressions.Regex
-                    .Replace(component.ComponentName.ToLowerInvariant(), @"[^a-z0-9]+", "-")
-                    .Trim('-');
-
-
-                    <h2 id="@anchorId">
-                        @component.ComponentName
-                    </h2>
-
-                    <p>@component.ComponentDescription</p>
-
-                    @foreach (var state in component.States)
-                    {
-                        <div class="jira-roadmap-state">
-
-
-
-
-                            <span class="jira-roadmap-state-heading">
-                                @state.State
-                            </span>
-
-                            <div class="jira-roadmap-card-body">
-                                <ul class="nhsuk-list">
-
-
-                                    @foreach (var issue in state.Issues)
-                                    {
-
-                                        <li class="jira-roadmap__tick-item">
-                                            <svg class="nhsuk-icon nhsuk-icon--tick" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" focusable="false" aria-hidden="true">
-                                                <path d="M11.4 18.8a2 2 0 0 1-2.7.1h-.1L4 14.1a1.5 1.5 0 0 1 2.1-2L10 16l8.1-8.1a1.5 1.5 0 1 1 2.2 2l-8.9 9Z"></path>
-                                            </svg>
-                                            @issue.Summary
-                                        </li>
-
-                                    }
-                                </ul>
-                            </div>
-
-                        </div>
-                    }
-                }
-
-            </div>
-        </div>
-    </div>
-</div> *@
-
 
 <div class="bg-white nhsuk-u-padding-bottom-7 nhsuk-u-padding-top-7">
     <div class="nhsuk-width-container app-width-container">

--- a/LearningHub.Nhs.WebUI/Views/JiraRoadmap/Index.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/JiraRoadmap/Index.cshtml
@@ -1,100 +1,71 @@
 ﻿@using LearningHub.Nhs.Models.JiraRoadmap
-
 @model LearningHub.Nhs.Models.JiraRoadmap.RoadmapResponseDto
-
-
-
-
 @{
     ViewData["Title"] = "Learning Hub Roadmap";
 }
 
 @section styles {
-    <link rel="stylesheet" type="text/css" href="~/css/nhsuk/pages/jira_roadmap.css asp-append-version="true" />
+    <link rel="stylesheet" type="text/css" href="~/css/nhsuk/pages/jira_roadmap.css" asp-append-version="true" />
 
 }
 
-@* <style type="text/css">
-
-.jira-roadmap-intro {
-        padding-left: 170px;
-        }
-.jira-roadmap-banner {
-        width: 100%;
-        padding-bottom: 20px;
-        background-color: $nhsuk-grey-light;
-}
-
-
-    .jira-roadmap-state {
-        box-shadow: 0 0 0 2px $nhsuk-grey-light;
-        border-radius: 8px;
-    }
-
-    .jira-roadmap-state-heading {
-        display: inline-block;
-        background-color: $nhsuk-blue;
-        color: $nhsuk-white;
-        border-radius: 8px 0 8px 0;
-    }
-
-
-</style> *@
-
-
-@* @section NavBreadcrumbs {
-
-
-} *@
-
-
-<div class="jira-roadmap-banner">
+@* <div class="jira-roadmap-banner">
     <div class="jira-roadmap-intro">
-            <div class="nhsuk-grid-column-full">
-
-            <h1 class="nhsuk-heading-xl">Learning Hub Roadmap</h1>
-
+        <div class="nhsuk-grid-column-full">
+            <h1 class="nhsuk-heading-xl nhsuk-u-margin-top-5">Learning Hub Roadmap</h1>
             <div class="nhsuk-u-reading-width">
-
                 <p class="nhsuk-body-l nhsuk-u-reading-width">
                     Introduction text - needs to be replaced with approved copy.
                 </p>
             </div>
+        </div>
+    </div>
+</div> *@
+
+<section class="nhsuk-hero">
+    <div class="nhsuk-width-container app-width-container">
+        <div class="nhsuk-grid-row">
+            <div class="nhsuk-grid-column-full">
+
+                @*                 <div class="nhsuk-u-padding-top-3 nhsuk-u-padding-bottom-3">
+                    <a href="/">Home</a>
+                    <i class="fa-solid fa-chevron-right nhsuk-u-padding-top-1 nhsuk-u-padding-bottom-1 nhsuk-u-padding-left-2 nhsuk-u-padding-right-2"></i>
+                </div> *@
+                <div class="nhsuk-u-padding-top-4 nhsuk-u-padding-bottom-7">
+                    <h1 class="nhsuk-heading-xl">Learning Hub Roadmap</h1>
+                </div>
             </div>
         </div>
     </div>
+</section>
 
-
-
-<div class="nhsuk-width-container app-width-container">
+@* <div class="nhsuk-width-container app-width-container">
     <div class="jira-roadmap">
         <div class="nhsuk-grid-row">
-
             <div class="nhsuk-grid-column-one-third">
                 <nav class="nhsuk-contents-list" aria-label="Page contents">
                     <h2 class="nhsuk-heading-s nhsuk-u-margin-bottom-2">Page contents</h2>
                     <ol class="nhsuk-contents-list__list">
-                       @foreach (var component in Model.Components)
+                        @foreach (var component in Model.Components)
                         {
                             var anchorId = component.ComponentName.ToLower().Replace(" ", "-");
 
                             <li class="nhsuk-contents-list__item">
                                 <a class="nhsuk-contents-list__link" href="#@anchorId">@component.ComponentName</a>
-                                </li>
-                         }
+                            </li>
+                        }
                     </ol>
                 </nav>
             </div>
-
             <div class="nhsuk-grid-column-two-thirds">
 
 
                 @foreach (var component in Model.Components)
                 {
-                   
+
                     var anchorId = System.Text.RegularExpressions.Regex
-                        .Replace(component.ComponentName.ToLowerInvariant(), @"[^a-z0-9]+", "-")
-                        .Trim('-');
+                    .Replace(component.ComponentName.ToLowerInvariant(), @"[^a-z0-9]+", "-")
+                    .Trim('-');
 
 
                     <h2 id="@anchorId">
@@ -107,32 +78,99 @@
                     {
                         <div class="jira-roadmap-state">
 
-                           
 
-                           
-                                    <span class="jira-roadmap-state-heading">
-                                        @state.State
-                                    </span>
-                           
-                                <div class="jira-roadmap-card-body">
-                                    <ul class="nhsuk-list">
+
+
+                            <span class="jira-roadmap-state-heading">
+                                @state.State
+                            </span>
+
+                            <div class="jira-roadmap-card-body">
+                                <ul class="nhsuk-list">
 
 
                                     @foreach (var issue in state.Issues)
                                     {
 
                                         <li class="jira-roadmap__tick-item">
+                                            <svg class="nhsuk-icon nhsuk-icon--tick" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" focusable="false" aria-hidden="true">
+                                                <path d="M11.4 18.8a2 2 0 0 1-2.7.1h-.1L4 14.1a1.5 1.5 0 0 1 2.1-2L10 16l8.1-8.1a1.5 1.5 0 1 1 2.2 2l-8.9 9Z"></path>
+                                            </svg>
                                             @issue.Summary
                                         </li>
 
                                     }
                                 </ul>
-                                </div> 
-                           
+                            </div>
+
                         </div>
                     }
                 }
 
             </div>
-
         </div>
+    </div>
+</div> *@
+
+
+<div class="bg-white nhsuk-u-padding-bottom-7 nhsuk-u-padding-top-7">
+    <div class="nhsuk-width-container app-width-container">
+        <div class="nhsuk-grid-row">
+            <div class="nhsuk-grid-column-one-quarter">
+                <nav class="nhsuk-contents-list" aria-label="Page contents">
+                    <ol class="nhsuk-contents-list__list">
+                        @foreach (var component in Model.Components)
+                        {
+                            var anchorId = System.Text.RegularExpressions.Regex
+                            .Replace(component.ComponentName.ToLowerInvariant(), @"[^a-z0-9]+", "-")
+                            .Trim('-');
+                            <li class="nhsuk-contents-list__item">
+                                <a class="nhsuk-contents-list__link" href="#@anchorId">@component.ComponentName</a>
+                            </li>
+                        }
+                    </ol>
+                </nav>
+            </div>
+            <div class="nhsuk-grid-column-three-quarters">
+                @foreach (var component in Model.Components)
+                {
+                    var anchorId = System.Text.RegularExpressions.Regex
+                    .Replace(component.ComponentName.ToLowerInvariant(), @"[^a-z0-9]+", "-")
+                    .Trim('-');
+                    <h2 id="@anchorId">
+                        @component.ComponentName
+                    </h2>
+                    <p>@component.ComponentDescription</p>
+
+                    @foreach (var state in component.States)
+                    {
+                        <div class="nhsuk-u-margin-bottom-6 jira-roadmap-state">
+                            <span class="nhsuk-heading-s jira-roadmap-state-heading">
+                                @state.State
+                            </span>
+                            <div class="jira-roadmap-card-body">
+                                <ul class="nhsuk-list">
+                                    @foreach (var issue in state.Issues)
+                                    {
+                                        <li class="jira-roadmap__tick-item">
+                                            <span>
+                                                <svg class="nhsuk-icon nhsuk-icon--tick" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" focusable="false" aria-hidden="true">
+                                                    <path d="M11.4 18.8a2 2 0 0 1-2.7.1h-.1L4 14.1a1.5 1.5 0 0 1 2.1-2L10 16l8.1-8.1a1.5 1.5 0 1 1 2.2 2l-8.9 9Z"></path>
+                                                </svg>
+                                            </span>
+                                            @issue.Summary
+                                        </li>
+                                    }
+                                </ul>
+                            </div>
+                        </div>
+                    }
+                    @if (component != Model.Components.Last())
+                    {
+                        <hr />
+                    }
+                }
+            </div>
+        </div>
+    </div>
+</div>

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Services.Interface/Services/IJiraRoadmapService.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Services.Interface/Services/IJiraRoadmapService.cs
@@ -9,9 +9,9 @@ namespace LearningHub.Nhs.OpenApi.Services.Interface.Services
     public interface IJiraRoadmapService
     {
         /// <summary>
-        /// Get all issues marked public for roadmap.
+        /// Get all tickets marked public for roadmap.
         /// </summary>
         /// <returns></returns>
-        Task<RoadmapResponseDto> GetPublicRoadmapIssues();
+        Task<RoadmapResponseDto> GetPublicRoadmapTickets();
     }
 }

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Services/Services/JiraRoadmapService.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Services/Services/JiraRoadmapService.cs
@@ -35,7 +35,7 @@
         /// Get all issues marked public for roadmap.
         /// </summary>
         /// <returns></returns>
-        public async Task<RoadmapResponseDto> GetPublicRoadmapIssues()
+        public async Task<RoadmapResponseDto> GetPublicRoadmapTickets()
         {
             RoadmapResponseDto viewModel = new RoadmapResponseDto();
 
@@ -66,18 +66,6 @@
 
                 if (jiraResponse?.Issues.Count > 0)
                 {
-                    ////var flatIssuesResponse = jiraResponse.Issues.Select(issue => new
-                    ////{
-                    ////    Component = issue.Fields?.Components?.FirstOrDefault()?.Name,
-                    ////    ComponentDescription = selectedComponents.ContainsKey(issue.Fields?.Components?.FirstOrDefault()?.Id) ? selectedComponents[issue.Fields?.Components?.FirstOrDefault()?.Id] : null,
-                    ////    RoadmapState = this.MapToDisplay(issue.Fields?.Status?.Name),
-                    ////    Issue = new RoadmapIssueDto
-                    ////    {
-                    ////        Summary = issue.Fields?.Summary?.ToString(),
-                    ////        Description = issue.Fields?.Description?.ToString()
-                    ////    }
-                    ////}).ToList();
-
                     var flatIssuesResponse = jiraResponse.Issues.SelectMany(issue => issue.Fields.Components.Where(c => selectedComponents.ContainsKey(c.Id))
                     .Select(component =>new
                     {

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Services/Services/JiraRoadmapService.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Services/Services/JiraRoadmapService.cs
@@ -66,17 +66,30 @@
 
                 if (jiraResponse?.Issues.Count > 0)
                 {
-                    var flatIssuesResponse = jiraResponse.Issues.Select(issue => new
+                    ////var flatIssuesResponse = jiraResponse.Issues.Select(issue => new
+                    ////{
+                    ////    Component = issue.Fields?.Components?.FirstOrDefault()?.Name,
+                    ////    ComponentDescription = selectedComponents.ContainsKey(issue.Fields?.Components?.FirstOrDefault()?.Id) ? selectedComponents[issue.Fields?.Components?.FirstOrDefault()?.Id] : null,
+                    ////    RoadmapState = this.MapToDisplay(issue.Fields?.Status?.Name),
+                    ////    Issue = new RoadmapIssueDto
+                    ////    {
+                    ////        Summary = issue.Fields?.Summary?.ToString(),
+                    ////        Description = issue.Fields?.Description?.ToString()
+                    ////    }
+                    ////}).ToList();
+
+                    var flatIssuesResponse = jiraResponse.Issues.SelectMany(issue => issue.Fields.Components.Where(c => selectedComponents.ContainsKey(c.Id))
+                    .Select(component =>new
                     {
-                        Component = issue.Fields?.Components?.FirstOrDefault()?.Name,
-                        ComponentDescription = selectedComponents.ContainsKey(issue.Fields?.Components?.FirstOrDefault()?.Id) ? selectedComponents[issue.Fields?.Components?.FirstOrDefault()?.Id] : null,
+                        Component = component.Name,
+                        ComponentDescription = selectedComponents[component.Id],
                         RoadmapState = this.MapToDisplay(issue.Fields?.Status?.Name),
                         Issue = new RoadmapIssueDto
                         {
                             Summary = issue.Fields?.Summary?.ToString(),
                             Description = issue.Fields?.Description?.ToString()
                         }
-                    }).ToList();
+                    })).ToList();
 
                     var componentList = flatIssuesResponse.GroupBy(x => x.Component)
                         .Select(componentGroup => new RoadmapComponentDto

--- a/OpenAPI/LearningHub.Nhs.OpenApi/Controllers/JiraRoadmapController.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi/Controllers/JiraRoadmapController.cs
@@ -26,23 +26,23 @@
         }
 
         /// <summary>
-        /// The GetRoadmapIssues controller, issues in jira.
+        /// The GetRoadmapTickets controller, tickets in jira.
         /// </summary>
         /// <returns>The <see cref="Task"/>.</returns>
         [HttpGet]
-        [Route("GetRoadmapIssues")]
-        public async Task<IActionResult> GetRoadmapIssues()
+        [Route("GetRoadmapTickets")]
+        public async Task<IActionResult> GetRoadmapTickets()
         {
-            var roadmapResponse = await this.GetRoadmapIssuesAsync();
+            var roadmapResponse = await this.GetRoadmapTicketsAsync();
             return this.Ok(roadmapResponse);
         }
 
         /// <summary>
-        /// Get all issues marked public and based on components in roadmap.
+        /// Get all tickets marked public and based on components in roadmap.
         /// </summary>
-        private async Task<RoadmapResponseDto> GetRoadmapIssuesAsync()
+        private async Task<RoadmapResponseDto> GetRoadmapTicketsAsync()
         {
-            return await this.jiraRoadmapService.GetPublicRoadmapIssues();
+            return await this.jiraRoadmapService.GetPublicRoadmapTickets();
         }
     }
 }


### PR DESCRIPTION
### JIRA link
[TD-6614](https://hee-tis.atlassian.net/browse/TD-6614)

### Description
Tested the integrated modules of dynamic roadmap feature and updated few css.

### Screenshots
<img width="1060" height="697" alt="image" src="https://github.com/user-attachments/assets/e21f8b5d-8761-445e-ba71-dcbd79347f43" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-6614]: https://hee-tis.atlassian.net/browse/TD-6614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ