### PR TITLE
TD-7375: After catalogue access permission is removed for a user, whe…

### DIFF
--- a/LearningHub.Nhs.WebUI/Views/Shared/_RestrictedAccessBanner.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Shared/_RestrictedAccessBanner.cshtml
@@ -4,26 +4,26 @@
 
 @if (ViewBag.UserAuthenticated && Model.RestrictedAccess && !Model.HasCatalogueAccess)
 {
-  <div class="nhsuk-bg-pale-blue nhsuk-u-padding-top-4 nhsuk-u-padding-bottom-3 nhsuk-u-margin-bottom-3">
-    <div class="nhsuk-width-container app-width-container">
-      @if (Model.CatalogueAccessRequest != null && Model.CatalogueAccessRequest.Status == CatalogueAccessRequestStatus.Pending)
-      {
-      <h2 class="nhsuk-card__heading">@Model.TitleText</h2>
-      <p>Your access request which was sent on @Model.CatalogueAccessRequest.DateRequested.ToString("dd MMM yyyy") is pending a decision.</p>
-      <p>If you need further information <a target="_blank" href="@ViewBag.SupportUrl">contact support</a></p>
-      }
-      else if (Model.CatalogueAccessRequest != null && Model.CatalogueAccessRequest.Status == CatalogueAccessRequestStatus.Rejected)
-      {
-      <h2>@Model.TitleText</h2>
-      <p class="nhsuk-u-reading-width">The catalogue administrator did not approve your request to access this catalogue on @Model.CatalogueAccessRequest.DateRejected.Value.ToString("dd MMM yyyy"). If anything has changed in relation to your original request, you can request access again.</p>
-      <a class="nhsuk-button" asp-controller="Catalogue" asp-action="RequestAccess" asp-route-catalogueNodeVersionId="@Model.CatalogueNodeVersionId">Request access</a>
-      }
-      else if (Model.CatalogueAccessRequest == null || Model.UserGroups.Count == 0)
-      {
-      <h2>@Model.TitleText</h2>
-      <p class="nhsuk-u-reading-width">@Model.BodyText</p>
-      <a class="nhsuk-button" asp-controller="Catalogue" asp-action="RequestAccess" asp-route-catalogueNodeVersionId="@Model.CatalogueNodeVersionId">Request access</a>
-      }
+    <div class="nhsuk-bg-pale-blue nhsuk-u-padding-top-4 nhsuk-u-padding-bottom-3 nhsuk-u-margin-bottom-3">
+        <div class="nhsuk-width-container app-width-container">
+            @if (Model.CatalogueAccessRequest != null && Model.CatalogueAccessRequest.Status == CatalogueAccessRequestStatus.Pending)
+            {
+                <h2 class="nhsuk-card__heading">@Model.TitleText</h2>
+                <p>Your access request which was sent on @Model.CatalogueAccessRequest.DateRequested.ToString("dd MMM yyyy") is pending a decision.</p>
+                <p>If you need further information <a target="_blank" href="@ViewBag.SupportUrl">contact support</a></p>
+            }
+            else if (Model.CatalogueAccessRequest != null && Model.CatalogueAccessRequest.Status == CatalogueAccessRequestStatus.Rejected)
+            {
+                <h2>@Model.TitleText</h2>
+                <p class="nhsuk-u-reading-width">The catalogue administrator did not approve your request to access this catalogue on @Model.CatalogueAccessRequest.DateRejected.Value.ToString("dd MMM yyyy"). If anything has changed in relation to your original request, you can request access again.</p>
+                <a class="nhsuk-button" asp-controller="Catalogue" asp-action="RequestAccess" asp-route-catalogueNodeVersionId="@Model.CatalogueNodeVersionId">Request access</a>
+            }
+            else if (Model.CatalogueAccessRequest == null || (Model.UserGroups?.Count ?? 0) == 0)
+            {
+                <h2>@Model.TitleText</h2>
+                <p class="nhsuk-u-reading-width">@Model.BodyText</p>
+                <a class="nhsuk-button" asp-controller="Catalogue" asp-action="RequestAccess" asp-route-catalogueNodeVersionId="@Model.CatalogueNodeVersionId">Request access</a>
+            }
+        </div>
     </div>
-  </div>
 }


### PR DESCRIPTION
…n user access resources within the restricted catalogue is resulting in an error.

### JIRA link
[TD-7375](https://hee-tis.atlassian.net/browse/TD-7375)

### Description
_Describe what has changed and how that will affect the app. If relevant, add links to any sources/documentation you used. After catalogue access permission is removed for a user, when user access resources within the restricted catalogue is resulting in an error. - Fixed the issue

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-7375]: https://hee-tis.atlassian.net/browse/TD-7375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ