### PR TITLE
TD-7354: LH Admin UI - GovNotify dashboard entries (Created Date) tim…

### DIFF
--- a/MessageQueueing/LearningHub.Nhs.MessageQueueing.Database/Stored Procedures/CreateQueueRequests.sql
+++ b/MessageQueueing/LearningHub.Nhs.MessageQueueing.Database/Stored Procedures/CreateQueueRequests.sql
@@ -17,6 +17,6 @@ BEGIN
 	DECLARE @CreateDate datetimeoffset(7) = ISNULL(TODATETIMEOFFSET(DATEADD(mi, @UserTimezoneOffset, GETUTCDATE()), @UserTimezoneOffset), SYSDATETIMEOFFSET())
 
     INSERT INTO QueueRequests (RequestTypeId, Recipient, TemplateId, Personalisation, Status, RetryCount, CreatedAt, DeliverAfter)
-    SELECT 1, Recipient, TemplateId, Personalisation, 1, 0, @CreateDate, DeliverAfter
+    SELECT 1, Recipient, TemplateId, Personalisation, 1, 0, @CreateDate, SWITCHOFFSET(DeliverAfter, '+00:00')
     FROM @QueueRequests;
 END

--- a/MessageQueueing/LearningHub.Nhs.MessageQueueing.Database/Stored Procedures/MessageDeliveryFailed.sql
+++ b/MessageQueueing/LearningHub.Nhs.MessageQueueing.Database/Stored Procedures/MessageDeliveryFailed.sql
@@ -6,19 +6,24 @@
 -- Modification History
 --
 -- 27-05-2025  Arunima George	Initial Revision
+-- 08-06-2026  SA   TD-7354
 -------------------------------------------------------------------------------
 
 CREATE PROCEDURE [dbo].[MessageDeliveryFailed]
 	@Id int,
-	@ErrorMessage nvarchar(max)
+	@ErrorMessage nvarchar(max),
+	@UserTimezoneOffset int = NULL
 AS
 BEGIN		
+       
+	   DECLARE @LastAttemptDate datetimeoffset(7) = ISNULL(TODATETIMEOFFSET(DATEADD(mi, @UserTimezoneOffset, GETUTCDATE()), @UserTimezoneOffset), SYSDATETIMEOFFSET())
+
 			UPDATE [dbo].[QueueRequests]
 			SET 
 				Status = 3,
 				RetryCount = RetryCount + 1,
 				ErrorMessage = @ErrorMessage,
-				LastAttemptAt = SYSDATETIMEOFFSET()
+				LastAttemptAt = @LastAttemptDate
 			where Id = @Id;
 END
 GO

--- a/MessageQueueing/LearningHub.Nhs.MessageQueueing.Database/Stored Procedures/MessageDeliverySuccess.sql
+++ b/MessageQueueing/LearningHub.Nhs.MessageQueueing.Database/Stored Procedures/MessageDeliverySuccess.sql
@@ -6,21 +6,24 @@
 -- Modification History
 --
 -- 27-05-2025  Arunima George	Initial Revision
+-- 08-06-2026  SA   TD-7354
 -------------------------------------------------------------------------------
 
 CREATE PROCEDURE [dbo].[MessageDeliverySuccess]
 	@Id int,
-	@NotificationId nvarchar(100)
+	@NotificationId nvarchar(100),
+	@UserTimezoneOffset int = NULL
 
 AS
 BEGIN	
+DECLARE @SentDate datetimeoffset(7) = ISNULL(TODATETIMEOFFSET(DATEADD(mi, @UserTimezoneOffset, GETUTCDATE()), @UserTimezoneOffset), SYSDATETIMEOFFSET())
 			UPDATE [dbo].[QueueRequests]
 			SET 
 				Status = 2,
 				NotificationId = @NotificationId,
 				RetryCount = RetryCount + 1,
-				SentAt = SYSDATETIMEOFFSET(),
-				LastAttemptAt = SYSDATETIMEOFFSET()
+				SentAt = @SentDate,
+				LastAttemptAt = @SentDate
 			where Id = @Id;
 END
 GO

--- a/MessageQueueing/LearningHub.Nhs.MessageQueueing/Repositories/IMessageQueueRepository.cs
+++ b/MessageQueueing/LearningHub.Nhs.MessageQueueing/Repositories/IMessageQueueRepository.cs
@@ -29,15 +29,17 @@
         /// Marks a message as failed, or queues it for a retry.
         /// </summary>
         /// <param name="response">The response.</param>
+        /// <param name="userTimeOffset">The userTimeOffset.</param>
         /// <returns>The <see cref="Task"/>.</returns>
-        Task MessageDeliveryFailed(GovNotifyResponse response);
+        Task MessageDeliveryFailed(GovNotifyResponse response, int? userTimeOffset);
 
         /// <summary>
         /// Marks a message as send.
         /// </summary>
         /// <param name="response">The response.</param>
+        /// <param name="userTimeOffset">The userTimeOffset.</param>
         /// <returns>The <see cref="Task"/>.</returns>
-        Task MessageDeliverySuccess(GovNotifyResponse response);
+        Task MessageDeliverySuccess(GovNotifyResponse response, int? userTimeOffset);
 
         /// <summary>
         /// Save one-off emails.

--- a/MessageQueueing/LearningHub.Nhs.MessageQueueing/Repositories/MessageQueueRepository.cs
+++ b/MessageQueueing/LearningHub.Nhs.MessageQueueing/Repositories/MessageQueueRepository.cs
@@ -62,24 +62,28 @@
         /// The Update Email request as success.
         /// </summary>
         /// <param name="response">Th response.</param>
+        /// <param name="userTimeOffset">Th userTimeOffset.</param>
         /// <returns>The <see cref="Task"/>.</returns>
-        public async Task MessageDeliverySuccess(GovNotifyResponse response)
+        public async Task MessageDeliverySuccess(GovNotifyResponse response, int? userTimeOffset)
         {
             var param0 = new SqlParameter("@p0", SqlDbType.Int) { Value = response.Id };
             var param1 = new SqlParameter("@p1", SqlDbType.NVarChar) { Value = response.NotificationId };
-            await this.dbContext.Database.ExecuteSqlRawAsync("dbo.MessageDeliverySuccess @p0, @p1", param0, param1);
+            var param2 = new SqlParameter("@p2", SqlDbType.Int) { Value = userTimeOffset ?? (object)DBNull.Value };
+            await this.dbContext.Database.ExecuteSqlRawAsync("dbo.MessageDeliverySuccess @p0, @p1, @p2", param0, param1, param2);
         }
 
         /// <summary>
         /// The Update Email request as failed.
         /// </summary>
         /// <param name="response">Th response.</param>
+        /// <param name="userTimeOffset">Th userTimeOffset.</param>
         /// <returns>The <see cref="Task"/>.</returns>
-        public async Task MessageDeliveryFailed(GovNotifyResponse response)
+        public async Task MessageDeliveryFailed(GovNotifyResponse response, int? userTimeOffset)
         {
             var param0 = new SqlParameter("@p0", SqlDbType.Int) { Value = response.Id };
             var param1 = new SqlParameter("@p1", SqlDbType.NVarChar) { Value = response.ErrorMessage };
-            await this.dbContext.Database.ExecuteSqlRawAsync("dbo.MessageDeliveryFailed @p0, @p1", param0, param1);
+            var param2 = new SqlParameter("@p2", SqlDbType.Int) { Value = userTimeOffset ?? (object)DBNull.Value };
+            await this.dbContext.Database.ExecuteSqlRawAsync("dbo.MessageDeliveryFailed @p0, @p1, @p2", param0, param1, param2);
         }
 
         /// <summary>

--- a/OpenAPI/LearningHub.Nhs.OpenApi/Controllers/GovNotifyMessagingController.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi/Controllers/GovNotifyMessagingController.cs
@@ -7,6 +7,7 @@
     using LearningHub.Nhs.MessagingService.Interfaces;
     using LearningHub.Nhs.Models.Common;
     using LearningHub.Nhs.Models.GovNotifyMessaging;
+    using LearningHub.Nhs.OpenApi.Repositories.Interface.Repositories;
     using LearningHub.Nhs.OpenApi.Services.Interface.Services.Messaging;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
@@ -21,17 +22,21 @@
         private readonly IGovNotifyService messageService;
         private readonly IMessageQueueRepository messageQueueRepository;
         private readonly IGovMessageService govMessageService;
+        private readonly Nhs.OpenApi.Repositories.Interface.Repositories.ITimezoneOffsetManager timezoneOffsetManager;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GovNotifyMessagingController"/> class.
         /// </summary>
         /// <param name="messageService">The message service.</param>
         /// <param name="messageQueueRepository">The email Queue Repository.</param>
-        public GovNotifyMessagingController(IGovNotifyService messageService, IMessageQueueRepository messageQueueRepository, IGovMessageService govMessageService)
+        /// <param name="govMessageService">The govMessageService.</param>
+        /// <param name="timezoneOffsetManager">The timezoneOffsetManager.</param>
+        public GovNotifyMessagingController(IGovNotifyService messageService, IMessageQueueRepository messageQueueRepository, IGovMessageService govMessageService, ITimezoneOffsetManager timezoneOffsetManager)
         {
             this.messageService = messageService;
             this.messageQueueRepository = messageQueueRepository;
             this.govMessageService = govMessageService;
+            this.timezoneOffsetManager = timezoneOffsetManager;
         }
 
         /// <summary>
@@ -135,7 +140,8 @@
         [HttpPost]
         public async Task<IActionResult> MessageSuccessUpdate([FromBody] GovNotifyResponse response)
         {
-            await this.messageQueueRepository.MessageDeliverySuccess(response);
+            var userTimeOffset = this.timezoneOffsetManager.UserTimezoneOffset;
+            await this.messageQueueRepository.MessageDeliverySuccess(response, userTimeOffset);
             return this.Ok();
         }
 
@@ -148,7 +154,8 @@
         [HttpPost]
         public async Task<IActionResult> MessageFailedUpdate([FromBody] GovNotifyResponse response)
         {
-            await this.messageQueueRepository.MessageDeliveryFailed(response);
+            var userTimeOffset = this.timezoneOffsetManager.UserTimezoneOffset;
+            await this.messageQueueRepository.MessageDeliveryFailed(response, userTimeOffset);
             return this.Ok();
         }
 


### PR DESCRIPTION
…ing is incorrect

### JIRA link
[TD-7354](https://hee-tis.atlassian.net/browse/TD-7354)

### Description
Fixed date issues

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-7354]: https://hee-tis.atlassian.net/browse/TD-7354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ