### PR TITLE
Fixes following testing on TD-6226

### DIFF
--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/catalogue/managecatalogue.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/catalogue/managecatalogue.vue
@@ -12,31 +12,24 @@
 
             <div v-if="catalogue && !isLoading">
                 <div class="lh-padding-fluid">
-                    <div class="lh-container-xl">
-                        <div class="nhsuk-back-link">
+                  <div class="lh-container-xl">
+                      <a :href="'/catalogue/' + reference" class="nhsuk-back-link" id="goBackLink">
+                        Go back
+                      </a>
+                    <h1>Catalogue Management</h1>
+                    <div class="nhsuk-grid-row" v-if="(catalogue.restrictedAccess || catalogue.hidden)">
+                      <div class="nhsuk-grid-column-full">
+                        <p>You are managing the following catalogue and can invite users to request access.</p>
+                        <input type="button" class="nhsuk-button" @click="inviteUserModal()" value="Invite Users" v-if="(catalogue.restrictedAccess || catalogue.hidden)" />
 
-                            <a :href="'/catalogue/' + reference" class="nhsuk-back-link__link" id="goBackLink">
-                                <svg class="nhsuk-icon nhsuk-icon__chevron-left"
-                                     xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-                                    <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
-                                </svg>
-                                Go back
-                            </a>
-                        </div>
-                        <h1>Catalogue Management</h1>
-                        <div class="nhsuk-grid-row" v-if="(catalogue.restrictedAccess || catalogue.hidden)">
-                            <div class="nhsuk-grid-column-full">
-                                <p>You are managing the following catalogue and can invite users to request access.</p>
-                                <input type="button" class="nhsuk-button" @click="inviteUserModal()" value="Invite Users" v-if="(catalogue.restrictedAccess || catalogue.hidden)" />  
-
-                            </div>
-                        </div>
-                        <div class="row pt-4">
-                            <div class="col">
-                                <h2>{{catalogue.name}}</h2>
-                            </div>
-                        </div>
+                      </div>
                     </div>
+                    <div class="row pt-4">
+                      <div class="col">
+                        <h2>{{catalogue.name}}</h2>
+                      </div>
+                    </div>
+                  </div>
                 </div>
 
                 <div class="lh-padding-fluid-md">

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/SelectResource.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/SelectResource.vue
@@ -14,9 +14,7 @@
         <div v-if="hierarchyEditLoaded && !catalogueLockedForEdit">
             <div class="lh-padding-fluid grey-banner">
                 <div class="lh-container-xl">
-                    <div class="nhsuk-back-link nhsuk-u-padding-bottom-3 nhsuk-u-padding-top-3">           
-                        <a v-bind:href="myContributionsPageUrl"> < My Contributions</a>
-                    </div>
+                    <a class="nhsuk-back-link" v-bind:href="myContributionsPageUrl">My Contributions</a>
                     <div class="py-3">
                         <h1 class="nhsuk-heading-xl nhsuk-u-margin-bottom-2">Contribute a resource</h1>
                         <div>Before you can continue, give this new resource a title and select a resource type.</div>

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/components/KeyWordsEditor.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute-resource/components/KeyWordsEditor.vue
@@ -17,7 +17,7 @@
                 </div>
                 <div class="col-12 input-with-button">
                     <input id="newKeyword" aria-labelledby="keyword-label" type="text" class="form-control nhsuk-input" maxlength="260" v-model="newKeyword" v-bind:class="{ 'input-validation-error': keywordError }" @input="keywordError=false" @change="keywordChange" />
-                    <button type="button" class="nhsuk-button nhsuk-button--secondary ml-3 button_width nhsuk-u-margin-bottom-0" @click="addKeyword">&nbsp;Add</button>
+                    <button type="button" class="nhsuk-button nhsuk-button--secondary ml-3 button_width nhsuk-u-margin-bottom-0" @click="addKeyword">Add</button>
                 </div>
                 <div class="col-12 footer-text" id="keyword-label">
                     You can enter a maximum of 50 characters per keyword

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/ContentCommon.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/contribute/ContentCommon.vue
@@ -102,7 +102,7 @@
                 </div>
                 <div class="col-12 mt-4 input-with-button">
                     <input id="newKeyword" aria-labelledby="keyword-label" aria-describedby="keyworddesc" type="text" class="form-control nhsuk-input" maxlength="260" v-model="newKeyword" v-bind:class="{ 'input-validation-error': keywordError }" @input="keywordError=false" @change="keywordChange" />
-                    <button type="button" class="nhsuk-button nhsuk-button--secondary ml-3 nhsuk-u-margin-bottom-0" @click="addKeyword">&nbsp;Add</button>
+                    <button type="button" class="nhsuk-button nhsuk-button--secondary ml-3 nhsuk-u-margin-bottom-0" @click="addKeyword">Add</button>
                 </div>
                 <div class="col-12 footer-text" id="keyword-label">
                     You can enter a maximum of 50 characters per keyword

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/notification/notification.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/notification/notification.vue
@@ -45,7 +45,7 @@
                             </td>
                             <td class="px-sm-3 py-sm-3">
                                 <div class="d-flex justify-content-between" v-if="notification.userDismissable">
-                                    <button data-target="#deleteModal" class="nhsuk-button nhsuk-u-margin-bottom-0" data-toggle="modal" @click="selectNotification(notification)">Delete</button>
+                                    <button data-target="#deleteModal" class="nhsuk-button nhsuk-button--secondary-solid nhsuk-u-margin-bottom-0" data-toggle="modal" @click="selectNotification(notification)">Delete</button>
                                 </div>
                             </td>
                         </tr>

--- a/LearningHub.Nhs.WebUI/Scripts/vuesrc/notification/notifications.vue
+++ b/LearningHub.Nhs.WebUI/Scripts/vuesrc/notification/notifications.vue
@@ -19,58 +19,52 @@
             </div>
 
             <div v-if="showMessage" :class="[showMessage ? 'd-block' : 'd-none', 'nhsuk-u-margin-bottom-7']">
-                <div class="nhsuk-back-link">
-                    <a class="nhsuk-back-link__link" href="#" @click="showNotificationList($event)">
-                        <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-                            <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
-                        </svg>
-                        Back to: Notifications
-                    </a>
+                <a class="nhsuk-back-link" href="#" @click="showNotificationList($event)">
+                  Back to: Notifications
+                </a>
+              <div class="row">
+                <div class="col-md-8">
+                  <h2>{{this.selectedNotification.title}}</h2>
                 </div>
+              </div>
 
-                <div class="row">
-                    <div class="col-md-8">
-                        <h2>{{this.selectedNotification.title}}</h2>
+              <div class="row nhsuk-u-font-size-19">
+                <div class="col-md-8" v-html="selectedNotification.body" />
+
+                <div class="col-md-4">
+                  <div class="d-block d-md-none mx-n4">
+                    <hr class="mt-3" />
+                  </div>
+
+                  <div class="row">
+                    <div class="col-4">Added on:</div>
+                    <div class="col">
+                      {{selectedNotification.date | formatDate('DD MMM YYYY')}}
                     </div>
-                </div>
-
-                <div class="row nhsuk-u-font-size-19">
-                    <div class="col-md-8" v-html="selectedNotification.body" />
-
-                    <div class="col-md-4">
-                        <div class="d-block d-md-none mx-n4">
-                            <hr class="mt-3" />
-                        </div>
-
-                        <div class="row">
-                            <div class="col-4">Added on:</div>
-                            <div class="col">
-                                {{selectedNotification.date | formatDate('DD MMM YYYY')}}
-                            </div>
-                            <div class="w-100 py-2"></div>
-                            <div class="col-4">Type:</div>
-                            <div class="col" v-for="item in notificationTypeContent()">
-                                <i :class="[item.className + ' pr-3']"></i>{{ item.text }}
-                            </div>
-                            <div class="w-100 py-2"></div>
-                            <div class="col-4">Status:</div>
-                            <div class="col">
-                                <i class="fa-regular fa-envelope-open text-success pr-3"></i>Read
-                            </div>
-                        </div>
-
-                        <div class="d-none d-md-block">
-                            <hr class="py-2 mt-3" />
-                        </div>
-
-                        <template v-if="selectedNotification.userDismissable">
-                            <div class="d-block d-md-none mx-n4">
-                                <hr class="py-2 mt-4" />
-                            </div>
-                            <button data-target="#deleteModal" data-toggle="modal" class="nhsuk-button">Delete</button>
-                        </template>
+                    <div class="w-100 py-2"></div>
+                    <div class="col-4">Type:</div>
+                    <div class="col" v-for="item in notificationTypeContent()">
+                      <i :class="[item.className + ' pr-3']"></i>{{ item.text }}
                     </div>
+                    <div class="w-100 py-2"></div>
+                    <div class="col-4">Status:</div>
+                    <div class="col">
+                      <i class="fa-regular fa-envelope-open text-success pr-3"></i>Read
+                    </div>
+                  </div>
+
+                  <div class="d-none d-md-block">
+                    <hr class="py-2 mt-3" />
+                  </div>
+
+                  <template v-if="selectedNotification.userDismissable">
+                    <div class="d-block d-md-none mx-n4">
+                      <hr class="py-2 mt-4" />
+                    </div>
+                    <button data-target="#deleteModal" data-toggle="modal" class="nhsuk-button">Delete</button>
+                  </template>
                 </div>
+              </div>
             </div>
 
             <div class="modal" tabindex="-1" role="dialog" id="deleteModalButton">

--- a/LearningHub.Nhs.WebUI/Styles/abstracts/_variables.scss
+++ b/LearningHub.Nhs.WebUI/Styles/abstracts/_variables.scss
@@ -26,6 +26,7 @@ $nhsuk-grey-divider: #D7D7D7;
 $nhsuk-blue-divider: #4081C1;
 $nhsuk-btn-blue-hover: #003f7b;
 $nhsuk-btn-outline-hover: #E4F2FF;
+$nhsuk-secondary-text-colour: #4C6272 ;
 $twitter-blue: #29A3EF;
 $govuk-focus-highlight-yellow: #fd0;
 $font-stack: FrutigerLTW01-55Roman, Arial, sans-serif;

--- a/LearningHub.Nhs.WebUI/Styles/nhsuk/layout.scss
+++ b/LearningHub.Nhs.WebUI/Styles/nhsuk/layout.scss
@@ -55,9 +55,15 @@ body {
 }
 
 .nhsuk-width-container.app-width-container.beta-banner {
-    padding: px2rem(8) px2rem(32);
-    max-width: px2rem(1208);
-    margin: 0 auto;
+  padding: px2rem(8) px2rem(32);
+  max-width: px2rem(1208);
+  margin: 0 auto;
+}
+
+#nhsuk-cookie-banner .nhsuk-width-container {
+  padding: px2rem(8) px2rem(32);
+  max-width: px2rem(1208);
+  margin: 0 auto;
 }
 
 .nhsuk-header .nhsuk-header__container::after {
@@ -174,15 +180,7 @@ body {
 }
 
 button[data-toggle="modal"] {
-    color: #005eb8;
-    padding: 0;
-    border: none;
-    background: none;
-
-    &:focus {
-        background: yellow;
-        border-bottom: 4px solid;
-    }
+  padding: 0.25rem;
 }
 
 .autosuggestion-menu {
@@ -516,10 +514,6 @@ li.autosuggestion-option:last-of-type a:focus {
     .nhsuk-width-container.app-width-container.beta-banner {
         padding-left: px2rem(16);
         padding-right: px2rem(16);
-    }
-
-    .nhsuk-back-link {
-        padding: 0.5rem 0;
     }
 
     .nhsuk-width-container.nhsuk-header__container.app-width-container {

--- a/LearningHub.Nhs.WebUI/Styles/nhsuk/nhsuk-overrides.scss
+++ b/LearningHub.Nhs.WebUI/Styles/nhsuk/nhsuk-overrides.scss
@@ -213,110 +213,116 @@ form label.nhsuk-u-visually-hidden {
     }
 }
 
-.nhsuk-header .nhsuk-width-container,
-.nhsuk-footer .nhsuk-width-container {
+.nhsuk-header .nhsuk-width-container, {
   max-width: px2rem(1144);
 }
 
-@media (min-width: px2rem(1024)) and (max-width: px2rem(1220)) {
-  .nhsuk-header .nhsuk-width-container {
-    margin-right: max(32px, calc(16px + env(safe-area-inset-right)));
-    margin-left: max(32px, calc(16px + env(safe-area-inset-left)));
+@media (min-width: px2rem(1024)) {
+  .nhsuk-footer .nhsuk-width-container {
+    max-width: px2rem(1208);
+    padding: 0 2rem;
   }
-}
-
-@media (max-width: px2rem(640)) {
-  // overrides header becoming block display at 640 and below. Allows header has 3 elements
-  .nhsuk-header__container {
-    display: flex;
-    flex-flow: row wrap;
-    gap: 0px;
   }
 
-  .nhsuk-header__account {
-    width: 100%;
-  }
-}
-
-.nhsuk-header__account-link {
-  // make space for notification dot
-  margin-left: -8px;
-}
-
-.nhsuk-header__search-form {
-  // these rules not being picked up from v-10.
-  // may not be needed in future versions of v10
-
-  .nhsuk-button {
-    background-color: #edf4fa;
-    border: 1px solid transparent;
-    border-radius: 0 .25rem .25rem 0;
-    box-shadow: none;
-    color: nhsuk-colour("blue");
-    margin: 0;
-    padding: 0 7px;
-    width: 2.75rem;
+  @media (min-width: px2rem(1024)) and (max-width: px2rem(1220)) {
+    .nhsuk-header .nhsuk-width-container {
+      margin-right: max(32px, calc(16px + env(safe-area-inset-right)));
+      margin-left: max(32px, calc(16px + env(safe-area-inset-left)));
+    }
   }
 
-  .nhsuk-input {
-    border-color: transparent;
-    border-radius: .25rem 0 0 .25rem;
-    font-size: 1rem;
-    padding-left: 10px;
-    padding-right: 10px;
-  }
-}
+  @media (max-width: px2rem(640)) {
+    // overrides header becoming block display at 640 and below. Allows header has 3 elements
+    .nhsuk-header__container {
+      display: flex;
+      flex-flow: row wrap;
+      gap: 0px;
+    }
 
-@media (min-width: px2rem(991)) {
-  .nhsuk-header__search-form .nhsuk-input {
-    min-width: 18rem;
-  }
-}
-
-.nhsuk-header__search-form {
-
-  .nhsuk-form-group {
-    width: 100%;
-    margin: 0;
+    .nhsuk-header__account {
+      width: 100%;
+    }
   }
 
-  .nhsuk-input-wrapper {
-    display: flex;
+  .nhsuk-header__account-link {
+    // make space for notification dot
+    margin-left: -8px;
   }
-}
 
-.nhsuk-header__navigation-item--current a {
-  border-bottom: 4px solid nhsuk-colour("grey-4");
-  font-weight: normal;
-}
+  .nhsuk-header__search-form {
+    // these rules not being picked up from v-10.
+    // may not be needed in future versions of v10
 
-.nhsuk-header__menu {
-  display: list-item;
-}
+    .nhsuk-button {
+      background-color: #edf4fa;
+      border: 1px solid transparent;
+      border-radius: 0 .25rem .25rem 0;
+      box-shadow: none;
+      color: nhsuk-colour("blue");
+      margin: 0;
+      padding: 0 7px;
+      width: 2.75rem;
+    }
 
-.nhsuk-header .nhsuk-header__navigation-list .nhsuk-header__menu {
-  align-self: auto;
-}
-
-.search-filters {
-  .nhsuk-expander .nhsuk-details__summary {
-    border: none;
+    .nhsuk-input {
+      border-color: transparent;
+      border-radius: .25rem 0 0 .25rem;
+      font-size: 1rem;
+      padding-left: 10px;
+      padding-right: 10px;
+    }
   }
-}
 
-// override nhsuk default styling for checkboxes to allow text to wrap
-// can be removed when quickfilters component is implemented
-
-.filterForm {
-  .nhsuk-checkboxes__label {
-    overflow-wrap: normal;
+  @media (min-width: px2rem(991)) {
+    .nhsuk-header__search-form .nhsuk-input {
+      min-width: 18rem;
+    }
   }
-}
 
-.autosuggestion-menu .autosuggestion-option:not(.autosugg-concepts) a {
-  flex-wrap: wrap;
-  .autosuggestion-subtext {
-    flex-basis: 100%;
+  .nhsuk-header__search-form {
+
+    .nhsuk-form-group {
+      width: 100%;
+      margin: 0;
+    }
+
+    .nhsuk-input-wrapper {
+      display: flex;
+    }
   }
-}
+
+  .nhsuk-header__navigation-item--current a {
+    border-bottom: 4px solid nhsuk-colour("grey-4");
+    font-weight: normal;
+  }
+
+  .nhsuk-header__menu {
+    display: list-item;
+  }
+
+  .nhsuk-header .nhsuk-header__navigation-list .nhsuk-header__menu {
+    align-self: auto;
+  }
+
+  .search-filters {
+    .nhsuk-expander .nhsuk-details__summary {
+      border: none;
+    }
+  }
+  // override nhsuk default styling for checkboxes to allow text to wrap
+  // can be removed when quickfilters component is implemented
+
+  .filterForm {
+    .nhsuk-checkboxes__label {
+      overflow-wrap: normal;
+    }
+  }
+
+  .autosuggestion-menu .autosuggestion-option:not(.autosugg-concepts) a {
+    flex-wrap: wrap;
+
+    .autosuggestion-subtext {
+      flex-basis: 100%;
+    }
+  }
 

--- a/LearningHub.Nhs.WebUI/Styles/nhsuk/nhsuk-overrides.scss
+++ b/LearningHub.Nhs.WebUI/Styles/nhsuk/nhsuk-overrides.scss
@@ -5,13 +5,17 @@
     font-style: italic;
 }
 
-.nhsuk-button--red {
-    background-color: $nhsuk-red !important;
+.nhsuk-button {
+  overflow-wrap:normal;
+ }
 
-    &:hover {
-        background-color: $nhsuk-red-hover !important;
-        border-color: $nhsuk-red-hover !important;
-    }
+.nhsuk-button--red {
+  background-color: $nhsuk-red !important;
+
+  &:hover {
+    background-color: $nhsuk-red-hover !important;
+    border-color: $nhsuk-red-hover !important;
+  }
 }
 
 .nhsuk-button--beta-login {
@@ -28,10 +32,6 @@
     color: $nhsuk-black
 }
 
-.nhsuk-back-link {
-    padding: px2rem(20) 0;
-    margin-bottom: 0;
-}
 
 .nhsuk-radios__divider {
     text-align: left;
@@ -42,18 +42,17 @@
     font-family: $font-stack;
 }
 
-/*  Conditional radio buttons - Note: The nhsuk-radios__conditional element needs to be a SIBLING of the radio button input element
-    otherwise the CSS selector won't work. See Views/Bookmark/Move.cshtml for a usage example. 
+/*  Conditional radio buttons - Note: Now using :has selector on nhsuk-radio--conditional to determine whether to show .nhsuk-radios__conditional.
+    
     The NHSUK component (nhsuk-radios__conditional) requires JavaScript to work. These tweaks allow it to work without.
 */
 .nhsuk-radios__conditional {
     display: none;
-    margin-left: -22px;
     margin-top: 8px;
 }
-
-.nhsuk-radios__input:checked ~ .nhsuk-radios__conditional {
-    display: block !important;
+ 
+.nhsuk-radios--conditional:has(.nhsuk-radios__input:checked) .nhsuk-radios__conditional {
+  display: block !important;
 }
 
 /* jquery unbobtrusive validation style over */
@@ -298,3 +297,26 @@ form label.nhsuk-u-visually-hidden {
 .nhsuk-header .nhsuk-header__navigation-list .nhsuk-header__menu {
   align-self: auto;
 }
+
+.search-filters {
+  .nhsuk-expander .nhsuk-details__summary {
+    border: none;
+  }
+}
+
+// override nhsuk default styling for checkboxes to allow text to wrap
+// can be removed when quickfilters component is implemented
+
+.filterForm {
+  .nhsuk-checkboxes__label {
+    overflow-wrap: normal;
+  }
+}
+
+.autosuggestion-menu .autosuggestion-option:not(.autosugg-concepts) a {
+  flex-wrap: wrap;
+  .autosuggestion-subtext {
+    flex-basis: 100%;
+  }
+}
+

--- a/LearningHub.Nhs.WebUI/Styles/nhsuk/pages/dashboard.scss
+++ b/LearningHub.Nhs.WebUI/Styles/nhsuk/pages/dashboard.scss
@@ -200,6 +200,7 @@ div.bmj-best-practice-logo-image {
     border-radius: 4px;
     font-family: sans-serif;
 }
+
 .filteractive {
     color: $nhsuk-blue !important;
     border-color: #376cac;
@@ -207,10 +208,15 @@ div.bmj-best-practice-logo-image {
 }
 
 .filterinactive {
-    color: #d8dde0;
-    border-color: #d8dde0;
-    background-color: $nhsuk-white;
-    opacity: 0.7;
+  color: $nhsuk-secondary-text-colour;
+  border-color: #d8dde0;
+  background-color: $nhsuk-white;
+  opacity: 0.7;
+}
+
+
+.filterinactive:visited {
+  color: $nhsuk-secondary-text-colour;
 }
 
 filterfocus {

--- a/LearningHub.Nhs.WebUI/Views/Bookmark/Move.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Bookmark/Move.cshtml
@@ -53,24 +53,24 @@
 
                             <div class="nhsuk-radios">
                                 <div class="nhsuk-radios--conditional">
-                                <div class="nhsuk-radios__item">
-                                    <input type="radio" asp-for="SelectedFolderId" value="0" id="SelectedFolderId" class="nhsuk-radios__input" data-val="false"
-                                           aria-controls="conditional-newfolder" aria-expanded="false" />
-                                    <label class="nhsuk-label nhsuk-radios__label" for="SelectedFolderId">
-                                        Add a folder and include the bookmark in it
-                                    </label>
-                                    @* Note: The hidden div following a conditional radio button (nhsuk-radios__conditional) needs to be a SIBLING of the radio button input element. *@
-                                    <div class="nhsuk-radios__conditional nhsuk-u-margin-bottom-0" id="conditional-newfolder">
-                                        <vc:text-input asp-for="NewFolderName"
-                                                       label="New folder name"
-                                                       populate-with-current-value="false"
-                                                       type="text"
-                                                       spell-check="false"
-                                                       hint-text=""
-                                                       autocomplete="off"
-                                                       css-class=""
-                                                       required="@(Model.SelectedFolderId == 0)" />
-                                    </div>
+                                  <div class="nhsuk-radios__item">
+                                      <input type="radio" asp-for="SelectedFolderId" value="0" id="SelectedFolderId" class="nhsuk-radios__input" data-val="false"
+                                             aria-controls="conditional-newfolder" aria-expanded="false" />
+                                      <label class="nhsuk-label nhsuk-radios__label" for="SelectedFolderId">
+                                          Add a folder and include the bookmark in it
+                                      </label>
+
+                                  </div>
+                                  <div class="nhsuk-radios__conditional nhsuk-u-margin-bottom-0" id="conditional-newfolder">
+                                  <vc:text-input asp-for="NewFolderName"
+                                                 label="New folder name"
+                                                 populate-with-current-value="false"
+                                                 type="text"
+                                                 spell-check="false"
+                                                 hint-text=""
+                                                 autocomplete="off"
+                                                 css-class=""
+                                                 required="@(Model.SelectedFolderId == 0)" />
                                 </div>
                                 </div>
 

--- a/LearningHub.Nhs.WebUI/Views/Home/LandingPage.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Home/LandingPage.cshtml
@@ -47,7 +47,7 @@
                 <div class="nhsuk-grid-column-one-half">
                     <h3>Use your Learning Hub or elfh credentials</h3>
                     <p>
-                        <a asp-controller="Login" asp-action="Index" class="nhsuk-button nhsuk-button--beta-login">Log in</a>
+                        <a asp-controller="Login" asp-action="Index" class="nhsuk-button">Log in</a>
                     </p>
                     <p class="nhsuk-u-margin-bottom-2">
                         <a href="/forgotten-password">Forgotten username or password</a>

--- a/LearningHub.Nhs.WebUI/Views/Resource/Resource.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Resource/Resource.cshtml
@@ -84,7 +84,7 @@
                         <input type="hidden" name="ResourceReferenceId" value="@Model.ResourceReferenceId" />
                         <input type="hidden" name="ResourceItem.ResourceId" value="@resource.ResourceId" />
                         <input type="hidden" name="ResourceItem.Title" value="@Model.ResourceItem.Title" />
-                        <input type="submit" class="nhsuk-button" value="Edit resource" />
+                        <button type="submit" class="nhsuk-button" value="Edit resource">Edit resource</button>
                     </form>
                     <form method="get" style="display:inline-block" action="~/Resource/UnpublishConfirm">
                         <input type="hidden" name="ResourceReferenceId" value="@Model.ResourceReferenceId" />
@@ -93,7 +93,7 @@
                         <input type="hidden" name="ResourceItem.ResourceTypeEnum" value="@(resource.ResourceTypeEnum)" />
                         <input type="hidden" name="ResourceItem.Catalogue.CatalogueNodeVersionId" value="@resource.Catalogue.CatalogueNodeVersionId" />
                         <input type="hidden" name="ExternalContentDetails.EsrLinkType" value="@((resource.ResourceTypeEnum == ResourceTypeEnum.Scorm || resource.ResourceTypeEnum == ResourceTypeEnum.GenericFile) ? Model.ExternalContentDetails.EsrLinkType : null)" />
-                        <input type="submit" class="nhsuk-button nhsuk-button--secondary" value="Unpublish" />
+                        <button type="submit" class="nhsuk-button nhsuk-button--secondary-solid" value="Unpublish">Unpublish</button>
                     </form>
                 </div>
             }
@@ -108,7 +108,7 @@
                         <input type="hidden" name="ResourceReferenceId" value="@Model.ResourceReferenceId" />
                         <input type="hidden" name="ResourceItem.ResourceId" value="@resource.ResourceId" />
                         <input type="hidden" name="ResourceItem.Title" value="@Model.ResourceItem.Title" />
-                        <input type="submit" class="nhsuk-button nhsuk-u-margin-bottom-4" value="Edit resource" />
+                        <button type="submit" class="nhsuk-button nhsuk-u-margin-bottom-4" value="Edit resource">Edit resource</button>
                     </form>
                 </div>
             }
@@ -186,7 +186,7 @@
                     {
                         <form method="get" action="~/MyLearning/Certificate">
                             <input type="hidden" name="ResourceReferenceId" value="@Model.ResourceReferenceId" />
-                            <input type="submit" formtarget="_blank" class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-top-1" value="View Certificate" />
+                            <button type="submit" formtarget="_blank" class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-top-1" value="View Certificate" >View Certificate</button>
                         </form>
                     }
                 </div>
@@ -228,7 +228,7 @@
                                 displayCertificateButton = false;
                                 <form method="get" action="~/MyLearning/Certificate">
                                     <input type="hidden" name="ResourceReferenceId" value="@Model.ResourceReferenceId" />
-                                    <input type="submit" formtarget="_blank" class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-top-1" value="View Certificate" />
+                                    <button type="submit" formtarget="_blank" class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-top-1" value="View Certificate">View Certificate</button>
                                 </form>
                             }
                         </div>
@@ -252,7 +252,8 @@
                             {
                                 <form method="get" action="~/MyLearning/Certificate">
                                     <input type="hidden" name="ResourceReferenceId" value="@Model.ResourceReferenceId" />
-                                    <input type="submit" formtarget="_blank" class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-top-1" value="View Certificate" />
+                                    <button type="submit" formtarget="_blank" class="nhsuk-button nhsuk-button--secondary nhsuk-u-margin-top-1" 
+                                    value="View Certificate">View Certificate</button>
                                 </form>
                             }
                         </div>

--- a/LearningHub.Nhs.WebUI/Views/Resource/_ResourceItem.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Resource/_ResourceItem.cshtml
@@ -64,7 +64,7 @@
                     This resource contains sensitive content which some people may find offensive or disturbing.
                 </p>
                 <div>
-                    <a class="nhsuk-button nhsuk-button--secondary" href="@GetSensitiveContentUrl()">Show content</a>
+                    <a class="nhsuk-button nhsuk-button--secondary-solid" href="@GetSensitiveContentUrl()">Show content</a>
                 </div>
             </div>
         }

--- a/LearningHub.Nhs.WebUI/Views/Shared/Components/NavigationItems/AccountLinks.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Shared/Components/NavigationItems/AccountLinks.cshtml
@@ -15,11 +15,11 @@
     }
     <ul class="nhsuk-header__account-list">
       <li class="nhsuk-header__account-item">
-        <svg class="nhsuk-icon nhsuk-icon--user" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" focusable="false" aria-hidden="true">
-          <path d="M12 1a11 11 0 1 1 0 22 11 11 0 0 1 0-22Zm0 2a9 9 0 0 0-5 16.5V18a4 4 0 0 1 4-4h2a4 4 0 0 1 4 4v1.5A9 9 0 0 0 12 3Zm0 3a3.5 3.5 0 1 1-3.5 3.5A3.4 3.4 0 0 1 12 6Z" />
-        </svg>
-
         <a class="nhsuk-header__account-link" asp-controller="Myaccount" asp-action="Index">
+
+          <svg class="nhsuk-icon nhsuk-icon--user" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" focusable="false" aria-hidden="true">
+            <path d="M12 1a11 11 0 1 1 0 22 11 11 0 0 1 0-22Zm0 2a9 9 0 0 0-5 16.5V18a4 4 0 0 1 4-4h2a4 4 0 0 1 4 4v1.5A9 9 0 0 0 12 3Zm0 3a3.5 3.5 0 1 1-3.5 3.5A3.4 3.4 0 0 1 12 6Z" />
+          </svg>
           My account
         </a>
       </li>

--- a/LearningHub.Nhs.WebUI/Views/Shared/Tenant/LearningHub/_Layout.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Shared/Tenant/LearningHub/_Layout.cshtml
@@ -145,10 +145,7 @@
   </environment>
   <script type="text/javascript" src="~/js/bundle/header.js" asp-append-version="true"></script>
   <script type="module" src="~/js/bundle/nhsuk.js" asp-append-version="true"></script>
-  <script type="module">
-    import { initAll } from '~/js/bundle/nhsuk.js';
-    initAll();
-  </script>
+
   <partial name="~/Views/Shared/_ValidationScriptsPartial.cshtml" />
   <partial name="~/Views/Shared/_SessionManagerScriptPartial.cshtml" />
   <partial name="~/Views/Shared/_JavascriptDetectorPartial.cshtml" />

--- a/LearningHub.Nhs.WebUI/Views/Shared/_FooterPartial.cshtml
+++ b/LearningHub.Nhs.WebUI/Views/Shared/_FooterPartial.cshtml
@@ -24,6 +24,6 @@
   };
 }
 
-<vc:footer copyright="© NHS England 2024"
+<vc:footer copyright="@($"© NHS England {DateTime.Now.Year}")"
            footer-group-list="@footerGroupData"
            is-vertically-aligned="true" />


### PR DESCRIPTION
### JIRA link
[TD-6226](https://hee-tis.atlassian.net/browse/TD-6226)

### Description
Responding to tests on TD-6226

1 & 2 - confirmed can no longer reproduce

3 - Removed unnecessary code from \Views\Shared\Tenant\LearningHub\_Layout.cshtml

4 - Turned off borders on expander
<img width="1071" height="756" alt="image" src="https://github.com/user-attachments/assets/a1ede58c-54d7-42f3-946c-5fda5876892f" />

5 - Removed break word settings on filter labels resetting to current LH standard. These will be replaced with quickfilters component soon.
<img width="806" height="422" alt="image" src="https://github.com/user-attachments/assets/e48eb2f0-aed5-4ce0-8a3f-28b061027155" />

6 - Same issue as #4 & 5
<img width="826" height="723" alt="image" src="https://github.com/user-attachments/assets/71eb2284-6bc9-4c20-8541-8ce5aeb87e2c" />
<img width="791" height="789" alt="image" src="https://github.com/user-attachments/assets/a3da3d57-c395-4df7-9047-beaf9c0e5cbf" />

7 - Box removed from top, Catalogues displayed in card form, alignment difference intended
<img width="1057" height="901" alt="image" src="https://github.com/user-attachments/assets/3afed485-5030-4165-bc00-661a78b05e89" />

8 - back link fixed
<img width="1059" height="616" alt="image" src="https://github.com/user-attachments/assets/b9875135-7edb-4fb3-9eea-478e532cccb4" />

9 - removed beta log-in tag from Log in button
<img width="1206" height="833" alt="image" src="https://github.com/user-attachments/assets/79ded2bd-f4c1-4e1f-9cb1-45775da21e86" />

10 - Back link fixed
<img width="1028" height="569" alt="image" src="https://github.com/user-attachments/assets/ac25516f-ab4b-4fe3-bd08-86f44b76be21" />

11 - Footer date made automatic for current year
<img width="1163" height="374" alt="image" src="https://github.com/user-attachments/assets/5c3c2cf9-2263-42ce-a3f3-2e4f5e234e6e" />

12 - working as intended

13 & 16 - button types and styles updated
<img width="1294" height="972" alt="image" src="https://github.com/user-attachments/assets/bd742a0f-646d-4a4a-b454-d5decfb86218" />

14 - Button set to secondary-solid type
<img width="1073" height="797" alt="image" src="https://github.com/user-attachments/assets/7730fd0e-5252-4a73-aefd-7e9eec4e088f" />

15 - Icon, button and My account text now all one link as per current LH linking to My Account
<img width="1052" height="247" alt="image" src="https://github.com/user-attachments/assets/4f1e8b44-ed71-498d-b7fe-7619408c6aef" />

17 - overflow-wrap removed from buttons
<img width="983" height="516" alt="image" src="https://github.com/user-attachments/assets/7cd385c0-372a-4be8-bd4f-fc6fb8ee5019" />

18 - filter buttons now WCAG 2 compliant, same colours as existing LH and removed visited link default purple setting
<img width="1085" height="679" alt="image" src="https://github.com/user-attachments/assets/f14f2e0e-4300-4257-a3f6-436bc5cb711e" />

19 - autosuggest subtexxt set to 100%
<img width="415" height="743" alt="image" src="https://github.com/user-attachments/assets/884645a6-cb2d-482a-99d1-f9acd96236bf" />

20 - Conditional item radio button scss fixed.
<img width="1028" height="783" alt="image" src="https://github.com/user-attachments/assets/611877df-033b-47fb-8cb5-7ae58e189739" />


### Screenshots
_Paste screenshots for all views created or changed: mobile, tablet and desktop, wave analyser showing no errors._

-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x ] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-6226]: https://hee-tis.atlassian.net/browse/TD-6226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ