### PR TITLE
set reports summary to 100% allowing for left padding

### DIFF
--- a/LearningHub.Nhs.WebUI/Styles/nhsuk/nhsuk-overrides.scss
+++ b/LearningHub.Nhs.WebUI/Styles/nhsuk/nhsuk-overrides.scss
@@ -326,3 +326,7 @@ form label.nhsuk-u-visually-hidden {
     }
   }
 
+.user-report .nhsuk-details .nhsuk-details__summary {
+  width: calc(100% - 1.5rem);
+}
+


### PR DESCRIPTION
### JIRA link
[TD-6226](https://hee-tis.atlassian.net/browse/TD-6226)

### Description
Added a width of 100% - 1.5rem to the summary box. which is the left padding allowing for the expander arrow to show

### Screenshots
<img width="1616" height="907" alt="image" src="https://github.com/user-attachments/assets/75ea3885-c487-4a60-9607-31cdcb4de7f4" />


-----
### Developer checks
(Leave tasks unticked if they haven't been appropriate for your ticket.)

I have:
- [x] Run the IDE auto formatter on all files I’ve worked on and made sure there are no IDE errors relating to them
- [ ] Written or updated tests for the changes (accessibility ui tests for views, tests for controller, data services, services, view models created or modified) and made sure all tests are passing
- [x] Manually tested my work with and without JavaScript (adding notes where functionality requires JavaScript)
- [x] Tested any Views or partials created or changed with [Wave Chrome plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh/related). Addressed any valid accessibility issues and documented any invalid errors
- [ ] Updated my Jira ticket with testing notes, including information about other parts of the system that were touched as part of the MR and need  to be tested to ensure nothing is broken
- [x] Scanned over my pull request in GitHub and addressed any warnings from the GitHub Build and Test checks in the GitHub PR ‘Files Changed’ tab
Either:
- [ ] Documented my work in [Confluence](https://hee-tis.atlassian.net/wiki/spaces/TP/pages/3461087233/Development), updating any business rules applied or modified. Updated GitHub readme/documentation for the repository if appropriate. List of documentation links added/changed:
  - [doc_1_here](link_1_here)
Or:
- [x] Confirmed that none of the work that I have undertaken requires any updates to documentation

[TD-6226]: https://hee-tis.atlassian.net/browse/TD-6226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ