### PR TITLE
Update storage location for report download

### DIFF
--- a/LearningHub.Nhs.WebUI/Services/FileService.cs
+++ b/LearningHub.Nhs.WebUI/Services/FileService.cs
@@ -261,7 +261,7 @@
             var uri = new Uri(url);
             string containerName = uri.Segments[1].TrimEnd('/');
             string blobName = string.Join(string.Empty, uri.Segments, 2, uri.Segments.Length - 2);
-            BlobClient blobClient = new BlobClient(this.settings.AzureBlobSettings.ConnectionString, containerName, blobName);
+            BlobClient blobClient = new BlobClient(this.settings.AzureFileStorageConnectionString, containerName, blobName);
 
             var properties = await blobClient.GetPropertiesAsync();
             string contentType = properties.Value.ContentType ?? "application/octet-stream";


### PR DESCRIPTION
### JIRA link
[TD-####](https://hee-tis.atlassian.net/browse/TD-####)

### Description
Force webui to use AzureFileStorageConnectionString instead of AzureBlobSettings

**TEST:ukslhcontentstore**
Function=AzureFileSettings
Webui=AzureBlobSettings OR AzureFileStorageConnectionString


**PROD:learninghubprodstor**
Function=AzureFileSettings
Webui=AzureFileStorageConnectionString

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation