### PR TITLE
TD-7454: Assessment certificate issue when passmark is null

### DIFF
--- a/AdminUI/LearningHub.Nhs.AdminUI/Helpers/LearningActivityHelper.cs
+++ b/AdminUI/LearningHub.Nhs.AdminUI/Helpers/LearningActivityHelper.cs
@@ -165,14 +165,23 @@
                 return "Downloaded";
             }
             else if (myLearningDetailedItemViewModel.ResourceType == ResourceTypeEnum.Assessment)
-            {
+            {              
+                if (!myLearningDetailedItemViewModel.AssessmentDetails.PassMark.HasValue)
+                {
+                    return myLearningDetailedItemViewModel.Complete ? "Completed" : "Incomplete";
+                }
+
                 if (myLearningDetailedItemViewModel.Complete)
                 {
-                    return myLearningDetailedItemViewModel.ScorePercentage >= myLearningDetailedItemViewModel.AssessmentDetails.PassMark ? "Passed" : "Failed";
+                    return myLearningDetailedItemViewModel.ScorePercentage >= myLearningDetailedItemViewModel.AssessmentDetails.PassMark.Value
+                        ? "Passed"
+                        : "Failed";
                 }
                 else
                 {
-                    return myLearningDetailedItemViewModel.ScorePercentage >= myLearningDetailedItemViewModel.AssessmentDetails.PassMark ? "Passed" : "Incomplete";
+                    return myLearningDetailedItemViewModel.ScorePercentage >= myLearningDetailedItemViewModel.AssessmentDetails.PassMark.Value
+                        ? "Passed"
+                        : "Incomplete";
                 }
             }
             else

--- a/LearningHub.Nhs.WebUI/Helpers/ViewActivityHelper.cs
+++ b/LearningHub.Nhs.WebUI/Helpers/ViewActivityHelper.cs
@@ -291,13 +291,22 @@
             }
             else if (activityDetailedItemViewModel.ResourceType == ResourceTypeEnum.Assessment)
             {
+                if (!activityDetailedItemViewModel.AssessmentDetails.PassMark.HasValue)
+                {
+                    return activityDetailedItemViewModel.Complete ? "Completed" : "Incomplete";
+                }
+
                 if (activityDetailedItemViewModel.Complete)
                 {
-                    return activityDetailedItemViewModel.ScorePercentage >= activityDetailedItemViewModel.AssessmentDetails.PassMark ? "Passed" : "Failed";
+                    return activityDetailedItemViewModel.ScorePercentage >= activityDetailedItemViewModel.AssessmentDetails.PassMark.Value
+                        ? "Passed"
+                        : "Failed";
                 }
                 else
                 {
-                    return activityDetailedItemViewModel.ScorePercentage >= activityDetailedItemViewModel.AssessmentDetails.PassMark ? "Passed" : "Incomplete";
+                    return activityDetailedItemViewModel.ScorePercentage >= activityDetailedItemViewModel.AssessmentDetails.PassMark.Value
+                        ? "Passed"
+                        : "Incomplete";
                 }
             }
             else

--- a/OpenAPI/LearningHub.Nhs.OpenApi.Services/Services/MyLearningService.cs
+++ b/OpenAPI/LearningHub.Nhs.OpenApi.Services/Services/MyLearningService.cs
@@ -470,11 +470,16 @@
 
                 var assessmentType = activityEntities.First().ResourceVersion.AssessmentResourceVersion.AssessmentType;
 
-                activityEntities = activityEntities.Where(x => x.AssessmentResourceActivity.FirstOrDefault() != null &&
-                                                                   x.AssessmentResourceActivity.First().Score.HasValue &&
-                                                                   (int)Math.Round(x.AssessmentResourceActivity.First().Score.Value,
-                                                                       MidpointRounding.AwayFromZero) >= x.ResourceVersion.AssessmentResourceVersion.PassMark)
-                                                                    .ToList();
+                activityEntities = activityEntities.Where(x =>
+                {
+                    var activity = x.AssessmentResourceActivity.FirstOrDefault();
+                    var passMark = x.ResourceVersion.AssessmentResourceVersion.PassMark;
+
+                    return activity != null &&
+                           activity.Score.HasValue &&
+                           (!passMark.HasValue ||
+                            (int)Math.Round(activity.Score.Value, MidpointRounding.AwayFromZero) >= passMark.Value);
+                }).ToList();
             }
             else if (activityEntities.Any() && (activityEntities.FirstOrDefault()?.Resource.ResourceTypeEnum == ResourceTypeEnum.Video || activityEntities.FirstOrDefault()?.Resource.ResourceTypeEnum == ResourceTypeEnum.Audio))
             {
@@ -567,11 +572,16 @@
                 latestActivityCheck.RemoveAll(x => x.Resource.ResourceTypeEnum == ResourceTypeEnum.Scorm && (x.ActivityStatusId == (int)ActivityStatusEnum.Downloaded || x.ActivityStatusId == (int)ActivityStatusEnum.Incomplete || x.ActivityStatusId == (int)ActivityStatusEnum.InProgress));
                 if (latestActivityCheck.Any() && latestActivityCheck.FirstOrDefault()?.Resource.ResourceTypeEnum == ResourceTypeEnum.Assessment)
                 {
+                    latestActivityCheck = latestActivityCheck.Where(x =>
+                    {
+                        var activity = x.AssessmentResourceActivity.FirstOrDefault();
+                        var passMark = x.ResourceVersion.AssessmentResourceVersion.PassMark;
 
-                    latestActivityCheck = latestActivityCheck.Where(x => x.AssessmentResourceActivity.FirstOrDefault() != null &&
-                    x.AssessmentResourceActivity.First().Score.HasValue &&
-                    (int)Math.Round(x.AssessmentResourceActivity.First().Score.Value, MidpointRounding.AwayFromZero) >= x.ResourceVersion.AssessmentResourceVersion.PassMark)
-                        .ToList();
+                        return activity != null &&
+                               activity.Score.HasValue &&
+                               (!passMark.HasValue ||
+                                (int)Math.Round(activity.Score.Value, MidpointRounding.AwayFromZero) >= passMark.Value);
+                    }).ToList();
                 }
 
                 ResourceActivity expectedActivity = null;

--- a/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/ScormActivityComplete.sql
+++ b/WebAPI/LearningHub.Nhs.Database/Stored Procedures/Activity/ScormActivityComplete.sql
@@ -45,12 +45,15 @@ BEGIN
 		
 	IF EXISTS (SELECT 'X' FROM activity.ResourceActivity WHERE LaunchResourceActivityId = @ScormResourceActivityId AND ActivityStatusId IN (3, 4, 5))
 	BEGIN
-		DECLARE @ActivityStatusErrorMessage nvarchar(1024)
-		SELECT @ActivityStatusErrorMessage = 'ResourceActivity entry with Completed status already exists for ScormActivityId=' + CONVERT(nvarchar(20), @ScormActivityId);
-		RAISERROR (@ActivityStatusErrorMessage,   
-				   16, -- Severity.  
-				   1 -- State.  
-				   );  
+			UPDATE activity.ResourceActivity SET ActivityStatusId = @ActivityStatusId, 
+		                                     DurationSeconds = @DurationSeconds, 
+											 Score = @Score, 
+											 ActivityEnd = DATEADD(second, @DurationSeconds, ActivityStart),
+											 CreateUserId = @UserId,
+											CreateDate = @AmendDate,
+											AmendUserId = @UserId,
+											AmendDate = @AmendDate
+											where LaunchResourceActivityId = @ScormResourceActivityId  
 	END
 ELSE
 BEGIN

--- a/WebAPI/LearningHub.Nhs.Services/MyLearningService.cs
+++ b/WebAPI/LearningHub.Nhs.Services/MyLearningService.cs
@@ -170,7 +170,17 @@
             if (activityEntities.Any() && activityEntities.FirstOrDefault()?.Resource.ResourceTypeEnum == ResourceTypeEnum.Assessment)
             {
                 totalNumberOfAccess = activityQuery.SelectMany(x => x.AssessmentResourceActivity).OrderByDescending(a => a.CreateDate).ToList().Count();
-                activityEntities = activityEntities.Where(x => x.AssessmentResourceActivity.FirstOrDefault() != null && x.AssessmentResourceActivity.FirstOrDefault().Score.HasValue && ((int)Math.Round(x.AssessmentResourceActivity.FirstOrDefault().Score.Value, MidpointRounding.AwayFromZero) >= x.ResourceVersion.AssessmentResourceVersion.PassMark)).ToList();
+                activityEntities = activityEntities.Where(x =>
+                {
+                    var activity = x.AssessmentResourceActivity.FirstOrDefault();
+                    var passMark = x.ResourceVersion.AssessmentResourceVersion.PassMark;
+
+                    return activity != null &&
+                           activity.Score.HasValue &&
+                           (!passMark.HasValue ||
+                            (int)Math.Round(activity.Score.Value, MidpointRounding.AwayFromZero) >= passMark.Value);
+                }).ToList();
+               //// activityEntities = activityEntities.Where(x => x.AssessmentResourceActivity.FirstOrDefault() != null && x.AssessmentResourceActivity.FirstOrDefault().Score.HasValue && ((int)Math.Round(x.AssessmentResourceActivity.FirstOrDefault().Score.Value, MidpointRounding.AwayFromZero) >= x.ResourceVersion.AssessmentResourceVersion.PassMark)).ToList();
             }
             else if (activityEntities.Any() && (activityEntities.FirstOrDefault()?.Resource.ResourceTypeEnum == ResourceTypeEnum.Video || activityEntities.FirstOrDefault()?.Resource.ResourceTypeEnum == ResourceTypeEnum.Audio))
             {
@@ -263,7 +273,17 @@
                 latestActivityCheck.RemoveAll(x => x.Resource.ResourceTypeEnum == ResourceTypeEnum.Scorm && (x.ActivityStatusId == (int)ActivityStatusEnum.Downloaded || x.ActivityStatusId == (int)ActivityStatusEnum.Incomplete || x.ActivityStatusId == (int)ActivityStatusEnum.InProgress));
                 if (latestActivityCheck.Any() && latestActivityCheck.FirstOrDefault()?.Resource.ResourceTypeEnum == ResourceTypeEnum.Assessment)
                 {
-                    latestActivityCheck = latestActivityCheck.Where(x => x.AssessmentResourceActivity.FirstOrDefault() != null && x.AssessmentResourceActivity.FirstOrDefault().Score.HasValue && ((int)Math.Round(x.AssessmentResourceActivity.FirstOrDefault().Score.Value, MidpointRounding.AwayFromZero) >= x.ResourceVersion.AssessmentResourceVersion.PassMark)).ToList();
+                   //// latestActivityCheck = latestActivityCheck.Where(x => x.AssessmentResourceActivity.FirstOrDefault() != null && x.AssessmentResourceActivity.FirstOrDefault().Score.HasValue && ((int)Math.Round(x.AssessmentResourceActivity.FirstOrDefault().Score.Value, MidpointRounding.AwayFromZero) >= x.ResourceVersion.AssessmentResourceVersion.PassMark)).ToList();
+                    latestActivityCheck = latestActivityCheck.Where(x =>
+                    {
+                        var activity = x.AssessmentResourceActivity.FirstOrDefault();
+                        var passMark = x.ResourceVersion.AssessmentResourceVersion.PassMark;
+
+                        return activity != null &&
+                               activity.Score.HasValue &&
+                               (!passMark.HasValue ||
+                                (int)Math.Round(activity.Score.Value, MidpointRounding.AwayFromZero) >= passMark.Value);
+                    }).ToList();
                 }
 
                 ResourceActivity expectedActivity = null;


### PR DESCRIPTION
### JIRA link
[TD-7454](https://hee-tis.atlassian.net/browse/TD-7454)

### Description
Fixed the issue Assessment certificate issue when pass mark is null

### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._
<img width="1101" height="750" alt="image" src="https://github.com/user-attachments/assets/59a2e2b6-c2d9-47e1-a9c4-1fb2b191a6ec" />

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [ ] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [ ] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [ ] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [ ] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [ ] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-7454]: https://hee-tis.atlassian.net/browse/TD-7454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ