### PR TITLE
TD-7354: lh admin UI gov notify dashboard entries (created date) timing is incorrect

### DIFF
--- a/AdminUI/LearningHub.Nhs.AdminUI/Views/GovNotifyDashboard/Details.cshtml
+++ b/AdminUI/LearningHub.Nhs.AdminUI/Views/GovNotifyDashboard/Details.cshtml
@@ -46,25 +46,25 @@
                     Created date
                 </dt>
                 <dd>
-                    @Html.DisplayFor(model => model.CreatedAt)
+                    @Model.CreatedAt.DateTime.ToString("dd/MM/yyyy HH:mm:ss")
                 </dd>
                 <dt>
                     Deliver after date
                 </dt>
                 <dd>
-                    @Html.DisplayFor(model => model.DeliverAfter)
+                    @Model.DeliverAfter?.DateTime.ToString("dd/MM/yyyy HH:mm:ss")
                 </dd>
                 <dt>
                     Sent Date
                 </dt>
                 <dd>
-                    @Html.DisplayFor(model => model.SentAt)
+                    @Model.SentAt?.DateTime.ToString("dd/MM/yyyy HH:mm:ss")
                 </dd>
                 <dt>
                     Last attempt date
                 </dt>
                 <dd>
-                    @Html.DisplayFor(model => model.LastAttemptAt)
+                    @Model.LastAttemptAt?.DateTime.ToString("dd/MM/yyyy HH:mm:ss")
                 </dd>
                 <dt>
                     Error message

--- a/AdminUI/LearningHub.Nhs.AdminUI/Views/GovNotifyDashboard/Index.cshtml
+++ b/AdminUI/LearningHub.Nhs.AdminUI/Views/GovNotifyDashboard/Index.cshtml
@@ -42,7 +42,7 @@
                         </td>
                         <td>@request.RequestStatus</td>
                         <td>@request.RetryCount</td>
-                        <td>@request.CreatedAt.LocalDateTime.ToString("dd/MM/yyyy HH:mm:ss")</td>
+                        <td>@request.CreatedAt.DateTime.ToString("dd/MM/yyyy HH:mm:ss")</td>
                     </tr>
                 }
             }

--- a/MessageQueueing/LearningHub.Nhs.MessageQueueing.Database/Stored Procedures/CreateQueueRequests.sql
+++ b/MessageQueueing/LearningHub.Nhs.MessageQueueing.Database/Stored Procedures/CreateQueueRequests.sql
@@ -6,15 +6,17 @@
 -- Modification History
 --
 -- 27-05-2025  Arunima George	Initial Revision
+-- 03-06-2026  Arunima George   TD-7354
 -------------------------------------------------------------------------------
 
-Create PROCEDURE [dbo].[CreateQueueRequests]
-    @QueueRequests dbo.QueueRequestTableType READONLY
+CREATE PROCEDURE [dbo].[CreateQueueRequests]
+    @QueueRequests dbo.QueueRequestTableType READONLY,
+	@UserTimezoneOffset int = NULL
 AS
 BEGIN
+	DECLARE @CreateDate datetimeoffset(7) = ISNULL(TODATETIMEOFFSET(DATEADD(mi, @UserTimezoneOffset, GETUTCDATE()), @UserTimezoneOffset), SYSDATETIMEOFFSET())
 
     INSERT INTO QueueRequests (RequestTypeId, Recipient, TemplateId, Personalisation, Status, RetryCount, CreatedAt, DeliverAfter)
-    SELECT 1, Recipient, TemplateId, Personalisation, 1, 0, SYSDATETIMEOFFSET(), DeliverAfter
+    SELECT 1, Recipient, TemplateId, Personalisation, 1, 0, @CreateDate, DeliverAfter
     FROM @QueueRequests;
 END
-GO

--- a/MessageQueueing/LearningHub.Nhs.MessageQueueing.Database/Stored Procedures/SaveSingleEmailTransactions.sql
+++ b/MessageQueueing/LearningHub.Nhs.MessageQueueing.Database/Stored Procedures/SaveSingleEmailTransactions.sql
@@ -1,12 +1,11 @@
 ﻿-------------------------------------------------------------------------------
 -- Author       Arunima George
 -- Created      27-05-2025
--- Purpose      Save one-off(like otp emails) failed email request.
+-- Purpose      Save all one-off(like otp) email request transactions.
 --
 -- Modification History
 --
 -- 27-05-2025  Arunima George	Initial Revision
--- 10-07-2025  Arunima George   Changed SP name to accomodate success/failed emails
 -- 03-06-2026  Arunima George   TD-7354
 -------------------------------------------------------------------------------
 

--- a/MessageQueueing/LearningHub.Nhs.MessageQueueing.Database/Stored Procedures/SaveSingleEmailTransactions.sql
+++ b/MessageQueueing/LearningHub.Nhs.MessageQueueing.Database/Stored Procedures/SaveSingleEmailTransactions.sql
@@ -1,11 +1,13 @@
 ﻿-------------------------------------------------------------------------------
 -- Author       Arunima George
 -- Created      27-05-2025
--- Purpose      Save all one-off(like otp) email request transactions.
+-- Purpose      Save one-off(like otp emails) failed email request.
 --
 -- Modification History
 --
 -- 27-05-2025  Arunima George	Initial Revision
+-- 10-07-2025  Arunima George   Changed SP name to accomodate success/failed emails
+-- 03-06-2026  Arunima George   TD-7354
 -------------------------------------------------------------------------------
 
 CREATE PROCEDURE [dbo].[SaveSingleEmailTransactions]
@@ -13,10 +15,13 @@ CREATE PROCEDURE [dbo].[SaveSingleEmailTransactions]
 	@TemplateId nvarchar(50),
 	@Personalisation nvarchar(max) = NULL,
 	@Status int,
-	@ErrorMessage nvarchar(max) = NULL
+	@ErrorMessage nvarchar(max) = NULL,
+	@UserTimezoneOffset int = NULL
 AS
 BEGIN	
+			DECLARE @CreateDate datetimeoffset(7) = ISNULL(TODATETIMEOFFSET(DATEADD(mi, @UserTimezoneOffset, GETUTCDATE()), @UserTimezoneOffset), SYSDATETIMEOFFSET())
+
 			insert into [dbo].[QueueRequests] (RequestTypeId, Recipient, TemplateId, Personalisation, Status, CreatedAt, LastAttemptAt,ErrorMessage )
-			values (3, @Recipient, @TemplateId, @Personalisation, @Status, SYSDATETIMEOFFSET(), SYSDATETIMEOFFSET(), @ErrorMessage);
+			values (3, @Recipient, @TemplateId, @Personalisation, @Status, @CreateDate, @CreateDate, @ErrorMessage);
 END
 GO

--- a/MessageQueueing/LearningHub.Nhs.MessageQueueing/Repositories/IMessageQueueRepository.cs
+++ b/MessageQueueing/LearningHub.Nhs.MessageQueueing/Repositories/IMessageQueueRepository.cs
@@ -15,8 +15,9 @@
         /// The QueueMessagesAsync.
         /// </summary>
         /// <param name="emails">The emails list.</param>
+        /// <param name="userTimeOffset"></param>
         /// <returns>The <see cref="Task"/>.</returns>
-        Task QueueMessagesAsync(IEnumerable<QueueRequests> emails);
+        Task QueueMessagesAsync(IEnumerable<QueueRequests> emails, int? userTimeOffset);
 
         /// <summary>
         /// The GetPendingEmailsAsync.
@@ -42,8 +43,9 @@
         /// Save one-off emails.
         /// </summary>
         /// <param name="request">The email request.</param>
+        /// <param name="userTimeOffset">user time offset.</param>
         /// <returns>The <see cref="Task"/>.</returns>
-        Task SaveSingleEmailTransactions(SingleEmailRequest request);
+        Task SaveSingleEmailTransactions(SingleEmailRequest request, int? userTimeOffset);
 
         /// <summary>
         /// The GetPaginatedMessageRequests.

--- a/MessageQueueing/LearningHub.Nhs.MessageQueueing/Repositories/MessageQueueRepository.cs
+++ b/MessageQueueing/LearningHub.Nhs.MessageQueueing/Repositories/MessageQueueRepository.cs
@@ -37,12 +37,14 @@
         /// The QueueMessagesAsync.
         /// </summary>
         /// <param name="requests">The queue requests.</param>
+        /// <param name="userTimeOffset">userTimeOffset.</param>
         /// <returns>The <see cref="Task"/>.</returns>
-        public async Task QueueMessagesAsync(IEnumerable<QueueRequests> requests)
+        public async Task QueueMessagesAsync(IEnumerable<QueueRequests> requests, int? userTimeOffset)
         {
             var dataTable = DataTableBuilder.ToQueueRequestDataTable(requests);
             var param0 = new SqlParameter("@p0", SqlDbType.Structured) { Value = dataTable, TypeName = "dbo.QueueRequestTableType" };
-            await this.dbContext.Database.ExecuteSqlRawAsync("dbo.CreateQueueRequests @p0", param0);
+            var param1 = new SqlParameter("@p1", SqlDbType.Int) { Value = userTimeOffset ?? (object)DBNull.Value };
+            await this.dbContext.Database.ExecuteSqlRawAsync("dbo.CreateQueueRequests @p0, @p1", param0, param1);
         }
 
         /// <summary>
@@ -84,15 +86,17 @@
         /// The Save Single Emails.
         /// </summary>
         /// <param name="request">The request.</param>
+        /// <param name="userTimeOffset">userTimeOffset.</param>
         /// <returns>The <see cref="Task"/>.</returns>
-        public async Task SaveSingleEmailTransactions(SingleEmailRequest request)
+        public async Task SaveSingleEmailTransactions(SingleEmailRequest request, int? userTimeOffset)
         {
             var param0 = new SqlParameter("@p0", SqlDbType.NVarChar) { Value = request.Recipient };
             var param1 = new SqlParameter("@p1", SqlDbType.NVarChar) { Value = request.TemplateId };
             var param2 = new SqlParameter("@p2", SqlDbType.NVarChar) { Value = request.Personalisation == null ? DBNull.Value : request.Personalisation };
             var param3 = new SqlParameter("@p3", SqlDbType.Int) { Value = request.Status };
             var param4 = new SqlParameter("@p4", SqlDbType.NVarChar) { Value = request.ErrorMessage == null ? DBNull.Value : request.ErrorMessage };
-            await this.dbContext.Database.ExecuteSqlRawAsync("dbo.SaveSingleEmailTransactions @p0, @p1, @p2, @p3, @p4", param0, param1, param2, param3, param4);
+            var param5 = new SqlParameter("@p5", SqlDbType.Int) { Value = userTimeOffset ?? (object)DBNull.Value };
+            await this.dbContext.Database.ExecuteSqlRawAsync("dbo.SaveSingleEmailTransactions @p0, @p1, @p2, @p3, @p4, @p5", param0, param1, param2, param3, param4, param5);
         }
 
         /// <summary>

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Services/Services/Messaging/GovMessageService.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Services/Services/Messaging/GovMessageService.cs
@@ -11,6 +11,7 @@
     using LearningHub.Nhs.Models.Entities.Messaging;
     using LearningHub.Nhs.Models.Enums.GovNotifyMessaging;
     using LearningHub.Nhs.Models.GovNotifyMessaging;
+    using LearningHub.Nhs.OpenApi.Repositories.Interface.Repositories;
     using LearningHub.Nhs.OpenApi.Services.Interface.Services.Messaging;
     using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
@@ -23,6 +24,7 @@
         private readonly IMessageQueueRepository messageQueueRepository;
         private readonly IGovNotifyService messageService;
         private readonly IMapper mapper;
+        private readonly ITimezoneOffsetManager timezoneOffsetManager;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GovMessageService"/> class.
@@ -31,16 +33,19 @@
         /// <param name="messageQueueRepository">The message repository.</param>
         /// <param name="messageService">The message Service.</param>
         /// <param name="mapper">mapper.</param>
+        /// <param name="timezoneOffsetManager">The timezoneOffsetManager.</param>
         public GovMessageService(
             ILogger<Message> logger,
             IMessageQueueRepository messageQueueRepository,
             IGovNotifyService messageService,
-            IMapper mapper)
+            IMapper mapper,
+            ITimezoneOffsetManager timezoneOffsetManager)
             : base(logger)
         {
             this.messageQueueRepository = messageQueueRepository;
             this.messageService = messageService;
             this.mapper = mapper;
+            this.timezoneOffsetManager = timezoneOffsetManager;
         }
 
         /// <summary>
@@ -74,7 +79,8 @@
                         Status = response.IsSuccess == true ? RequestStatusEnum.Sent : RequestStatusEnum.Failed,
                         ErrorMessage = response.ErrorMessage,
                     };
-                    await this.messageQueueRepository.SaveSingleEmailTransactions(emailRequest);
+                    var userTimeOffset = this.timezoneOffsetManager.UserTimezoneOffset;
+                    await this.messageQueueRepository.SaveSingleEmailTransactions(emailRequest, userTimeOffset);
                 }
             }
 
@@ -87,7 +93,7 @@
         /// <param name="request">The QueueRequestList.</param>
         /// <returns>The <see cref="Task{IActionResult}"/>.</returns>
         public async Task QueueRequestsAsync(QueueMessageList request)
-        {
+        {   
             if (request?.Messages == null || !request.Messages.Any())
             {
                 throw new ArgumentException("At least one email must be provided in the request.");
@@ -101,7 +107,8 @@
                 DeliverAfter = q.DeliverAfter ?? null,
             });
 
-            await this.messageQueueRepository.QueueMessagesAsync(requests);
+            var userTimeOffset = this.timezoneOffsetManager.UserTimezoneOffset;
+            await this.messageQueueRepository.QueueMessagesAsync(requests, userTimeOffset);
         }
 
         /// <summary>


### PR DESCRIPTION
### JIRA link
[TD-7354](https://hee-tis.atlassian.net/browse/TD-7354)

### Description
Fixed datetime issue.

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-7354]: https://hee-tis.atlassian.net/browse/TD-7354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ