### PR TITLE
TD-7404: Accessed Date Not Displayed for Enrolled Courses That Have N…

### DIFF
--- a/LearningHub.Nhs.WebUI/Views/Home/_CertificateCard.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Home/_CertificateCard.cshtml
@@ -14,10 +14,6 @@
     bool providerExists = Model.Item2.Providers?.Count > 0;
     string cardStyle = Model.Item1.Contains("my-learning") ? "card-provider-details--darkblank" : "card-provider-details--blank";
     var activityDate = Model.Item2.AwardedDate.Date;
-    // // var today = DateTime.Today;
-    // // var dateTimeText = activityDate == today ? "Today"
-    // // : activityDate == today.AddDays(-1) ? "Yesterday"
-    // // : activityDate.ToString("dd MMM yyyy");
     var today = DateTime.Today;
 
     var dateTimeText =

--- a/LearningHub.Nhs.WebUI/Views/Home/_CertificateCard.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Home/_CertificateCard.cshtml
@@ -14,10 +14,17 @@
     bool providerExists = Model.Item2.Providers?.Count > 0;
     string cardStyle = Model.Item1.Contains("my-learning") ? "card-provider-details--darkblank" : "card-provider-details--blank";
     var activityDate = Model.Item2.AwardedDate.Date;
+    // // var today = DateTime.Today;
+    // // var dateTimeText = activityDate == today ? "Today"
+    // // : activityDate == today.AddDays(-1) ? "Yesterday"
+    // // : activityDate.ToString("dd MMM yyyy");
     var today = DateTime.Today;
-    var dateTimeText = activityDate == today ? "Today"
-    : activityDate == today.AddDays(-1) ? "Yesterday"
-    : activityDate.ToString("dd MMM yyyy");
+
+    var dateTimeText =
+        activityDate == DateTimeOffset.MinValue ? "" :
+        activityDate.Date == today ? "Today" :
+        activityDate.Date == today.AddDays(-1) ? "Yesterday" :
+        activityDate.ToString("dd MMM yyyy");
     string GetMoodleCourseUrl(int courseId)
     {
         return moodleApiService.GetCourseUrl(courseId);

--- a/LearningHub.Nhs.WebUI/Views/Home/_LearningActivityCard.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Home/_LearningActivityCard.cshtml
@@ -14,9 +14,12 @@
     string cardStyle = Model.Item1.Contains("my-learning") ? "card-provider-details--darkblank" : "card-provider-details--blank";
     var activityDate = Model.Item2.ActivityDate.Date;
     var today = DateTime.Today;
-    var dateTimeText = activityDate == today ? "Today"
-    : activityDate == today.AddDays(-1) ? "Yesterday"
-    : activityDate.ToString("dd MMM yyyy");
+
+    var dateTimeText =
+        activityDate == DateTimeOffset.MinValue ? "" :
+        activityDate.Date == today ? "Today" :
+        activityDate.Date == today.AddDays(-1) ? "Yesterday" :
+        activityDate.ToString("dd MMM yyyy");
     string GetMoodleCourseUrl(int courseId)
     {
         return moodleApiService.GetCourseUrl(courseId);

--- a/LearningHub.Nhs.WebUI/Views/MyLearning/Certificates.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/MyLearning/Certificates.cshtml
@@ -208,9 +208,12 @@
 
                             var activityDate = certificate.AwardedDate.Date;
                             var today = DateTime.Today;
-                            var dateTimeText = activityDate == today ? "Today"
-                            : activityDate == today.AddDays(-1) ? "Yesterday"
-                            : activityDate.ToString("dd MMM yyyy");
+
+                            var dateTimeText =
+                            activityDate == DateTimeOffset.MinValue ? "" :
+                            activityDate.Date == today ? "Today" :
+                            activityDate.Date == today.AddDays(-1) ? "Yesterday" :
+                            activityDate.ToString("dd MMM yyyy");
 
 
 

--- a/LearningHub.Nhs.WebUI/Views/MyLearning/DownloadActivityRecords.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/MyLearning/DownloadActivityRecords.cshtml
@@ -1118,9 +1118,12 @@
 
                         var activityDate = activity.ActivityDate.Date;
                         var today = DateTime.Today;
-                        var dateTimeText = activityDate == today ? "Today"
-                        : activityDate == today.AddDays(-1) ? "Yesterday"
-                        : activityDate.ToString("dd MMM yyyy");
+
+                        var dateTimeText =
+                        activityDate == DateTimeOffset.MinValue ? "" :
+                        activityDate.Date == today ? "Today" :
+                        activityDate.Date == today.AddDays(-1) ? "Yesterday" :
+                        activityDate.ToString("dd MMM yyyy");
                         var certicateAwardedDate = activity.CertificateAwardedDate.Date;
                         var certificateAwardedText = certicateAwardedDate == today ? "Today"
                         : certicateAwardedDate == today.AddDays(-1) ? "Yesterday"

--- a/LearningHub.Nhs.WebUI/Views/MyLearning/Index.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/MyLearning/Index.cshtml
@@ -108,10 +108,17 @@
                         var displayText = isCompleted ? "Completed" : "Accessed";
 
                         var activityDate = activity.ActivityDate.Date;
-                        var today = DateTime.Today;
+                        @*  var today = DateTime.Today;
                         var dateTimeText = activityDate == today ? "Today"
                         : activityDate == today.AddDays(-1) ? "Yesterday"
-                        : activityDate.ToString("dd MMM yyyy");
+                        : activityDate.ToString("dd MMM yyyy"); *@ 
+                        var today = DateTime.Today;
+
+                        var dateTimeText =
+                        activityDate == DateTimeOffset.MinValue ? "" :
+                        activityDate.Date == today ? "Today" :
+                        activityDate.Date == today.AddDays(-1) ? "Yesterday" :
+                        activityDate.ToString("dd MMM yyyy");
                         var certicateAwardedDate = activity.CertificateAwardedDate.Date;
                         var certificateAwardedText = certicateAwardedDate == today ? "Today"
                         : certicateAwardedDate == today.AddDays(-1) ? "Yesterday"

--- a/LearningHub.Nhs.WebUI/Views/MyLearning/Index.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/MyLearning/Index.cshtml
@@ -108,10 +108,6 @@
                         var displayText = isCompleted ? "Completed" : "Accessed";
 
                         var activityDate = activity.ActivityDate.Date;
-                        @*  var today = DateTime.Today;
-                        var dateTimeText = activityDate == today ? "Today"
-                        : activityDate == today.AddDays(-1) ? "Yesterday"
-                        : activityDate.ToString("dd MMM yyyy"); *@ 
                         var today = DateTime.Today;
 
                         var dateTimeText =

--- a/LearningHub.Nhs.WebUI/Views/MyLearning/LearningHistory.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/MyLearning/LearningHistory.cshtml
@@ -177,9 +177,12 @@
 
                         var activityDate = activity.ActivityDate.Date;
                         var today = DateTime.Today;
-                        var dateTimeText = activityDate == today ? "Today"
-                        : activityDate == today.AddDays(-1) ? "Yesterday"
-                        : activityDate.ToString("dd MMM yyyy");
+
+                        var dateTimeText =
+                        activityDate == DateTimeOffset.MinValue ? "" :
+                        activityDate.Date == today ? "Today" :
+                        activityDate.Date == today.AddDays(-1) ? "Yesterday" :
+                        activityDate.ToString("dd MMM yyyy");
                         var certicateAwardedDate = activity.CertificateAwardedDate.Date;
                         var certificateAwardedText = certicateAwardedDate == today ? "Today"
                         : certicateAwardedDate == today.AddDays(-1) ? "Yesterday"


### PR DESCRIPTION
…ot Been Accessed

### JIRA link
[TD-7404](https://hee-tis.atlassian.net/browse/TD-7404)

### Description
Accessed Date Not Displayed for Enrolled Courses That Have Not Been Accessed

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-7404]: https://hee-tis.atlassian.net/browse/TD-7404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ