### PR TITLE
TD-7354: To Correct the created date as per the UTC timing

### DIFF
--- a/AdminUI/LearningHub.Nhs.AdminUI/LearningHub.Nhs.AdminUI.csproj
+++ b/AdminUI/LearningHub.Nhs.AdminUI/LearningHub.Nhs.AdminUI.csproj
@@ -83,7 +83,7 @@
 		<PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
 		<PackageReference Include="Azure.Storage.Files.Shares" Version="12.8.0" />
 		<PackageReference Include="BuildWebCompiler" Version="1.12.405" />
-		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
+		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.15" />
 		<PackageReference Include="FluentValidation" Version="11.11.0" />
 		<PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
 		<PackageReference Include="HtmlSanitizer" Version="6.0.453" />

--- a/LearningHub.Nhs.WebUI.AutomatedUiTests/LearningHub.Nhs.WebUI.AutomatedUiTests.csproj
+++ b/LearningHub.Nhs.WebUI.AutomatedUiTests/LearningHub.Nhs.WebUI.AutomatedUiTests.csproj
@@ -11,7 +11,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
+		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.15" />
 		<PackageReference Include="FluentAssertions" Version="6.12.0" />
 		<PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.13" />

--- a/LearningHub.Nhs.WebUI/Controllers/AccountController.cs
+++ b/LearningHub.Nhs.WebUI/Controllers/AccountController.cs
@@ -1066,12 +1066,13 @@
         /// <summary>
         /// Account confirmation and Create account API request.
         /// </summary>
+        /// <param name="accountCreationConfirmationModel">accountCreationConfirmation.</param>
         /// <returns>The <see cref="IActionResult"/>.</returns>
         [HttpPost]
         [Route("Registration/CreateAccountConfirmation")]
         [ResponseCache(CacheProfileName = "Never")]
         [TypeFilter(typeof(RedirectMissingMultiPageFormData), Arguments = new object[] { nameof(MultiPageFormDataFeature.AddRegistrationPrompt) })]
-        public async Task<IActionResult> CreateAccountConfirmation()
+        public async Task<IActionResult> CreateAccountConfirmation(AccountCreationConfirmation accountCreationConfirmationModel)
         {
             var accountCreation = await this.multiPageFormService.GetMultiPageFormData<AccountCreationViewModel>(MultiPageFormDataFeature.AddRegistrationPrompt, this.TempData);
             this.ViewBag.AccountCreationType = accountCreation.AccountCreationType;
@@ -1100,6 +1101,7 @@
                     LocationStartDate = accountCreation.StartDate.GetValueOrDefault(),
                     MedicalCouncilNumber = accountCreation.RegistrationNumber,
                     SpecialtyId = int.TryParse(accountCreation.PrimarySpecialtyId, out int specialtyId) ? specialtyId : 0,
+                    TimezoneOffset = accountCreationConfirmationModel.TimezoneOffset,
                 };
                 var response = await this.userService.RegisterNewUser(request);
                 if (!response.IsValid)

--- a/LearningHub.Nhs.WebUI/LearningHub.Nhs.WebUI.csproj
+++ b/LearningHub.Nhs.WebUI/LearningHub.Nhs.WebUI.csproj
@@ -106,7 +106,7 @@
 		<PackageReference Include="AspNetCoreRateLimit" Version="5.0.0" />
 		<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
 		<PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
-		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
+		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.15" />
 		<PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
 		<PackageReference Include="GDS.MultiPageFormData" Version="1.0.6" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.11.72" />

--- a/LearningHub.Nhs.WebUI/Models/Account/AccountCreationConfirmation.cs
+++ b/LearningHub.Nhs.WebUI/Models/Account/AccountCreationConfirmation.cs
@@ -34,5 +34,10 @@
         /// Gets or sets the AccountCreationViewModel.
         /// </summary>
         public AccountCreationViewModel AccountCreationViewModel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the TimezoneOffset.
+        /// </summary>
+        public int? TimezoneOffset { get; set; }
     }
 }

--- a/LearningHub.Nhs.WebUI/Views/Account/CreateAccountConfirmation.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Account/CreateAccountConfirmation.cshtml
@@ -215,6 +215,7 @@
                     }
                 </dl>
                 <form asp-controller="Account" asp-action="CreateAccountConfirmation" method="post">
+                    <input type="hidden" id="TimezoneOffset" name="TimezoneOffset" />
                     <button class="nhsuk-button" id="save-button" type="submit">@(accountCreationType == AccountCreationTypeEnum.FullAccess ? "Continue to create a Full User account" : "Continue to create a General user account")</button>
                 </form>
                 @if (accountCreationType == AccountCreationTypeEnum.GeneralAccess)
@@ -236,3 +237,6 @@
         </div>
     </div>
 </div>
+<script type="text/javascript">
+    document.getElementById("TimezoneOffset").value = -new Date().getTimezoneOffset();
+</script>

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Services.Interface/LearningHub.Nhs.OpenApi.Services.Interface.csproj
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Services.Interface/LearningHub.Nhs.OpenApi.Services.Interface.csproj
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
+		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.15" />
 		<PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />
 	</ItemGroup>
 

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Services/LearningHub.Nhs.OpenApi.Services.csproj
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Services/LearningHub.Nhs.OpenApi.Services.csproj
@@ -32,7 +32,7 @@
 		<PackageReference Include="Azure.Storage.Blobs" Version="12.14.1" />
 		<PackageReference Include="Azure.Storage.Files.Shares" Version="12.8.0" />
 		<PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
-		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
+		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.15" />
 		<PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.1" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Tests/LearningHub.Nhs.OpenApi.Tests.csproj
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Tests/LearningHub.Nhs.OpenApi.Tests.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
+		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.15" />
 		<PackageReference Include="FluentAssertions" Version="5.10.3" />
 		<PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />

--- a/OpenAPI/LearningHub.Nhs.OpenApi/LearningHub.NHS.OpenAPI.csproj
+++ b/OpenAPI/LearningHub.Nhs.OpenApi/LearningHub.NHS.OpenAPI.csproj
@@ -17,7 +17,7 @@
 
     <ItemGroup>
         <PackageReference Include="AspNetCore.Authentication.ApiKey" Version="8.0.1" />
-        <PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
+        <PackageReference Include="elfhHub.Nhs.Models" Version="3.0.15" />
         <PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
         <PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />

--- a/WebAPI/LearningHub.Nhs.API/LearningHub.Nhs.Api.csproj
+++ b/WebAPI/LearningHub.Nhs.API/LearningHub.Nhs.Api.csproj
@@ -26,7 +26,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
-		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
+		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.15" />
 		<PackageReference Include="IdentityServer4.AccessTokenValidation" Version="3.0.1" />
 		<PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
 		<PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />

--- a/WebAPI/LearningHub.Nhs.Api.Shared/LearningHub.Nhs.Api.Shared.csproj
+++ b/WebAPI/LearningHub.Nhs.Api.Shared/LearningHub.Nhs.Api.Shared.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
+		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.15" />
 		<PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
 		<PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />
 		<PackageReference Update="StyleCop.Analyzers" Version="1.1.118">

--- a/WebAPI/LearningHub.Nhs.Api.UnitTests/LearningHub.Nhs.Api.UnitTests.csproj
+++ b/WebAPI/LearningHub.Nhs.Api.UnitTests/LearningHub.Nhs.Api.UnitTests.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
+		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.15" />
 		<PackageReference Include="FluentAssertions" Version="8.0.1" />
 		<PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
 		<PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />

--- a/WebAPI/LearningHub.Nhs.Repository.Interface/LearningHub.Nhs.Repository.Interface.csproj
+++ b/WebAPI/LearningHub.Nhs.Repository.Interface/LearningHub.Nhs.Repository.Interface.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
-   <PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
+   <PackageReference Include="elfhHub.Nhs.Models" Version="3.0.15" />
    <PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
    <PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />
    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />

--- a/WebAPI/LearningHub.Nhs.Repository/LearningHub.Nhs.Repository.csproj
+++ b/WebAPI/LearningHub.Nhs.Repository/LearningHub.Nhs.Repository.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
+		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.15" />
 		<PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
 		<PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />

--- a/WebAPI/LearningHub.Nhs.Services.Interface/LearningHub.Nhs.Services.Interface.csproj
+++ b/WebAPI/LearningHub.Nhs.Services.Interface/LearningHub.Nhs.Services.Interface.csproj
@@ -14,7 +14,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Azure.Storage.Queues" Version="12.21.0" />
-		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
+		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.15" />
 		<PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
 		<PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />
 		<PackageReference Include="System.Data.SqlClient" Version="4.9.0" />

--- a/WebAPI/LearningHub.Nhs.Services.UnitTests/LearningHub.Nhs.Services.UnitTests.csproj
+++ b/WebAPI/LearningHub.Nhs.Services.UnitTests/LearningHub.Nhs.Services.UnitTests.csproj
@@ -9,7 +9,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AutoFixture" Version="4.18.1" />
-		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
+		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.15" />
 		<PackageReference Include="EntityFrameworkCore.Testing.Moq" Version="5.0.0" />
 		<PackageReference Include="FluentAssertions" Version="8.0.1" />
 		<PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />

--- a/WebAPI/LearningHub.Nhs.Services/LearningHub.Nhs.Services.csproj
+++ b/WebAPI/LearningHub.Nhs.Services/LearningHub.Nhs.Services.csproj
@@ -10,7 +10,7 @@
 		<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
 		<PackageReference Include="Azure.Storage.Blobs" Version="12.23.0" />
 		<PackageReference Include="Azure.Storage.Files.Shares" Version="12.8.0" />
-		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
+		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.15" />
 		<PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
 		<PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
 		<PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />

--- a/WebAPI/MigrationTool/LearningHub.Nhs.Migration.ConsoleApp/LearningHub.Nhs.Migration.ConsoleApp.csproj
+++ b/WebAPI/MigrationTool/LearningHub.Nhs.Migration.ConsoleApp/LearningHub.Nhs.Migration.ConsoleApp.csproj
@@ -22,7 +22,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
-		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
+		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.15" />
 		<PackageReference Include="IdentityModel" Version="5.2.0" />
 		<PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
 		<PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />

--- a/WebAPI/MigrationTool/LearningHub.Nhs.Migration.Interface/LearningHub.Nhs.Migration.Interface.csproj
+++ b/WebAPI/MigrationTool/LearningHub.Nhs.Migration.Interface/LearningHub.Nhs.Migration.Interface.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
+		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.15" />
 		<PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
 		<PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />
 		<PackageReference Update="StyleCop.Analyzers" Version="1.1.118">

--- a/WebAPI/MigrationTool/LearningHub.Nhs.Migration.Models/LearningHub.Nhs.Migration.Models.csproj
+++ b/WebAPI/MigrationTool/LearningHub.Nhs.Migration.Models/LearningHub.Nhs.Migration.Models.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
+		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.15" />
 		<PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
 		<PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
 		<PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />

--- a/WebAPI/MigrationTool/LearningHub.Nhs.Migration.Staging.Repository/LearningHub.Nhs.Migration.Staging.Repository.csproj
+++ b/WebAPI/MigrationTool/LearningHub.Nhs.Migration.Staging.Repository/LearningHub.Nhs.Migration.Staging.Repository.csproj
@@ -7,7 +7,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
+		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.15" />
 		<PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
 		<PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />

--- a/WebAPI/MigrationTool/LearningHub.Nhs.Migration.UnitTests/LearningHub.Nhs.Migration.UnitTests.csproj
+++ b/WebAPI/MigrationTool/LearningHub.Nhs.Migration.UnitTests/LearningHub.Nhs.Migration.UnitTests.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
+		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.15" />
 		<PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />
 		<PackageReference Include="LearningHub.Nhs.Models" Version="4.0.18" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />

--- a/WebAPI/MigrationTool/LearningHub.Nhs.Migration/LearningHub.Nhs.Migration.csproj
+++ b/WebAPI/MigrationTool/LearningHub.Nhs.Migration/LearningHub.Nhs.Migration.csproj
@@ -8,7 +8,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="AngleSharp" Version="0.16.1" />
-		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.14" />
+		<PackageReference Include="elfhHub.Nhs.Models" Version="3.0.15" />
 		<PackageReference Include="FluentValidation" Version="11.11.0" />
 		<PackageReference Include="HtmlSanitizer" Version="6.0.453" />
 		<PackageReference Include="LearningHub.Nhs.Caching" Version="2.0.0" />


### PR DESCRIPTION
### JIRA link
[TD-7354](https://hee-tis.atlassian.net/browse/TD-7354)

### Description
To Correct the created date as per the UTC timing

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-7354]: https://hee-tis.atlassian.net/browse/TD-7354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ