### PR TITLE
TD-7454: Certificate Not Generated for Informal Assessments When Pass…

### DIFF
--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Resources/GetMyLearningCertificatesDashboardResources.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Resources/GetMyLearningCertificatesDashboardResources.sql
@@ -7,6 +7,7 @@
 --
 -- 24 Jun 2024	OA	Initial Revision
 -- 29 Sep 2025  SA  Integrated the provider dertails 
+-- 26-06-2026   SA TD-7454: Certificate Not Generated for Informal Assessments When Pass Mark is Null
 -------------------------------------------------------------------------------
 
 CREATE PROCEDURE [resources].[GetMyLearningCertificatesDashboardResources]
@@ -44,7 +45,7 @@ BEGIN
                     (r.ResourceTypeId IN (2, 7) AND ra.ActivityStatusId = 3 OR ra.ActivityStart < '2020-09-07 00:00:00 +00:00' OR mar.Id IS NOT NULL AND mar.PercentComplete = 100)
                 OR (r.ResourceTypeId = 6 AND (sa.CmiCoreLesson_status IN(3,5) OR (ra.ActivityStatusId IN(3, 5))))
                 OR ((r.ResourceTypeId = 11 AND arv.AssessmentType = 2) AND (ara.Score >= arv.PassMark OR ra.ActivityStatusId IN(3, 5)))
-                OR ((r.ResourceTypeId = 11 AND arv.AssessmentType =1) AND (ara.Score >= arv.PassMark AND ra.ActivityStatusId IN(3, 5,7)))
+                OR ((r.ResourceTypeId = 11 AND arv.AssessmentType =1) AND ((arv.PassMark IS NULL OR ara.Score >= arv.PassMark) AND ra.ActivityStatusId IN(3, 5,7)))
                 OR (r.ResourceTypeId IN (1, 5, 8, 9, 10, 12) AND ra.ActivityStatusId = 3))		
             GROUP BY ra.ResourceId
             ORDER BY ResourceActivityId DESC

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Resources/GetUsercertificateDetails.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Resources/GetUsercertificateDetails.sql
@@ -9,6 +9,7 @@
 -- 16-09-2025   Tobi    Added null check for ResourceReferenceID
 --17-09-2025    Swapna  Added resource version id
 -- 01-10-2025  SA added assesment score and passmark and provider details
+-- 26-06-2026  SA  TD-7454: Certificate Not Generated for Informal Assessments When Pass Mark is Null
 -------------------------------------------------------------------------------
 CREATE PROCEDURE [resources].[GetUsercertificateDetails]
     @UserId INT,
@@ -66,8 +67,25 @@ BEGIN
                     FROM activity.AssessmentResourceActivity ara
                     JOIN resources.AssessmentResourceVersion arv
                       ON arv.ResourceVersionId = ra.ResourceVersionId
-                    WHERE ara.ResourceActivityId = ra.Id
-                      AND ara.Score is not null AND ara.Score >= arv.PassMark -- formal AND informal assessment
+                   WHERE ara.ResourceActivityId = ra.Id
+					AND ara.Score IS NOT NULL
+					AND (
+					 -- Formal assessment: must meet the pass mark
+					(arv.AssessmentType = 2
+					 AND ara.Score >= arv.PassMark)
+
+					OR
+
+					-- Informal assessment:
+					-- If PassMark is defined, user must pass.
+					-- If PassMark is NULL, any completed attempt is valid.
+					(arv.AssessmentType = 1
+					 AND (
+							arv.PassMark IS NULL
+						 OR ara.Score >= arv.PassMark
+						 )
+					)
+				  )
                 )
                 -- Or explicitly marked as passed
                 OR ra.ActivityStatusId = 5


### PR DESCRIPTION
… Mark is Null

### JIRA link
[TD-7454](https://hee-tis.atlassian.net/browse/TD-7454)

### Description
Fixed the issue Certificate Not Generated for Informal Assessments When Pass Mark is Null

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-7454]: https://hee-tis.atlassian.net/browse/TD-7454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ